### PR TITLE
Fix triplicated content-type headers on gql_dio_link

### DIFF
--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -82,10 +82,9 @@ class DioLink extends Link {
   @override
   Stream<Response> request(Request request, [forward]) async* {
     final dio.Response<Map<String, dynamic>> dioResponse =
-        await _excuteDioRequest(
+        await _executeDioRequest(
       body: _serializeRequest(request),
       headers: <String, String>{
-        "Content-type": "application/json",
         "Accept": "*/*",
         ...defaultHeaders,
         ..._getHttpLinkHeaders(request),
@@ -126,7 +125,7 @@ class DioLink extends Link {
     }
   }
 
-  Future<dio.Response<Map<String, dynamic>>> _excuteDioRequest({
+  Future<dio.Response<Map<String, dynamic>>> _executeDioRequest({
     @required Map<String, dynamic> body,
     @required Map<String, String> headers,
   }) async {
@@ -136,7 +135,6 @@ class DioLink extends Link {
         data: body,
         options: dio.Options(
           responseType: dio.ResponseType.json,
-          contentType: "application/json",
           headers: headers,
         ),
       );

--- a/links/gql_dio_link/test/gql_dio_link_test.dart
+++ b/links/gql_dio_link/test/gql_dio_link_test.dart
@@ -159,9 +159,8 @@ void main() {
           options: argThat(
             predicate((dio.Options o) => o.extEqual(dio.Options(
                   responseType: dio.ResponseType.json,
-                  contentType: "application/json",
                   headers: <String, dynamic>{
-                    "Content-type": "application/json",
+                    dio.Headers.contentTypeHeader: "application/json",
                     "Accept": "*/*",
                   },
                 ))),
@@ -214,9 +213,8 @@ void main() {
           options: argThat(
             predicate((dio.Options o) => o.extEqual(dio.Options(
                   responseType: dio.ResponseType.json,
-                  contentType: "application/json",
                   headers: <String, dynamic>{
-                    "Content-type": "application/json",
+                    dio.Headers.contentTypeHeader: "application/json",
                     "Accept": "*/*",
                     "foo": "bar",
                   },
@@ -272,9 +270,8 @@ void main() {
           options: argThat(
             predicate((dio.Options o) => o.extEqual(dio.Options(
                     responseType: dio.ResponseType.json,
-                    contentType: "application/json",
                     headers: <String, dynamic>{
-                      "Content-type": "application/json",
+                      dio.Headers.contentTypeHeader: "application/json",
                       "Accept": "*/*",
                       "foo": "bar",
                     }))),
@@ -312,7 +309,7 @@ void main() {
             const [
               HttpLinkHeaders(
                 headers: {
-                  "Content-type": "application/jsonize",
+                  dio.Headers.contentTypeHeader: "application/jsonize",
                 },
               ),
             ],
@@ -327,9 +324,8 @@ void main() {
           options: argThat(
             predicate((dio.Options o) => o.extEqual(dio.Options(
                     responseType: dio.ResponseType.json,
-                    contentType: "application/json",
                     headers: <String, dynamic>{
-                      "Content-type": "application/jsonize",
+                      dio.Headers.contentTypeHeader: "application/jsonize",
                       "Accept": "*/*",
                     }))),
             named: "options",


### PR DESCRIPTION
I've fixed an issue with the package that was adding twice the content-type header, thus causing the request to fail for graphql.

There's a discussion here for further details:
https://github.com/TarekkMA/gql_dio_link/issues/4