### PR TITLE
implement SourceNode

### DIFF
--- a/gql_build/lib/src/ast_builder.dart
+++ b/gql_build/lib/src/ast_builder.dart
@@ -15,7 +15,7 @@ class AstBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
+    final doc = (await readDocument(buildStep)).flatDocument;
 
     final library = buildAstLibrary(
       doc,

--- a/gql_build/lib/src/data_builder.dart
+++ b/gql_build/lib/src/data_builder.dart
@@ -22,8 +22,8 @@ class DataBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
-    final schema = await readDocument(buildStep, schemaId);
+    final doc = (await readDocument(buildStep)).flatDocument;
+    final schema = (await readDocument(buildStep, schemaId)).flatDocument;
 
     final library = buildDataLibrary(
       doc,

--- a/gql_build/lib/src/enum_builder.dart
+++ b/gql_build/lib/src/enum_builder.dart
@@ -15,7 +15,7 @@ class EnumBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
+    final doc = (await readDocument(buildStep)).flatDocument;
 
     final library = buildEnumLibrary(
       doc,

--- a/gql_build/lib/src/fragment_builder.dart
+++ b/gql_build/lib/src/fragment_builder.dart
@@ -37,13 +37,14 @@ class FragmentBuilder implements Builder {
     final fragmentMap = <String, FragmentDefinitionNode>{};
 
     await for (final input in buildStep.findAssets(_graphqlFiles)) {
-      final doc = await readDocument(buildStep, input);
+      final source = await readDocument(buildStep, input);
+      final doc = source.flatDocument;
       doc.definitions
           .whereType<FragmentDefinitionNode>()
           .forEach((def) => fragmentMap.putIfAbsent(def.name.value, () => def));
     }
 
-    final schema = await readDocument(buildStep, schemaId);
+    final schema = (await readDocument(buildStep, schemaId)).flatDocument;
 
     final library = buildFragmentLibrary(
       fragmentMap,

--- a/gql_build/lib/src/input_builder.dart
+++ b/gql_build/lib/src/input_builder.dart
@@ -15,7 +15,7 @@ class InputBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
+    final doc = (await readDocument(buildStep)).flatDocument;
 
     final library = buildInputLibrary(
       doc,

--- a/gql_build/lib/src/op_builder.dart
+++ b/gql_build/lib/src/op_builder.dart
@@ -21,8 +21,8 @@ class OpBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
-    final schema = await readDocument(buildStep, schemaId);
+    final doc = (await readDocument(buildStep)).flatDocument;
+    final schema = (await readDocument(buildStep, schemaId)).flatDocument;
 
     final library = buildOpLibrary(
       doc,

--- a/gql_build/lib/src/req_builder.dart
+++ b/gql_build/lib/src/req_builder.dart
@@ -21,8 +21,8 @@ class ReqBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
-    final schema = await readDocument(buildStep, schemaId);
+    final doc = (await readDocument(buildStep)).flatDocument;
+    final schema = (await readDocument(buildStep, schemaId)).flatDocument;
 
     final library = buildReqLibrary(
       doc,

--- a/gql_build/lib/src/scalar_builder.dart
+++ b/gql_build/lib/src/scalar_builder.dart
@@ -15,7 +15,7 @@ class ScalarBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
+    final doc = (await readDocument(buildStep)).flatDocument;
 
     final library = buildScalarLibrary(
       doc,

--- a/gql_build/lib/src/schema_builder.dart
+++ b/gql_build/lib/src/schema_builder.dart
@@ -15,7 +15,7 @@ class SchemaBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
+    final doc = (await readDocument(buildStep)).flatDocument;
 
     final library = buildSchemaLibrary(
       doc,

--- a/gql_build/lib/src/utils/reader.dart
+++ b/gql_build/lib/src/utils/reader.dart
@@ -1,82 +1,81 @@
 import "dart:async";
 
-import "package:path/path.dart" as p;
-import "package:glob/glob.dart";
 import "package:build/build.dart";
 
-import "package:gql/ast.dart";
+import "package:gql_code_builder/source.dart";
 import "package:gql/language.dart";
 
 import "package:gql_build/src/config.dart";
 
-Set<String> allRelativeImports(String doc) {
+Set<AssetId> _getImports(
+  String source, {
+  AssetId from,
+}) {
   final imports = <String>{};
-  for (final pattern in [
+
+  final patterns = [
     RegExp(r'^#\s*import\s+"([^"]+)"', multiLine: true),
-    RegExp(r"^#\s*import\s+'([^']+)'", multiLine: true)
-  ]) {
-    pattern.allMatches(doc)?.forEach((m) {
-      final path = m?.group(1);
-      if (path != null) {
-        imports.add(
-          path.endsWith(sourceExtension) ? path : "$path$sourceExtension",
-        );
-      }
-    });
-  }
+    RegExp(r"^#\s*import\s+'([^']+)'", multiLine: true),
+  ];
 
-  return imports;
-}
-
-Future<DocumentNode> readDocument(
-  BuildStep buildStep, [
-  AssetId rootId,
-]) async =>
-    parseString(
-      await readCombinedSource(buildStep, rootId),
-      url: (rootId ?? buildStep.inputId).path,
+  for (final pattern in patterns) {
+    pattern.allMatches(source)?.forEach(
+      (match) {
+        final path = match?.group(1);
+        if (path != null) {
+          imports.add(
+            path.endsWith(sourceExtension) ? path : "$path$sourceExtension",
+          );
+        }
+      },
     );
-
-Future<String> readCombinedSource(
-  BuildStep buildStep, [
-  AssetId rootId,
-]) async {
-  final Map<String, String> importMap = {};
-  final Set<String> seenImports = {};
-
-  void collectContentRecursivelyFrom(AssetId id) async {
-    importMap[id.path] = await buildStep.readAsString(id);
-    final segments = id.pathSegments..removeLast();
-
-    final imports = allRelativeImports(importMap[id.path])
-        .map(
-          (i) => p.toUri(p.normalize(p.joinAll([...segments, i]))).toString(),
-        )
-        .where((i) => !importMap.containsKey(i)) // avoid duplicates/cycles
-        .toSet();
-
-    seenImports.addAll(imports);
-
-    final assetIds = await Stream.fromIterable(imports)
-        .asyncExpand(
-          (relativeImport) => buildStep.findAssets(Glob(relativeImport)),
-        )
-        .toSet();
-
-    for (final assetId in assetIds) {
-      await collectContentRecursivelyFrom(assetId);
-    }
   }
 
-  await collectContentRecursivelyFrom(rootId ?? buildStep.inputId);
-
-  seenImports
-      .where(
-        (i) => !importMap.containsKey(i),
+  return imports
+      .map(
+        (import) => AssetId.resolve(
+          import,
+          from: from,
+        ),
       )
-      .forEach(
-        (missing) => log.warning("Could not import missing file $missing."),
-      );
-
-  return importMap.values.join("\n\n\n");
+      .toSet();
 }
+
+Future<SourceNode> _assetToSourceNode(
+  BuildStep buildStep,
+  AssetId assetId,
+) async {
+  final sourceString = await buildStep.readAsString(assetId);
+
+  final imports = _getImports(
+    sourceString,
+    from: assetId,
+  );
+
+  final url = assetId.uri.toString();
+
+  return SourceNode(
+    url: url,
+    document: parseString(
+      sourceString,
+      url: url,
+    ),
+    imports: await Stream.fromIterable(imports)
+        .asyncMap(
+          (importedAssetId) => _assetToSourceNode(
+            buildStep,
+            importedAssetId,
+          ),
+        )
+        .toSet(),
+  );
+}
+
+Future<SourceNode> readDocument(
+  BuildStep buildStep, [
+  AssetId rootId,
+]) =>
+    _assetToSourceNode(
+      buildStep,
+      rootId ?? buildStep.inputId,
+    );

--- a/gql_build/lib/src/var_builder.dart
+++ b/gql_build/lib/src/var_builder.dart
@@ -20,8 +20,8 @@ class VarBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    final doc = await readDocument(buildStep);
-    final schema = await readDocument(buildStep, schemaId);
+    final doc = (await readDocument(buildStep)).flatDocument;
+    final schema = (await readDocument(buildStep, schemaId)).flatDocument;
 
     final library = buildVarLibrary(
       doc,

--- a/gql_code_builder/lib/source.dart
+++ b/gql_code_builder/lib/source.dart
@@ -1,0 +1,25 @@
+import "package:gql/ast.dart";
+
+/// Source node represents source file and it's imports
+class SourceNode {
+  final String url;
+  final DocumentNode document;
+  final Set<SourceNode> imports;
+
+  const SourceNode({
+    this.url,
+    this.document,
+    this.imports = const {},
+  });
+
+  /// Returns flattened Document as a temporary solution before existing
+  /// builders have adopted [SourceNode]
+  DocumentNode get flatDocument => DocumentNode(
+        definitions: <DefinitionNode>[
+          ...document.definitions,
+          ...imports.expand(
+            (import) => import.flatDocument.definitions,
+          ),
+        ],
+      );
+}


### PR DESCRIPTION
- implement `SourceNode`
- read sources as a tree of source nodes instead of a flat concatenated document
- temporarily flatten source tree to document for backwards-compatibility