### PR TITLE
move `variables` from `Operation` to `Request`

### DIFF
--- a/gql_dedupe_link/CHANGELOG.md
+++ b/gql_dedupe_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+- upgrade `package:gql_exec` to v0.2.0
+
 ## 1.0.7
 
 - use `package:gql_exec`

--- a/gql_dedupe_link/pubspec.yaml
+++ b/gql_dedupe_link/pubspec.yaml
@@ -1,13 +1,13 @@
 name: gql_dedupe_link
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/gql-dart/gql/tree/master/gql_dedupe_link
 description: GQL Link to deduplicate identical in-flight execution requests
 environment: 
   sdk: '>=2.2.2 <3.0.0'
 dependencies: 
   meta: ^1.1.7
-  gql_exec: ^0.1.0
+  gql_exec: ^0.2.0
   gql_link: ^0.2.1
   async: ^2.3.0
 dev_dependencies: 

--- a/gql_dedupe_link/test/gql_dedupe_link_test.dart
+++ b/gql_dedupe_link/test/gql_dedupe_link_test.dart
@@ -1,8 +1,8 @@
 import "dart:async";
 
-import "package:gql_exec/gql_exec.dart";
 import "package:gql/language.dart";
 import "package:gql_dedupe_link/gql_dedupe_link.dart";
+import "package:gql_exec/gql_exec.dart";
 import "package:gql_link/gql_link.dart";
 import "package:mockito/mockito.dart";
 import "package:test/test.dart";
@@ -19,8 +19,8 @@ void main() {
       final req1 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
 
       final result1 = Response(
@@ -60,15 +60,15 @@ void main() {
       final req1 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
 
       final req2 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 42},
         ),
+        variables: const <String, dynamic>{"i": 42},
       );
 
       final result1 = Response(
@@ -123,15 +123,15 @@ void main() {
       final req1 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
 
       final req2 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
 
       final result1 = Response(
@@ -179,8 +179,8 @@ void main() {
       final req1 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
 
       final result1 = Response(
@@ -225,8 +225,8 @@ void main() {
       final req1 = Request(
         operation: Operation(
           document: document,
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
 
       final result1 = Response(

--- a/gql_example_cli/bin/main.dart
+++ b/gql_example_cli/bin/main.dart
@@ -25,10 +25,10 @@ Future<Null> main(List<String> arguments) async {
           Request(
             operation: Operation(
               document: find_pokemon.document,
-              variables: <String, String>{
-                "name": find,
-              },
             ),
+            variables: <String, String>{
+              "name": find,
+            },
           ),
         )
         .first;
@@ -61,10 +61,10 @@ Future<Null> main(List<String> arguments) async {
         Request(
           operation: Operation(
             document: list_pokemon.document,
-            variables: <String, String>{
-              "count": count,
-            },
           ),
+          variables: <String, String>{
+            "count": count,
+          },
         ),
       )
       .first;

--- a/gql_example_cli/pubspec.yaml
+++ b/gql_example_cli/pubspec.yaml
@@ -5,7 +5,7 @@ dependencies:
   args: any
   gql: ^0.12.0
   gql_link: ^0.2.1
-  gql_exec: ^0.1.0
+  gql_exec: ^0.2.0
   gql_http_link: ^0.2.2
 dev_dependencies: 
   build_runner: ^1.0.0

--- a/gql_exec/CHANGELOG.md
+++ b/gql_exec/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- move `variables` from `Operation` to `Request`
+
 ## 0.1.1
 
 - fixed documentation

--- a/gql_exec/lib/exec/operation.dart
+++ b/gql_exec/lib/exec/operation.dart
@@ -2,9 +2,7 @@ import "package:collection/collection.dart";
 import "package:gql/ast.dart";
 import "package:meta/meta.dart";
 
-/// Container of a [document] and it's [variables]
-///
-/// Optionally defines the [operationName]
+/// An operation in a [document] , optionally defined by [operationName]
 @immutable
 class Operation {
   /// Document containing at least one [OperationDefinitionNode]
@@ -15,19 +13,14 @@ class Operation {
   /// Must be specified if [document] contains more than one [OperationDefinitionNode]
   final String operationName;
 
-  /// Variables for the operation
-  final Map<String, dynamic> variables;
-
   const Operation({
     @required this.document,
     this.operationName,
-    this.variables = const <String, dynamic>{},
   }) : assert(document != null);
 
   List<Object> _getChildren() => [
         document,
         operationName,
-        variables,
       ];
 
   @override

--- a/gql_exec/lib/exec/request.dart
+++ b/gql_exec/lib/exec/request.dart
@@ -3,17 +3,21 @@ import "package:gql_exec/exec/context.dart";
 import "package:gql_exec/exec/operation.dart";
 import "package:meta/meta.dart";
 
-/// Execution request
+/// Execution request of an [operation] with [variables].
 @immutable
 class Request {
   /// [Operation] to be executed
   final Operation operation;
+
+  /// Variables of the operation for this request
+  final Map<String, dynamic> variables;
 
   /// A [Context] to be passed along with a [Request]
   final Context context;
 
   const Request({
     @required this.operation,
+    this.variables = const <String, dynamic>{},
     this.context = const Context(),
   })  : assert(operation != null),
         assert(context != null);
@@ -35,6 +39,7 @@ class Request {
 
   List<Object> _getChildren() => [
         operation,
+        variables,
         context,
       ];
 

--- a/gql_exec/pubspec.yaml
+++ b/gql_exec/pubspec.yaml
@@ -1,14 +1,14 @@
 name: gql_exec
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 0.1.1
+version: 0.2.0
 homepage: https://github.com/gql-dart/gql/tree/master/gql_exec
 description: Basis for GraphQL execution layer to support Link and Client.
-environment:
+environment: 
   sdk: '>=2.2.2 <3.0.0'
-dependencies:
+dependencies: 
   gql: ^0.12.0
   meta: ^1.1.7
   collection: ^1.14.11
-dev_dependencies:
+dev_dependencies: 
   test: ^1.0.0
   gql_pedantic: ^1.0.0

--- a/gql_http_link/CHANGELOG.md
+++ b/gql_http_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+- upgrade `package:gql_exec` to v0.2.0
+
 ## 0.2.4
 
 - use `package:gql_exec`

--- a/gql_http_link/pubspec.yaml
+++ b/gql_http_link/pubspec.yaml
@@ -1,13 +1,13 @@
 name: gql_http_link
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 0.2.4
+version: 0.2.5
 homepage: https://github.com/gql-dart/gql/tree/master/gql_http_link
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 environment: 
   sdk: '>=2.2.2 <3.0.0'
 dependencies: 
   meta: ^1.1.7
-  gql_exec: ^0.1.0
+  gql_exec: ^0.2.0
   gql_link: ^0.2.1
   http: ^0.12.0+2
 dev_dependencies: 

--- a/gql_http_link/test/gql_http_link_test.dart
+++ b/gql_http_link/test/gql_http_link_test.dart
@@ -33,8 +33,8 @@ void main() {
       request = Request(
         operation: Operation(
           document: parseString("query MyQuery {}"),
-          variables: const <String, dynamic>{"i": 12},
         ),
+        variables: const <String, dynamic>{"i": 12},
       );
       link = HttpLink(
         "/graphql-test",
@@ -168,8 +168,8 @@ void main() {
         Request(
           operation: Operation(
             document: parseString("query MyQuery {}"),
-            variables: const <String, dynamic>{"i": 12},
           ),
+          variables: const <String, dynamic>{"i": 12},
           context: Context.fromList(
             const [
               HttpLinkHeaders(
@@ -229,8 +229,8 @@ void main() {
             Request(
               operation: Operation(
                 document: parseString("query MyQuery {}"),
-                variables: const <String, dynamic>{"i": 12},
               ),
+              variables: const <String, dynamic>{"i": 12},
             ),
           )
           .first;
@@ -272,8 +272,8 @@ void main() {
         Request(
           operation: Operation(
             document: parseString("query MyQuery {}"),
-            variables: const <String, dynamic>{"i": 12},
           ),
+          variables: const <String, dynamic>{"i": 12},
           context: Context.fromList(
             const [
               HttpLinkHeaders(
@@ -536,8 +536,8 @@ void main() {
               Request(
                 operation: Operation(
                   document: parseString("query MyQuery {}"),
-                  variables: const <String, dynamic>{"i": 12},
                 ),
+                variables: const <String, dynamic>{"i": 12},
               ),
             )
             .first;
@@ -580,8 +580,8 @@ void main() {
               Request(
                 operation: Operation(
                   document: parseString("query MyQuery {}"),
-                  variables: const <String, dynamic>{"i": 12},
                 ),
+                variables: const <String, dynamic>{"i": 12},
               ),
             )
             .first;

--- a/gql_link/CHANGELOG.md
+++ b/gql_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- upgrade `package:gql_exec` to v0.2.0
+
 ## 0.2.1
 
 -  use `package:gql_exec`

--- a/gql_link/lib/src/request_serializer.dart
+++ b/gql_link/lib/src/request_serializer.dart
@@ -13,7 +13,7 @@ class RequestSerializer {
 
     return <String, dynamic>{
       "operationName": request.operation.operationName,
-      "variables": request.operation.variables,
+      "variables": request.variables,
       "query": printNode(request.operation.document),
       if (thunk != null) "extensions": thunk.getRequestExtensions(request),
     };

--- a/gql_link/pubspec.yaml
+++ b/gql_link/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gql_link
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/gql-dart/gql/tree/master/gql_link
 description: A simple and modular AST-based GraphQL request execution interface.
 environment: 
@@ -8,7 +8,7 @@ environment:
 dependencies: 
   meta: ^1.1.7
   gql: ^0.12.0
-  gql_exec: ^0.1.0
+  gql_exec: ^0.2.0
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1

--- a/gql_transform_link/CHANGELOG.md
+++ b/gql_transform_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+- upgrade `package:gql_exec` to v0.2.0
+
 ## 0.1.2
 
 - use `package:gql_exec`

--- a/gql_transform_link/example/gql_transform_link_example.dart
+++ b/gql_transform_link/example/gql_transform_link_example.dart
@@ -9,7 +9,7 @@ void main() {
     TransformLink(
       requestTransformer: (req) => req.withContextEntry(
         RequestExtensionsThunk(
-          (req2) => req2.operation.variables,
+          (req2) => req2.variables,
         ),
       ),
       responseTransformer: (resp) => resp.withContextEntry(

--- a/gql_transform_link/pubspec.yaml
+++ b/gql_transform_link/pubspec.yaml
@@ -1,12 +1,12 @@
 name: gql_transform_link
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/gql-dart/gql/tree/master/gql_transform_link
 description: GQL Link to transform Requests and Responses. May be used to update context, document, variables, data, errors, etc.
 environment: 
   sdk: '>=2.2.2 <3.0.0'
 dependencies: 
-  gql_exec: ^0.1.0
+  gql_exec: ^0.2.0
   gql_link: ^0.2.1
 dev_dependencies: 
   test: ^1.0.0

--- a/gql_transform_link/test/gql_transform_link_test.dart
+++ b/gql_transform_link/test/gql_transform_link_test.dart
@@ -1,7 +1,7 @@
 import "dart:async";
 
-import "package:gql_exec/gql_exec.dart";
 import "package:gql/language.dart";
+import "package:gql_exec/gql_exec.dart";
 import "package:gql_link/gql_link.dart";
 import "package:gql_transform_link/gql_transform_link.dart";
 import "package:mockito/mockito.dart";
@@ -15,7 +15,7 @@ void main() {
       final mockLink = MockLink();
 
       final extensionGetter = RequestExtensionsThunk(
-        (req) => req.operation.variables,
+        (req) => req.variables,
       );
 
       when(
@@ -39,8 +39,8 @@ void main() {
         Request(
           operation: Operation(
             document: parseString(""""""),
-            variables: const <String, dynamic>{"i": 12},
           ),
+          variables: const <String, dynamic>{"i": 12},
         ),
       );
 
@@ -49,8 +49,8 @@ void main() {
           Request(
             operation: Operation(
               document: parseString(""""""),
-              variables: const <String, dynamic>{"i": 12},
             ),
+            variables: const <String, dynamic>{"i": 12},
           ).withContextEntry(extensionGetter),
           null,
         ),
@@ -85,8 +85,8 @@ void main() {
         Request(
           operation: Operation(
             document: parseString(""""""),
-            variables: const <String, dynamic>{"i": 12},
           ),
+          variables: const <String, dynamic>{"i": 12},
         ),
       );
 


### PR DESCRIPTION
`Operation` is now a container of an operation in a document
designed to only be dependent on the GraphQL document.
`Request` is now a parameterized invocation of an `Operation`.