### PR TITLE
context-configured GET requests and serialization config

### DIFF
--- a/links/gql_http_link/lib/src/link.dart
+++ b/links/gql_http_link/lib/src/link.dart
@@ -27,6 +27,29 @@ class HttpLinkHeaders extends ContextEntry {
       ];
 }
 
+/// HTTP link request method
+///
+/// If no entry is present, defaults to `POST` unless the operation is a query and [HttpLink.useGETForQueries] is `true`.
+@immutable
+class HttpLinkMethod extends ContextEntry {
+  /// HTTP method to use for this request. Valid options are `POST`, `GET` and `null`
+  final String method;
+
+  const HttpLinkMethod([this.method])
+      : assert(
+          method == null || method == "POST" || method == "GET",
+          "method must be POST, GET, or null",
+        );
+
+  const HttpLinkMethod.post() : method = "POST";
+  const HttpLinkMethod.get() : method = "GET";
+
+  @override
+  List<Object> get fieldsForEquality => [
+        method,
+      ];
+}
+
 /// HTTP link Response Context
 @immutable
 class HttpLinkResponseContext extends ContextEntry {
@@ -168,6 +191,10 @@ class HttpLink extends Link {
     )(request);
 
     final contextHeaders = _getHttpLinkHeaders(request);
+    final HttpLinkMethod contextMethod = request.context.entry(
+      HttpLinkMethod(),
+    );
+
     final headers = {
       "Content-type": "application/json",
       "Accept": "*/*",
@@ -177,8 +204,8 @@ class HttpLink extends Link {
 
     final fileMap = extractFlattenedFileMap(body);
 
-    final useGetForThisRequest =
-        fileMap.isEmpty && useGETForQueries && request.isQuery;
+    final useGetForThisRequest = contextMethod.method == "GET" ||
+        (fileMap.isEmpty && useGETForQueries && request.isQuery);
 
     if (useGetForThisRequest) {
       return http.Request(

--- a/links/gql_link/lib/src/request_serializer.dart
+++ b/links/gql_link/lib/src/request_serializer.dart
@@ -1,5 +1,39 @@
 import "package:gql_exec/gql_exec.dart";
 import "package:gql/language.dart";
+import "package:meta/meta.dart";
+
+/// Context for configuring JSON [Request] serialization
+@immutable
+class RequestSerializationInclusions extends ContextEntry {
+  /// Whether to include the query document in the request. Default `true`
+  final bool query;
+
+  /// Whether to include the operation name in the request. Default `true`
+  final bool operationName;
+
+  /// Whether to include the variables in the request. Default `true`
+  final bool variables;
+
+  /// Whether to include present [RequestExtensionsThunk] results in the request. Default `true`
+  final bool extensions;
+
+  const RequestSerializationInclusions({
+    this.query = true,
+    this.operationName = true,
+    this.variables = true,
+    this.extensions = true,
+  });
+
+  static const defaults = RequestSerializationInclusions();
+
+  @override
+  List<Object> get fieldsForEquality => [
+        query,
+        operationName,
+        variables,
+        extensions,
+      ];
+}
 
 /// JSON [Request] serializer.
 class RequestSerializer {
@@ -11,11 +45,17 @@ class RequestSerializer {
   Map<String, dynamic> serializeRequest(Request request) {
     final RequestExtensionsThunk thunk = request.context.entry();
 
+    final RequestSerializationInclusions include = request.context.entry(
+      RequestSerializationInclusions.defaults,
+    );
+
     return <String, dynamic>{
-      "operationName": request.operation.operationName,
-      "variables": request.variables,
-      "query": printNode(request.operation.document),
-      if (thunk != null) "extensions": thunk.getRequestExtensions(request),
+      if (include.operationName)
+        "operationName": request.operation.operationName,
+      if (include.variables) "variables": request.variables,
+      if (include.query) "query": printNode(request.operation.document),
+      if (include.extensions && thunk != null)
+        "extensions": thunk.getRequestExtensions(request),
     };
   }
 }


### PR DESCRIPTION
This is a draft of functionality I added to make `PersistedQueriesLink` work in `graphql_flutter` v4:
* Adds a `HttpLinkMethod` for context-based GET requests
* Adds a `RequestSerializationInclusions` for configuring serialization

I'm pretty unsure about both APIs, but essentially `PersistedQueriesLink` wants to set `GET` in context and have a way to set `includeQuery: false`.