### PR TITLE
Peek for opening bracket while parsing interfaces

### DIFF
--- a/gql/lib/src/language/parser.dart
+++ b/gql/lib/src/language/parser.dart
@@ -662,7 +662,7 @@ class _Parser {
       _expectOptionalToken(TokenKind.amp);
       do {
         types.add(_parseNamedType());
-      } while (_expectOptionalToken(TokenKind.amp) != null);
+      } while (!_peek(TokenKind.braceL));
     }
 
     return types;


### PR DESCRIPTION
I'm not sure that's the ideal code, but worked with [my example](https://github.com/gql-dart/gql/issues/65).

Solves the first stacktrace of https://github.com/gql-dart/gql/issues/65