### PR TITLE
Avoid WSLink config null error

### DIFF
--- a/gql_websocket_link/lib/src/link.dart
+++ b/gql_websocket_link/lib/src/link.dart
@@ -20,7 +20,11 @@ class WSLink extends Link {
 
   ResponseParser parser;
 
-  WSLink(this.url, {this.config, this.parser = const ResponseParser()});
+  WSLink(
+    this.url, {
+    this.config = const SocketClientConfig(),
+    this.parser = const ResponseParser(),
+  });
 
   @override
   Stream<Response> request(Request request, [forward]) async* {


### PR DESCRIPTION
Instantiate a default `SocketClientConfig` on `WSLink` to avoid "was called on null" errors.