### PR TITLE
[gql_exec] Print operation

### DIFF
--- a/links/gql_exec/lib/src/operation.dart
+++ b/links/gql_exec/lib/src/operation.dart
@@ -1,6 +1,9 @@
-import "package:collection/collection.dart";
-import "package:gql/ast.dart";
+import "dart:convert";
 import "package:meta/meta.dart";
+import "package:collection/collection.dart";
+
+import "package:gql/ast.dart";
+import "package:gql/language.dart" show printNode;
 
 /// An operation in a [document], optionally defined by [operationName]
 @immutable
@@ -42,6 +45,8 @@ class Operation {
       );
 
   @override
-  String toString() =>
-      "Operation(document: $document, operationName: $operationName)";
+  String toString() {
+    final documentRepr = json.encode(printNode(document));
+    return "Operation(document: DocumentNode($documentRepr), operationName: $operationName)";
+  }
 }

--- a/links/gql_exec/pubspec.yaml
+++ b/links/gql_exec/pubspec.yaml
@@ -1,11 +1,11 @@
 name: gql_exec
-version: 0.2.4
+version: 0.2.5
 description: Basis for GraphQL execution layer to support Link and Client.
 repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
-  gql: ^0.12.1
+  gql: ^0.12.3
   meta: ^1.1.7
   collection: ^1.14.11
 dev_dependencies: 


### PR DESCRIPTION
errors are hard to parse without having the actual operation printed.

@klavs On the other hand, maybe that's ok/desired so that the output is legible?