### PR TITLE
Downgrade some gql dependencies

### DIFF
--- a/gql/pubspec.yaml
+++ b/gql/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   source_span: ^1.5.5
   code_builder: ^3.2.0
   meta: ^1.1.7
-  collection: ^1.14.12
+  collection: ^1.14.11
   build: ^1.0.0
-  dart_style: ^1.2.10
+  dart_style: ^1.2.9
   pedantic: ^1.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Coming from Artemis, `gql` dependency is not working due to some conflicts with `analyzer`->`flutter_test` dependency tree.

Although Artemis (and `gql`) are Dart-only libraries, it's best to be in sync with at least flutter beta branch.

This is conjunction with https://github.com/comigor/artemis/pull/35 should be enough to make both libraries work on `beta` branch.