### PR TITLE
Dispose the underlining http client

### DIFF
--- a/gql_http_link/CHANGELOG.md
+++ b/gql_http_link/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.3.0
+## 0.2.6
 
-- add `dispose()` function
+- add `dispose()` function to close the `http.Client`
 
 ## 0.2.5
 

--- a/gql_http_link/CHANGELOG.md
+++ b/gql_http_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- add `dispose()` function
+
 ## 0.2.5
 
 - upgrade `package:gql_exec` to v0.2.0

--- a/gql_http_link/lib/src/link.dart
+++ b/gql_http_link/lib/src/link.dart
@@ -142,6 +142,11 @@ class HttpLink extends Link {
       ),
     );
   }
+
+  /// Closes the underlining [http.Client]
+  void dispose() {
+    _httpClient?.close();
+  }
 }
 
 Map<String, String> _getHttpLinkHeaders(Request request) {

--- a/gql_http_link/pubspec.yaml
+++ b/gql_http_link/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gql_http_link
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 0.3.0
+version: 0.2.6
 homepage: https://github.com/gql-dart/gql/tree/master/gql_http_link
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 environment: 

--- a/gql_http_link/pubspec.yaml
+++ b/gql_http_link/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gql_http_link
 author: Klāvs Priedītis <klavs@prieditis.lv>
-version: 0.2.5
+version: 0.3.0
 homepage: https://github.com/gql-dart/gql/tree/master/gql_http_link
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 environment: 

--- a/gql_http_link/test/gql_http_link_test.dart
+++ b/gql_http_link/test/gql_http_link_test.dart
@@ -598,5 +598,13 @@ void main() {
         TypeMatcher<FormatException>(),
       );
     });
+
+    test("closes the underlining http client", () {
+      link.dispose();
+
+      verify(
+        client.close(),
+      ).called(1);
+    });
   });
 }


### PR DESCRIPTION
Create a dispose method on HttpLink to close the underlining http client.