### PR TITLE
Http link custom scalars

### DIFF
--- a/links/gql_http_link/CHANGELOG.md
+++ b/links/gql_http_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+- discard assertion in `extractFlattenedFileMap` to allow for custom scalars, add test
+
 ## 0.3.1
 
 - `extractFlattenedFileMap` fix to support `bool` values

--- a/links/gql_http_link/lib/src/_utils.dart
+++ b/links/gql_http_link/lib/src/_utils.dart
@@ -71,14 +71,6 @@ Map<String, MultipartFile> extractFlattenedFileMap(
       });
   }
 
-  assert(
-    body is bool || body is String || body is num || body == null,
-    "$body of type ${body.runtimeType} was found "
-    "in in the request at path ${currentPath.join(".")}, "
-    "but the only the types { Map, List, MultipartFile, bool, String, num, null } "
-    "are allowed",
-  );
-
   return currentMap;
 }
 

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_http_link
-version: 0.3.1
+version: 0.3.2
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 repository: https://github.com/gql-dart/gql
 environment: 
@@ -7,8 +7,8 @@ environment:
 dependencies: 
   meta: ^1.1.7
   gql: ^0.12.1
-  gql_exec: ^0.2.2
-  gql_link: ^0.3.0
+  gql_exec: ^0.2.4
+  gql_link: ^0.3.1
   http: ^0.12.1
   http_parser: ^3.1.4
 dev_dependencies: 

--- a/links/gql_http_link/test/gql_http_link_test.dart
+++ b/links/gql_http_link/test/gql_http_link_test.dart
@@ -17,6 +17,12 @@ class MockRequestSerializer extends Mock implements RequestSerializer {}
 
 class MockResponseParser extends Mock implements ResponseParser {}
 
+class CustomScalar {
+  const CustomScalar(this.value);
+  final int value;
+  String toJson() => "CustomScalar($value)";
+}
+
 void main() {
   group("HttpLink", () {
     MockClient client;
@@ -337,6 +343,7 @@ void main() {
             "bool": false
           },
           "array": [true, 123, "ID"],
+          "custom": CustomScalar(1),
         },
       )).first;
 
@@ -355,7 +362,8 @@ void main() {
                   r'"int":1234567,'
                   r'"null":null,'
                   r'"object":{"nested":["array"],"bool":false},'
-                  r'"array":[true,123,"ID"]'
+                  r'"array":[true,123,"ID"],'
+                  r'"custom":"CustomScalar(1)"'
                   r"},"
                   r'"query":"query MyQuery($richInput: RichInput) {\n  \n}"'
                   r"}",

--- a/links/gql_link/CHANGELOG.md
+++ b/links/gql_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- override toString in Exceptions for legibility (@Britannio)
+
 ## 0.3.0
 
 - remove `author` field from `pubspec.yaml`

--- a/links/gql_link/pubspec.yaml
+++ b/links/gql_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_link
-version: 0.3.0
+version: 0.3.1
 description: A simple and modular AST-based GraphQL request execution interface.
 repository: https://github.com/gql-dart/gql
 environment: 
@@ -7,7 +7,7 @@ environment:
 dependencies: 
   meta: ^1.1.7
   gql: ^0.12.1
-  gql_exec: ^0.2.2
+  gql_exec: ^0.2.4
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1


### PR DESCRIPTION
* fix custom scalar support in http link (the assert just shouldn't have been there, probably after being moved)
* publish `gql_http_link==0.3.2`
* publish `gql_link==0.3.1` with better exception toStrings