### PR TITLE
Add UniqueInputFieldNames validator

### DIFF
--- a/gql/lib/src/validation/rules/unique_input_field_names.dart
+++ b/gql/lib/src/validation/rules/unique_input_field_names.dart
@@ -1,0 +1,36 @@
+import "package:gql/ast.dart";
+import "package:gql/src/validation/validating_visitor.dart";
+import "package:gql/src/validation/validator.dart";
+
+class DuplicateInputFieldNameError extends ValidationError {
+  const DuplicateInputFieldNameError({
+    ObjectFieldNode node,
+  }) : super(
+          node: node,
+        );
+}
+
+class UniqueInputFieldNames extends ValidatingVisitor {
+  Map<String, NameNode> knownNames = {};
+  List<Map<String, NameNode>> knownNameStack = [];
+
+  @override
+  List<ValidationError> visitObjectValueNode(ObjectValueNode node) {
+    knownNameStack.add(knownNames);
+    knownNames = {};
+    final List<ValidationError> errors = [];
+    node.fields.forEach((field) => errors.addAll(_visitObjectFieldNode(field)));
+    knownNames = knownNameStack.removeLast();
+    return errors;
+  }
+
+  List<ValidationError> _visitObjectFieldNode(ObjectFieldNode node) {
+    final fieldName = node.name.value;
+    if (knownNames.containsKey(fieldName)) {
+      return [DuplicateInputFieldNameError(node: node)];
+    } else {
+      knownNames[fieldName] = node.name;
+    }
+    return [];
+  }
+}

--- a/gql/lib/src/validation/rules/unique_input_field_names.dart
+++ b/gql/lib/src/validation/rules/unique_input_field_names.dart
@@ -12,15 +12,12 @@ class DuplicateInputFieldNameError extends ValidationError {
 
 class UniqueInputFieldNames extends ValidatingVisitor {
   Map<String, NameNode> knownNames = {};
-  List<Map<String, NameNode>> knownNameStack = [];
 
   @override
   List<ValidationError> visitObjectValueNode(ObjectValueNode node) {
-    knownNameStack.add(knownNames);
-    knownNames = {};
+    knownNames.clear();
     final List<ValidationError> errors = [];
     node.fields.forEach((field) => errors.addAll(_visitObjectFieldNode(field)));
-    knownNames = knownNameStack.removeLast();
     return errors;
   }
 

--- a/gql/lib/src/validation/validator.dart
+++ b/gql/lib/src/validation/validator.dart
@@ -3,6 +3,7 @@ import "package:gql/src/validation/rules/lone_schema_definition.dart";
 import "package:gql/src/validation/rules/unique_directive_names.dart";
 import "package:gql/src/validation/rules/unique_enum_value_names.dart";
 import "package:gql/src/validation/rules/unique_field_definition_names.dart";
+import "package:gql/src/validation/rules/unique_input_field_names.dart";
 import "package:gql/src/validation/rules/unique_operation_types.dart";
 import "package:gql/src/validation/rules/unique_type_names.dart";
 import "package:gql/src/validation/validating_visitor.dart";
@@ -91,7 +92,8 @@ enum ValidationRule {
   uniqueEnumValueNames,
   loneSchemaDefinition,
   uniqueOperationTypes,
-  uniqueTypeNames
+  uniqueTypeNames,
+  uniqueInputFieldNames
 }
 
 ValidatingVisitor _mapRule(ValidationRule rule) {
@@ -108,6 +110,8 @@ ValidatingVisitor _mapRule(ValidationRule rule) {
       return UniqueOperationTypes();
     case ValidationRule.uniqueTypeNames:
       return UniqueTypeNames();
+    case ValidationRule.uniqueInputFieldNames:
+      return UniqueInputFieldNames();
     default:
       return null;
   }

--- a/gql/test/validation/unique_input_field_names_test.dart
+++ b/gql/test/validation/unique_input_field_names_test.dart
@@ -1,0 +1,92 @@
+import "package:gql/src/validation/rules/unique_input_field_names.dart";
+import "package:gql/src/validation/validator.dart";
+import "package:test/test.dart";
+
+import "./common.dart";
+
+final validate = createValidator({
+  ValidationRule.uniqueInputFieldNames,
+});
+
+void main() {
+  group("Unique input field names", () {
+    test("errors on non-unique input field names", () {
+      expect(
+        validate(
+          """
+          {
+            field(arg: { f1: "value", f1: "value" })
+          }
+          """,
+        ),
+        contains(
+          errorOfType<DuplicateInputFieldNameError>(),
+        ),
+      );
+    });
+    test("errors on multiple non-unique input field names", () {
+      expect(
+        validate(
+          """
+          {
+            field(arg: { f1: "value", f1: "value", f1: "value" })
+          }
+          """,
+        ),
+        containsAll(
+          <Matcher>[
+            errorOfType<DuplicateInputFieldNameError>(),
+            errorOfType<DuplicateInputFieldNameError>()
+          ],
+        ),
+      );
+    });
+
+    test("errors on nested non-unique input field names", () {
+      expect(
+        validate(
+          """
+          {
+            field(arg: { f1: {f2: "value", f2: "value" }})
+          }
+          """,
+        ),
+        contains(
+          errorOfType<DuplicateInputFieldNameError>(),
+        ),
+      );
+    });
+
+    test("allows for nested input objects with similar fields", () {
+      expect(validate("""
+          {
+            field(arg: {
+              deep: {
+                deep: {
+                  id: 1
+                }
+                id: 1
+              }
+              id: 1
+            })
+          }
+          """), isEmpty);
+    });
+
+    test("allows for input objects with fields", () {
+      expect(validate("""
+          {
+            field(arg: { f: true })
+          }
+          """), isEmpty);
+    });
+
+    test("allows for same input object within two args", () {
+      expect(validate("""
+          {
+            field(arg1: { f: true }, arg2: { f: true })
+          }
+          """), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
This adds the UniqueInputFieldNames validator. It required a few more tweaks to the original JS code, because as far as I can tell, there is no "enter" and "leave" hooks for the visitors (yet?). 

I also copied most of the test cases from the JS source to make sure that this implementation is complying with the reference.

