### PR TITLE
Make GraphQLError implement Exception

### DIFF
--- a/gql_exec/lib/exec/error.dart
+++ b/gql_exec/lib/exec/error.dart
@@ -3,7 +3,7 @@ import "package:meta/meta.dart";
 
 /// GraphQL Error returned if execution fails
 @immutable
-class GraphQLError {
+class GraphQLError implements Exception {
   /// Error message
   final String message;
 


### PR DESCRIPTION
This should make it easier for clients (like Ferry) to provide a `List<Exception>` which could include both Network Errors and GraphQL Errors.
