### PR TITLE
Recursive #import inlining

### DIFF
--- a/gql_code_gen/lib/ast_builder.dart
+++ b/gql_code_gen/lib/ast_builder.dart
@@ -26,7 +26,8 @@ Set<String> allRelativeImports(String doc) {
       final path = m?.group(1);
       if (path != null) {
         imports.add(
-            path.endsWith(graphqlExtension) ? path : "$path$graphqlExtension");
+            path.endsWith(graphqlExtension) ? path : "$path$graphqlExtension",
+        );
       }
     });
   }

--- a/gql_code_gen/lib/ast_builder.dart
+++ b/gql_code_gen/lib/ast_builder.dart
@@ -17,7 +17,7 @@ const graphqlExtension = ".graphql";
 const astExtension = ".ast.g.dart";
 
 Set<String> allRelativeImports(String doc) {
-  Set<String> imports;
+  final imports = <String>{};
   for (final pattern in [
     RegExp(r'^#\s*import\s+"([^"]+)"'),
     RegExp(r"^#\s*import\s+'([^']+)'")

--- a/gql_code_gen/lib/ast_builder.dart
+++ b/gql_code_gen/lib/ast_builder.dart
@@ -40,9 +40,7 @@ Future<String> inlineImportsRecursively(BuildStep buildStep) async {
 
   void collectContentRecursivelyFrom(AssetId id) async {
     importMap[id.path] = await buildStep.readAsString(id);
-    final segments = id.pathSegments
-      //..removeAt(0) // strip lib
-      ..removeLast();
+    final segments = id.pathSegments..removeLast();
 
     final imports = allRelativeImports(importMap[id.path])
         .map((i) => p.normalize(p.joinAll([...segments, i])))
@@ -63,8 +61,13 @@ Future<String> inlineImportsRecursively(BuildStep buildStep) async {
 
   await collectContentRecursivelyFrom(buildStep.inputId);
 
-  seenImports.where((i) => !importMap.containsKey(i)).forEach(
-      (missing) => log.warning("Could not import missing file $missing."));
+  seenImports
+      .where(
+        (i) => !importMap.containsKey(i),
+      )
+      .forEach(
+        (missing) => log.warning("Could not import missing file $missing."),
+      );
 
   return importMap.values.join("\n\n\n");
 }

--- a/gql_code_gen/lib/ast_builder.dart
+++ b/gql_code_gen/lib/ast_builder.dart
@@ -1,7 +1,6 @@
 library ast_builder;
 
 import "dart:async";
-import "dart:collection";
 import "package:path/path.dart" as p;
 import "package:glob/glob.dart";
 
@@ -19,8 +18,8 @@ const astExtension = ".ast.g.dart";
 Set<String> allRelativeImports(String doc) {
   final imports = <String>{};
   for (final pattern in [
-    RegExp(r'^#\s*import\s+"([^"]+)"'),
-    RegExp(r"^#\s*import\s+'([^']+)'")
+    RegExp(r'^#\s*import\s+"([^"]+)"', multiLine: true),
+    RegExp(r"^#\s*import\s+'([^']+)'", multiLine: true)
   ]) {
     pattern.allMatches(doc)?.forEach((m) {
       final path = m?.group(1);

--- a/gql_code_gen/lib/ast_builder.dart
+++ b/gql_code_gen/lib/ast_builder.dart
@@ -1,7 +1,7 @@
 library ast_builder;
 
 import "dart:async";
-import 'dart:collection';
+import "dart:collection";
 import "package:path/path.dart" as p;
 import "package:glob/glob.dart";
 
@@ -26,7 +26,7 @@ Set<String> allRelativeImports(String doc) {
       final path = m.group(1);
       if (path != null) {
         imports.add(
-            path.endsWith(graphqlExtension) ? path : '$path$graphqlExtension');
+            path.endsWith(graphqlExtension) ? path : "$path$graphqlExtension");
       }
     });
   }
@@ -65,25 +65,26 @@ class _AstBuilder implements Builder {
   @override
   FutureOr<void> build(BuildStep buildStep) async {
     final src = await buildStep.readAsString(buildStep.inputId);
-    Set<AssetId> seen = {buildStep.inputId};
+    final Set<AssetId> seen = {buildStep.inputId};
 
-    List<String> segments = buildStep.inputId.pathSegments;
+    final segments = buildStep.inputId.pathSegments;
     segments.removeLast();
 
     final imports = allRelativeImports(src);
     // there should be 1 per import
-    LinkedHashSet<String> resolvedStatements =
-        await Stream.fromIterable(imports)
-            .asyncExpand(
-              (relativeImport) => buildStep.findAssets(
-                Glob(p.joinAll([...segments, relativeImport])),
-              ),
-            )
-            .where((id) => seen.add(id))
-            .asyncMap((id) => buildStep.readAsString(id))
-            .toSet();
+    final resolvedStatements = LinkedHashSet<String>.from(
+      await Stream.fromIterable(imports)
+          .asyncExpand(
+            (relativeImport) => buildStep.findAssets(
+              Glob(p.joinAll([...segments, relativeImport])),
+            ),
+          )
+          .where(seen.add)
+          .asyncMap((id) => buildStep.readAsString(id))
+          .toSet(),
+    );
     resolvedStatements.add(src);
-    log.info('wtf');
+    log.info("wtf");
     log.info(imports);
 
     final doc = parseString(resolvedStatements.join("\n\n\n"),


### PR DESCRIPTION
closes #27
 
This implements a simple solution to #27 in a recursive fashion. It probably isn't the most elegant solution to the problem, but (I'm fairly sure) it handles nested imports without risk of an infinite loop due to a cycle.