### PR TITLE
Ensure doubles are generated properly

### DIFF
--- a/gql_code_builder/lib/src/operation/data.dart
+++ b/gql_code_builder/lib/src/operation/data.dart
@@ -223,7 +223,9 @@ Method _buildGetter(
                 .code
             : node.selectionSet == null
                 ? fieldTypeDef == null
-                    ? dataField.asA(returns).code
+                    ? returns.symbol == "double"
+                        ? dataField.nullSafeProperty("toDouble").call([]).code
+                        : dataField.asA(returns).code
                     : returns.call([
                         dataField.asA(refer("String")),
                       ]).code


### PR DESCRIPTION
This PR updates the data_builder to call `toDouble` on fields that expect a `double`. This ensures that even if the data received is stored in the `data` map as an integer, it will still get returned as a `double`.