### PR TITLE
Multipart File Upload and useGETForQueries support

### DIFF
--- a/links/gql_http_link/CHANGELOG.md
+++ b/links/gql_http_link/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- add multipart file support
+- add `useGETForQueries` option
+
 ## 0.2.9
 
 - remove `author` field from `pubspec.yaml`

--- a/links/gql_http_link/lib/src/_utils.dart
+++ b/links/gql_http_link/lib/src/_utils.dart
@@ -66,7 +66,9 @@ Map<String, MultipartFile> extractFlattenedFileMap(
 
   if (body is MultipartFile) {
     return currentMap
-      ..addAll(<String, MultipartFile>{currentPath.join("."): body});
+      ..addAll({
+        currentPath.join("."): body,
+      });
   }
 
   assert(

--- a/links/gql_http_link/lib/src/_utils.dart
+++ b/links/gql_http_link/lib/src/_utils.dart
@@ -1,0 +1,120 @@
+import "dart:convert";
+import "dart:typed_data";
+import "package:meta/meta.dart";
+
+import "package:http/http.dart";
+import "package:gql/ast.dart";
+import "package:gql_exec/gql_exec.dart" as gql;
+
+extension WithType on gql.Request {
+  OperationType get type {
+    final definitions = operation.document.definitions
+        .whereType<OperationDefinitionNode>()
+        .toList();
+    if (operation.operationName != null) {
+      definitions.removeWhere(
+        (node) => node.name.value != operation.operationName,
+      );
+    }
+    // TODO differentiate error types, add exception
+    assert(definitions.length == 1);
+    return definitions.first.type;
+  }
+
+  bool get isQuery => type == OperationType.query;
+
+  /// Map of  [MultipartFile]s passed in [variables],
+  /// with paths as keys.
+  ///
+  /// example mapping:
+  /// ```dart
+  /// {
+  ///   "foo": [ { "bar": MultipartFile("blah.txt") } ]
+  ///  }
+  /// // =>
+  /// {
+  ///   "foo.0.bar": MultipartFile("blah.txt")
+  /// }
+  /// ```
+  Map<String, MultipartFile> get fileVariables =>
+      _extractFlattenedFileMap(variables);
+}
+
+/// Recursively extract [MultipartFile]s and return them as a normalized map of [path] => [file]
+/// From the given request variables
+///
+/// This is only used in
+Map<String, MultipartFile> _extractFlattenedFileMap(
+  dynamic variables, {
+  Map<String, MultipartFile> currentMap,
+  List<String> currentPath = const <String>[],
+}) {
+  currentMap ??= <String, MultipartFile>{};
+  if (variables is Map<String, dynamic>) {
+    final Iterable<MapEntry<String, dynamic>> entries = variables.entries;
+    for (final MapEntry<String, dynamic> element in entries) {
+      currentMap.addAll(_extractFlattenedFileMap(
+        element.value,
+        currentMap: currentMap,
+        currentPath: List<String>.from(currentPath)..add(element.key),
+      ));
+    }
+    return currentMap;
+  }
+  if (variables is List<dynamic>) {
+    for (int i = 0; i < variables.length; i++) {
+      currentMap.addAll(_extractFlattenedFileMap(
+        variables[i],
+        currentMap: currentMap,
+        currentPath: List<String>.from(currentPath)..add(i.toString()),
+      ));
+    }
+    return currentMap;
+  }
+
+  if (variables is MultipartFile) {
+    return currentMap
+      ..addAll(<String, MultipartFile>{currentPath.join("."): variables});
+  }
+
+  assert(
+    variables is String || variables is num || variables == null,
+    "$variables of type ${variables.runtimeType} was found "
+    "in in the request at path ${currentPath.join(".")}, "
+    "but the only the types { Map, List, MultipartFile, String, num, null } "
+    "are allowed",
+  );
+  return currentMap;
+}
+
+extension AddAllFiles on MultipartRequest {
+  void addAllFiles(Map<String, MultipartFile> fileMap) {
+    final Map<String, List<String>> fileMapping = <String, List<String>>{};
+    final List<MultipartFile> fileList = <MultipartFile>[];
+
+    final List<MapEntry<String, MultipartFile>> fileMapEntries =
+        fileMap.entries.toList(growable: false);
+
+    for (int i = 0; i < fileMapEntries.length; i++) {
+      final MapEntry<String, MultipartFile> entry = fileMapEntries[i];
+      final String indexString = i.toString();
+      fileMapping.addAll(<String, List<String>>{
+        indexString: <String>[entry.key],
+      });
+      final MultipartFile f = entry.value;
+      fileList.add(MultipartFile(
+        indexString,
+        f.finalize(),
+        f.length,
+        contentType: f.contentType,
+        filename: f.filename,
+      ));
+    }
+
+    fields["map"] = json.encode(fileMapping);
+
+    files.addAll(fileList);
+  }
+
+  set body(String body) => fields["operations"] = body;
+}

--- a/links/gql_http_link/lib/src/link.dart
+++ b/links/gql_http_link/lib/src/link.dart
@@ -170,11 +170,10 @@ class HttpLink extends Link {
 
     final fileMap = extractFlattenedFileMap(body);
 
-    final method = (fileMap.isEmpty && useGETForQueries && request.isQuery)
-        ? "GET"
-        : "POST";
-    // TODO other ways to override method (via context)
-    if (method == "GET") {
+    final useGetForThisRequest =
+        fileMap.isEmpty && useGETForQueries && request.isQuery;
+
+    if (useGetForThisRequest) {
       return http.Request(
         "GET",
         uri.replace(

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -1,15 +1,15 @@
 name: gql_http_link
-version: 0.2.9
+version: 0.3.0
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 repository: https://github.com/gql-dart/gql
-environment: 
-  sdk: '>=2.7.2 <3.0.0'
-dependencies: 
+environment:
+  sdk: ">=2.7.2 <3.0.0"
+dependencies:
   meta: ^1.1.7
   gql_exec: ^0.2.2
   gql_link: ^0.3.0
   http: ^0.12.1
-dev_dependencies: 
+dev_dependencies:
   test: ^1.0.0
   mockito: ^4.1.1
   gql: ^0.12.1

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -1,15 +1,15 @@
 name: gql_http_link
-version: 0.3.0
+version: 0.2.9
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 repository: https://github.com/gql-dart/gql
-environment:
-  sdk: ">=2.7.2 <3.0.0"
-dependencies:
+environment: 
+  sdk: '>=2.7.2 <3.0.0'
+dependencies: 
   meta: ^1.1.7
   gql_exec: ^0.2.2
   gql_link: ^0.3.0
   http: ^0.12.1
-dev_dependencies:
+dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
   gql: ^0.12.1

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   meta: ^1.1.7
   gql_exec: ^0.2.2
   gql_link: ^0.3.0
-  http: ^0.12.0+2
+  http: ^0.12.1
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1

--- a/links/gql_http_link/test/gql_http_link_test.dart
+++ b/links/gql_http_link/test/gql_http_link_test.dart
@@ -9,6 +9,8 @@ import "package:http/http.dart" as http;
 import "package:mockito/mockito.dart";
 import "package:test/test.dart";
 
+import "./helpers.dart";
+
 class MockClient extends Mock implements http.Client {}
 
 class MockRequestSerializer extends Mock implements RequestSerializer {}
@@ -44,15 +46,10 @@ void main() {
 
     test("parses a successful response", () {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -82,15 +79,10 @@ void main() {
 
     test("uses the defined endpoint", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -101,27 +93,15 @@ void main() {
 
       await execute().first;
 
-      verify(
-        client.post(
-          "/graphql-test",
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
-      ).called(1);
+      verify(client.send(any)).called(1);
     });
 
     test("uses json mime types", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -132,30 +112,15 @@ void main() {
 
       await execute().first;
 
-      verify(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: {
-            "Content-type": "application/json",
-            "Accept": "*/*",
-          },
-          encoding: anyNamed("encoding"),
-        ),
-      ).called(1);
+      verify(client.send(any)).called(1);
     });
 
     test("adds headers from context", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -182,18 +147,7 @@ void main() {
         ),
       ).first;
 
-      verify(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: {
-            "Content-type": "application/json",
-            "Accept": "*/*",
-            "foo": "bar",
-          },
-          encoding: anyNamed("encoding"),
-        ),
-      ).called(1);
+      verify(client.send(any)).called(1);
     });
 
     test("adds default headers", () async {
@@ -207,15 +161,10 @@ void main() {
       );
 
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -235,31 +184,15 @@ void main() {
           )
           .first;
 
-      verify(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: {
-            "Content-type": "application/json",
-            "Accept": "*/*",
-            "foo": "bar",
-          },
-          encoding: anyNamed("encoding"),
-        ),
-      ).called(1);
+      verify(client.send(any)).called(1);
     });
 
     test("headers from context override defaults", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -286,30 +219,15 @@ void main() {
         ),
       ).first;
 
-      verify(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: {
-            "Content-type": "application/jsonize",
-            "Accept": "*/*",
-          },
-          encoding: anyNamed("encoding"),
-        ),
-      ).called(1);
+      verify(client.send(any)).called(1);
     });
 
     test("serializes the request", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -320,28 +238,15 @@ void main() {
 
       await execute().first;
 
-      verify(
-        client.post(
-          any,
-          body:
-              """{"operationName":null,"variables":{"i":12},"query":"query MyQuery {\\n  \\n}"}""",
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
-      ).called(1);
+      verify(client.send(any)).called(1);
     });
 
     test("parses a successful response with errors", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(
               <String, dynamic>{
                 "errors": <Map<String, dynamic>>[
@@ -394,23 +299,15 @@ void main() {
     });
 
     test("throws HttpLinkServerException when status code >= 300", () async {
-      final http.Response response = http.Response(
-        json.encode(<String, dynamic>{
-          "data": <String, dynamic>{},
-        }),
-        300,
-      );
+      final data = json.encode(<String, dynamic>{
+        "data": <String, dynamic>{},
+      });
 
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          response,
+          simpleResponse(data, 300),
         ),
       );
 
@@ -426,10 +323,7 @@ void main() {
         exception,
         TypeMatcher<HttpLinkServerException>(),
       );
-      expect(
-        exception.response,
-        response,
-      );
+      expect(exception.response.body, data);
       expect(
         exception.parsedResponse,
         equals(
@@ -445,21 +339,14 @@ void main() {
     });
 
     test("throws HttpLinkServerException when no data and errors", () async {
-      final http.Response response = http.Response(
-        json.encode(<String, dynamic>{}),
-        200,
-      );
+      final data = json.encode(<String, dynamic>{});
+      final _response = simpleResponse(data, 200);
 
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          response,
+          _response,
         ),
       );
 
@@ -476,8 +363,8 @@ void main() {
         TypeMatcher<HttpLinkServerException>(),
       );
       expect(
-        exception.response,
-        response,
+        exception.response.body,
+        data,
       );
       expect(
         exception.parsedResponse,
@@ -505,15 +392,10 @@ void main() {
       final originalException = Exception("Foo bar");
 
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             json.encode(<String, dynamic>{
               "data": <String, dynamic>{},
             }),
@@ -557,15 +439,10 @@ void main() {
 
     test("throws ParserException when unable to serialize request", () async {
       when(
-        client.post(
-          any,
-          body: anyNamed("body"),
-          headers: anyNamed("headers"),
-          encoding: anyNamed("encoding"),
-        ),
+        client.send(any),
       ).thenAnswer(
         (_) => Future.value(
-          http.Response(
+          simpleResponse(
             "foobar",
             200,
           ),

--- a/links/gql_http_link/test/gql_http_link_test.dart
+++ b/links/gql_http_link/test/gql_http_link_test.dart
@@ -561,7 +561,7 @@ void main() {
       );
     });
 
-    test("uses GET for query", () async {
+    test("uses GET for query without files", () async {
       when(
         client.send(any),
       ).thenAnswer(

--- a/links/gql_http_link/test/gql_http_link_test.dart
+++ b/links/gql_http_link/test/gql_http_link_test.dart
@@ -54,7 +54,7 @@ void main() {
               "data": <String, dynamic>{},
             }),
             200,
-            headers: {"header-1": "value-1"},
+            {"header-1": "value-1"},
           ),
         ),
       );
@@ -333,7 +333,7 @@ void main() {
               },
             ),
             200,
-            headers: {"header-1": "value-1"},
+            {"header-1": "value-1"},
           ),
         ),
       );

--- a/links/gql_http_link/test/helpers.dart
+++ b/links/gql_http_link/test/helpers.dart
@@ -1,0 +1,14 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:http/http.dart" as http;
+
+http.StreamedResponse simpleResponse(String body, [int status]) {
+  final List<int> bytes = utf8.encode(body);
+  final Stream<List<int>> stream =
+      Stream<List<int>>.fromIterable(<List<int>>[bytes]);
+
+  final http.StreamedResponse r = http.StreamedResponse(stream, status ?? 200);
+
+  return r;
+}

--- a/links/gql_http_link/test/helpers.dart
+++ b/links/gql_http_link/test/helpers.dart
@@ -3,12 +3,17 @@ import "dart:convert";
 
 import "package:http/http.dart" as http;
 
-http.StreamedResponse simpleResponse(String body, [int status, Map<String,String> headers = const {}]) {
+http.StreamedResponse simpleResponse(
+  String body, [
+  int status,
+  Map<String, String> headers = const {},
+]) {
   final List<int> bytes = utf8.encode(body);
   final Stream<List<int>> stream =
       Stream<List<int>>.fromIterable(<List<int>>[bytes]);
 
-  final http.StreamedResponse r = http.StreamedResponse(stream, status ?? 200, headers: headers);
+  final http.StreamedResponse r =
+      http.StreamedResponse(stream, status ?? 200, headers: headers);
 
   return r;
 }

--- a/links/gql_http_link/test/helpers.dart
+++ b/links/gql_http_link/test/helpers.dart
@@ -3,12 +3,12 @@ import "dart:convert";
 
 import "package:http/http.dart" as http;
 
-http.StreamedResponse simpleResponse(String body, [int status]) {
+http.StreamedResponse simpleResponse(String body, [int status, Map<String,String> headers = const {}]) {
   final List<int> bytes = utf8.encode(body);
   final Stream<List<int>> stream =
       Stream<List<int>>.fromIterable(<List<int>>[bytes]);
 
-  final http.StreamedResponse r = http.StreamedResponse(stream, status ?? 200);
+  final http.StreamedResponse r = http.StreamedResponse(stream, status ?? 200, headers: headers);
 
   return r;
 }

--- a/links/gql_http_link/test/multipart_upload_test.dart
+++ b/links/gql_http_link/test/multipart_upload_test.dart
@@ -220,7 +220,7 @@ void main() {
 
       final gqlQueryWithFiles = Request(
         operation: Operation(
-          document: parseString(uploadMutation),
+          document: parseString(uploadQuery),
         ),
         variables: <String, dynamic>{
           "files": testFiles(),
@@ -253,7 +253,7 @@ void main() {
               r"{"
               r'"operationName":null,'
               r'"variables":{"files":[null,null]},'
-              r'"query":"mutation($files: [Upload!]!) {\n'
+              r'"query":"query($files: [Upload!]!) {\n'
               r"  multipleUpload(files: $files) {\n    id\n    filename\n    mimetype\n    path\n  }\n"
               r'}"'
               r"}"
@@ -280,44 +280,6 @@ void main() {
           ],
         ),
       );
-    });
-
-    test("query request encoding without files", () async {
-      when(
-        mockHttpClient.send(any),
-      ).thenAnswer(
-        (_) => Future.value(
-          simpleResponse(
-            json.encode(<String, dynamic>{
-              "data": <String, dynamic>{},
-            }),
-            200,
-          ),
-        ),
-      );
-
-      final gqlQueryWithoutFiles = Request(
-        operation: Operation(
-          document: parseString(uploadQuery),
-        ),
-        variables: const <String, dynamic>{
-          "files": <http.MultipartFile>[],
-        },
-      );
-
-      await httpLink.request(gqlQueryWithoutFiles).first;
-
-      verify(
-        mockHttpClient.send(
-          argThat(
-            isA<http.Request>().having(
-              (request) => request.method,
-              "method",
-              "GET",
-            ),
-          ),
-        ),
-      ).called(1);
     });
   });
 }

--- a/links/gql_http_link/test/multipart_upload_test.dart
+++ b/links/gql_http_link/test/multipart_upload_test.dart
@@ -1,0 +1,206 @@
+import "dart:async";
+import "dart:convert";
+import "package:meta/meta.dart";
+
+import "package:gql_exec/gql_exec.dart";
+import "package:gql/language.dart";
+import "package:gql_http_link/gql_http_link.dart";
+import "package:gql_link/gql_link.dart";
+import "package:http/http.dart" as http;
+import "package:http_parser/http_parser.dart";
+import "package:mockito/mockito.dart";
+import "package:test/test.dart";
+
+class MockClient extends Mock implements http.Client {}
+
+class MockRequestSerializer extends Mock implements RequestSerializer {}
+
+class MockResponseParser extends Mock implements ResponseParser {}
+
+void main() {
+  MockClient mockHttpClient;
+  HttpLink httpLink;
+
+  group("upload", () {
+    const String uploadMutation = r"""
+    mutation($files: [Upload!]!) {
+      multipleUpload(files: $files) {
+        id
+        filename
+        mimetype
+        path
+      }
+    }
+    """;
+
+    setUp(() {
+      mockHttpClient = MockClient();
+
+      httpLink = HttpLink(
+        "http://localhost:3001/graphql",
+        httpClient: mockHttpClient,
+      );
+    });
+
+    test("upload success", () async {
+      Future<void> expectUploadBody(
+          http.ByteStream bodyBytesStream, String boundary) async {
+        final List<Function> expectContinuationList = (() {
+          int i = 0;
+          return <Function>[
+            // ExpectString
+            (List<int> actual, String expected) => expect(
+                String.fromCharCodes(actual.sublist(i, i += expected.length)),
+                expected),
+            // ExpectBytes
+            (List<int> actual, List<int> expected) =>
+                expect(actual.sublist(i, i += expected.length), expected),
+            // Expect final length
+            (int expectedLength) => expect(i, expectedLength),
+          ];
+        })();
+        final Function expectContinuationString = expectContinuationList[0];
+        final Function expectContinuationBytes = expectContinuationList[1];
+        final Function expectContinuationLength = expectContinuationList[2];
+        final bodyBytes = await bodyBytesStream.toBytes();
+        expectContinuationString(bodyBytes, "--");
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-disposition: form-data; name="operations"\r\n\r\n');
+        // operationName of unamed operations is "UNNAMED/" +  document.hashCode.toString()
+        expectContinuationString(bodyBytes,
+            r'{"operationName":null,"variables":{"files":[null,null]},"query":"mutation($files: [Upload!]!) {\n  multipleUpload(files: $files) {\n    id\n    filename\n    mimetype\n    path\n  }\n}"}');
+        expectContinuationString(bodyBytes, "\r\n--");
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-disposition: form-data; name="map"\r\n\r\n{"0":["variables.files.0"],"1":["variables.files.1"]}');
+        expectContinuationString(bodyBytes, "\r\n--");
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(
+          bodyBytes,
+          '\r\ncontent-type: image/jpeg\r\ncontent-disposition: form-data; name="0"; filename="sample_upload.jpg"\r\n\r\n',
+        );
+        expectContinuationBytes(bodyBytes, [0, 1, 254, 255]);
+        expectContinuationString(bodyBytes, "\r\n--");
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes,
+            '\r\ncontent-type: text/plain; charset=utf-8\r\ncontent-disposition: form-data; name="1"; filename="sample_upload.txt"\r\n\r\n');
+        expectContinuationString(bodyBytes, "just plain text");
+        expectContinuationString(bodyBytes, "\r\n--");
+        expectContinuationString(bodyBytes, boundary);
+        expectContinuationString(bodyBytes, "--\r\n");
+        expectContinuationLength(bodyBytes.lengthInBytes);
+      }
+
+      http.ByteStream bodyBytes;
+      when(mockHttpClient.send(any)).thenAnswer((Invocation a) async {
+        bodyBytes = (a.positionalArguments[0] as http.BaseRequest).finalize();
+        return simpleResponse(body: r"""
+{
+  "data": {
+    "multipleUpload": [
+      {
+        "id": "r1odc4PAz",
+        "filename": "sample_upload.jpg",
+        "mimetype": "image/jpeg",
+        "path": "./uploads/r1odc4PAz-sample_upload.jpg"
+      },
+      {
+        "id": "5Ea18qlMur",
+        "filename": "sample_upload.txt",
+        "mimetype": "text/plain",
+        "path": "./uploads/5Ea18qlMur-sample_upload.txt"
+      }
+    ]
+  }
+}
+        """);
+      });
+
+      final gqlRequest = Request(
+        operation: Operation(
+          document: parseString(uploadMutation),
+        ),
+        variables: <String, dynamic>{
+          "files": [
+            http.MultipartFile.fromBytes(
+              "",
+              [0, 1, 254, 255],
+              filename: "sample_upload.jpg",
+              contentType: MediaType("image", "jpeg"),
+            ),
+            http.MultipartFile.fromString(
+              "",
+              "just plain text",
+              filename: "sample_upload.txt",
+              contentType: MediaType("text", "plain"),
+            ),
+          ],
+        },
+      );
+      final response = await httpLink.request(gqlRequest).first;
+
+      expect(response.errors, isEmpty);
+      expect(response.data, isNotNull);
+
+      final http.MultipartRequest request = verify(
+        mockHttpClient.send(captureAny),
+      ).captured.first as http.MultipartRequest;
+      expect(request.method, "POST");
+      expect(request.url.toString(), "http://localhost:3001/graphql");
+      expect(request.headers["accept"], "*/*");
+      expect(
+          request.headers["Authorization"], "Bearer my-special-bearer-token");
+      final List<String> contentTypeStringSplit =
+          request.headers["content-type"].split("; boundary=");
+      expect(contentTypeStringSplit[0], "multipart/form-data");
+      await expectUploadBody(bodyBytes, contentTypeStringSplit[1]);
+
+      final multipleUpload = (response.data["multipleUpload"] as List<dynamic>)
+          .cast<Map<String, dynamic>>();
+
+      expect(multipleUpload, <Map<String, String>>[
+        <String, String>{
+          "id": "r1odc4PAz",
+          "filename": "sample_upload.jpg",
+          "mimetype": "image/jpeg",
+          "path": "./uploads/r1odc4PAz-sample_upload.jpg"
+        },
+        <String, String>{
+          "id": "5Ea18qlMur",
+          "filename": "sample_upload.txt",
+          "mimetype": "text/plain",
+          "path": "./uploads/5Ea18qlMur-sample_upload.txt"
+        },
+      ]);
+    });
+
+    //test("upload fail error response", () {
+    //  const String responseBody = json.encode({
+    //    "errors":[
+    //      {
+    //        "message": r"Variable "$files" of required type "[Upload!]!" was not provided.",
+    //        "locations": [{ "line" :1, "column" :14 }],
+    //        "extensions": {
+    //          "code": "INTERNAL_SERVER_ERROR",
+    //          "exception": {
+    //             "stacktrace": [ r"GraphQLError: Variable "$files" of required type "[Upload!]!" was not provided.", ... ]
+    //          }
+    //        }
+    //      }
+    //    ]
+    //  });
+    //  const int statusCode = 400;
+    //});
+  });
+}
+
+http.StreamedResponse simpleResponse({@required String body, int status}) {
+  final List<int> bytes = utf8.encode(body);
+  final Stream<List<int>> stream =
+      Stream<List<int>>.fromIterable(<List<int>>[bytes]);
+
+  final http.StreamedResponse r = http.StreamedResponse(stream, status ?? 200);
+
+  return r;
+}

--- a/links/gql_websocket_link/README.md
+++ b/links/gql_websocket_link/README.md
@@ -34,7 +34,7 @@ import "package:gql_websocket_link/gql_websocket_link.dart";
 void main () {
   final link = Link.from([
     // SomeLink(),
-    WSLink("ws://<GRAPHQL_SERVER_ENDPOINT>/graphql"),
+    WebSocketLink("ws://<GRAPHQL_SERVER_ENDPOINT>/graphql"),
   ]);
 }
 


### PR DESCRIPTION
This extracts the logic for multipart file upload and `useGETForQueries` from `graphql/client.dart`, with accompanying tests

**Major changes**:
* `useGetForQueries` argument to `HttpLink`
* using `http.Client.send` instead of `post`
* `HttpLink` stores `uri` as a `Uri`
* I reworked `HttpLink._serializeRequest` into an exception handling HOF to handle the different paths, but really I think `RequestSerializer` should have a generic `Serialized` type which is `http.BaseRequest` for `HttpLink`. Otherwise it can't really handle the serialization concern IMO

This addresses some of #57