### PR TITLE
add config for enum fallback values

### DIFF
--- a/codegen/end_to_end_test/build.yaml
+++ b/codegen/end_to_end_test/build.yaml
@@ -25,6 +25,8 @@ targets:
       gql_build|schema_builder:
         enabled: true
         options:
+          enum_fallbacks:
+            LengthUnit: METER
           type_overrides:
             Date:
               name: DateTime

--- a/codegen/end_to_end_test/lib/graphql/schema.schema.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/schema.schema.gql.dart
@@ -26,6 +26,7 @@ class GEpisode extends EnumClass {
 class GLengthUnit extends EnumClass {
   const GLengthUnit._(String name) : super(name);
 
+  @BuiltValueEnumConst(wireName: 'METER', fallback: true)
   static const GLengthUnit METER = _$gLengthUnitMETER;
 
   static const GLengthUnit FOOT = _$gLengthUnitFOOT;

--- a/codegen/end_to_end_test/lib/graphql/schema.schema.gql.g.dart
+++ b/codegen/end_to_end_test/lib/graphql/schema.schema.gql.g.dart
@@ -40,7 +40,7 @@ GLengthUnit _$gLengthUnitValueOf(String name) {
     case 'FOOT':
       return _$gLengthUnitFOOT;
     default:
-      throw new ArgumentError(name);
+      return _$gLengthUnitMETER;
   }
 }
 
@@ -74,6 +74,13 @@ class _$GEpisodeSerializer implements PrimitiveSerializer<GEpisode> {
 }
 
 class _$GLengthUnitSerializer implements PrimitiveSerializer<GLengthUnit> {
+  static const Map<String, Object> _toWire = const <String, Object>{
+    'METER': 'METER',
+  };
+  static const Map<Object, String> _fromWire = const <Object, String>{
+    'METER': 'METER',
+  };
+
   @override
   final Iterable<Type> types = const <Type>[GLengthUnit];
   @override
@@ -82,12 +89,12 @@ class _$GLengthUnitSerializer implements PrimitiveSerializer<GLengthUnit> {
   @override
   Object serialize(Serializers serializers, GLengthUnit object,
           {FullType specifiedType = FullType.unspecified}) =>
-      object.name;
+      _toWire[object.name] ?? object.name;
 
   @override
   GLengthUnit deserialize(Serializers serializers, Object serialized,
           {FullType specifiedType = FullType.unspecified}) =>
-      GLengthUnit.valueOf(serialized as String);
+      GLengthUnit.valueOf(_fromWire[serialized] ?? serialized as String);
 }
 
 class _$GReviewInputSerializer implements StructuredSerializer<GReviewInput> {

--- a/codegen/end_to_end_test/pubspec.yaml
+++ b/codegen/end_to_end_test/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 dependencies: 
   built_collection: '>=2.0.0 <5.0.0'
   built_value: ^7.0.2
+  gql_exec: ^0.2.5
   gql_build: ^0.1.3
   gql_code_builder: ^0.1.3
-  gql_exec: ^0.2.4
 dev_dependencies: 
   collection: ^1.14.13
   build: ^1.0.0

--- a/codegen/end_to_end_test/test/schema/enums_test.dart
+++ b/codegen/end_to_end_test/test/schema/enums_test.dart
@@ -1,3 +1,5 @@
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/graphql/serializers.gql.dart';
 import "package:test/test.dart";
 
 import 'package:end_to_end_test/graphql/schema.schema.gql.dart';
@@ -10,6 +12,13 @@ void main() {
 
     test('are correct type', () {
       expect(GEpisode.EMPIRE, TypeMatcher<GEpisode>());
+    });
+
+    test('fallback of LengthUnit to METER works', () {
+      expect(
+          serializers.deserialize("UNKNOWN_UNIT",
+              specifiedType: FullType(GLengthUnit)),
+          equals(GLengthUnit.METER));
     });
   });
 }

--- a/codegen/gql_build/README.md
+++ b/codegen/gql_build/README.md
@@ -39,14 +39,37 @@ Generates a typed view of your data.
 ### var_builder
 Creates data classes for any GraphQL variables used in a query or fragment.
 
-### enum_builder
-Generates an enum-like class per GraphQL enum type. Defines known enum values to be used in your code, and allows unknown enum values to be used without causing runtime error when handling response data.
-
-### scalar_builder
-Generates a container for a scalar value to be used when viewing the response data and building request variables.
-
 ### schema_builder
-Combines `enum_builder`, `input_builder` and `scalar_builder`.
+Creates data classes from you specified graphql schema.
+
+#### Configuration
+
+`type_overrides`: [Map\] Specify how scalar types should be serialized
+
+Example: 
+
+```yaml
+type_overrides:
+    CustomStringScalar:
+      name: String
+     CustomField:
+       name: CustomField
+       import: 'package:mypackage/custom_field.dart'
+```
+
+`enum_fallbacks`: \[Map\] Specify fallback values to enum values in order to not break the serializer when 
+new enum values are added to the schema and the client has not updated to the new schema yet.
+
+`global_enum_fallbacks`: \[bool\] Add a generated fallback value for each enum value (except for ones that have a custom fallback value specified in the enum_fallbacks map).
+Defaults to false.
+
+Example:
+
+```yaml
+global_enum_fallbacks: true # add a generated fallback value to all enums
+enum_fallbacks:
+    MyEnumType: OTHER   # except for the type 'MyEnumType', use the value 'OTHER' as fallback there
+```
 
 ### serializer_builder
 Creates `built_value` serializers for each `built_value` class.

--- a/codegen/gql_build/README.md
+++ b/codegen/gql_build/README.md
@@ -40,7 +40,7 @@ Generates a typed view of your data.
 Creates data classes for any GraphQL variables used in a query or fragment.
 
 ### schema_builder
-Creates data classes from you specified graphql schema.
+Creates data classes from your specified graphql schema.
 
 #### Configuration
 

--- a/codegen/gql_build/lib/gql_build.dart
+++ b/codegen/gql_build/lib/gql_build.dart
@@ -52,6 +52,7 @@ Builder schemaBuilder(
 ) =>
     SchemaBuilder(
       typeOverrideMap(options?.config["type_overrides"]),
+      enumFallbackConfig(options?.config),
     );
 
 /// Builds an aggregate Serlializers object for [built_value]s

--- a/codegen/gql_build/lib/src/schema_builder.dart
+++ b/codegen/gql_build/lib/src/schema_builder.dart
@@ -11,8 +11,12 @@ import "package:gql_code_builder/schema.dart";
 
 class SchemaBuilder implements Builder {
   final Map<String, Reference> typeOverrides;
+  final EnumFallbackConfig enumFallbackConfig;
 
-  SchemaBuilder(this.typeOverrides);
+  SchemaBuilder(
+    this.typeOverrides,
+    this.enumFallbackConfig,
+  );
 
   @override
   Map<String, List<String>> get buildExtensions => {
@@ -32,6 +36,7 @@ class SchemaBuilder implements Builder {
       doc,
       basename(generatedPartUrl),
       typeOverrides,
+      enumFallbackConfig,
     );
 
     return writeDocument(

--- a/codegen/gql_build/lib/src/utils/config.dart
+++ b/codegen/gql_build/lib/src/utils/config.dart
@@ -1,4 +1,5 @@
 import "package:code_builder/code_builder.dart";
+import "package:gql_code_builder/schema.dart";
 import "package:yaml/yaml.dart";
 
 Map<String, Reference> typeOverrideMap(dynamic typeOverrideConfig) {
@@ -28,6 +29,36 @@ Set<Reference> customSerializers(dynamic customSerializersConfig) {
           ),
         )
         .toSet();
+  }
+  return {};
+}
+
+EnumFallbackConfig enumFallbackConfig(Map<String, dynamic> config) {
+  if (config == null) {
+    return EnumFallbackConfig(
+        fallbackValueMap: {},
+        generateFallbackValuesGlobally: false,
+        globalEnumFallbackName: null);
+  }
+
+  return EnumFallbackConfig(
+    globalEnumFallbackName:
+        (config["global_enum_fallback_name"] ?? "gUnknownEnumValue") as String,
+    generateFallbackValuesGlobally: config["global_enum_fallbacks"] == true,
+    fallbackValueMap: enumFallbackMap(config["enum_fallbacks"]),
+  );
+}
+
+Map<String, String> enumFallbackMap(final dynamic enumFallbacks) {
+  if (enumFallbacks is YamlMap) {
+    return Map.fromEntries(
+      enumFallbacks.entries.map(
+        (entry) => MapEntry(
+          entry.key as String,
+          entry.value as String,
+        ),
+      ),
+    );
   }
   return {};
 }

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   analyzer: ^0.39.14
-  gql: ^0.12.1
+  gql: ^0.12.3
   path: ^1.6.4
   glob: ^1.2.0
   build: ^1.0.0
-  gql_code_builder: ^0.1.2
+  gql_code_builder: ^0.1.3
   code_builder: ^3.3.0
   dart_style: ^1.2.9
   built_value: ^7.1.0
@@ -18,6 +18,5 @@ dependencies:
   built_collection: ^4.3.2
   yaml: ^2.2.1
 dev_dependencies: 
-  test: ^1.0.0
   build_test: ^0.10.7
-  gql_pedantic: ^1.0.1
+  gql_pedantic: ^1.0.2

--- a/codegen/gql_code_builder/lib/schema.dart
+++ b/codegen/gql_code_builder/lib/schema.dart
@@ -1,15 +1,17 @@
 import "package:code_builder/code_builder.dart";
 import "package:gql_code_builder/src/schema.dart";
 import "package:gql_code_builder/source.dart";
+import "package:meta/meta.dart";
 
 Library buildSchemaLibrary(
-  SourceNode schemaSource,
-  String partUrl,
-  Map<String, Reference> typeOverrides,
-) {
+    SourceNode schemaSource,
+    String partUrl,
+    Map<String, Reference> typeOverrides,
+    EnumFallbackConfig enumFallbackConfig) {
   final lib = buildSchema(
     schemaSource,
     typeOverrides,
+    enumFallbackConfig,
   ) as Library;
 
   return lib.rebuild(
@@ -18,4 +20,19 @@ Library buildSchemaLibrary(
         Directive.part(partUrl),
       ),
   );
+}
+
+class EnumFallbackConfig {
+  final bool generateFallbackValuesGlobally;
+  final String globalEnumFallbackName;
+  final Map<String, String> fallbackValueMap;
+
+  const EnumFallbackConfig({
+    @required this.generateFallbackValuesGlobally,
+    this.globalEnumFallbackName,
+    @required this.fallbackValueMap,
+  })  : assert(fallbackValueMap != null),
+        assert(generateFallbackValuesGlobally != null),
+        assert(
+            !generateFallbackValuesGlobally || globalEnumFallbackName != null);
 }

--- a/codegen/gql_code_builder/lib/src/schema.dart
+++ b/codegen/gql_code_builder/lib/src/schema.dart
@@ -1,5 +1,6 @@
 import "package:code_builder/code_builder.dart";
 import "package:gql/ast.dart";
+import "package:gql_code_builder/schema.dart";
 import "package:gql_code_builder/src/schema/enum.dart";
 import "package:gql_code_builder/src/schema/input.dart";
 import "package:gql_code_builder/src/schema/scalar.dart";
@@ -9,21 +10,25 @@ import "package:gql_code_builder/source.dart";
 Spec buildSchema(
   SourceNode schemaSource,
   Map<String, Reference> typeOverrides,
+  EnumFallbackConfig enumFallbackConfig,
 ) =>
     schemaSource.document.accept(
       _SchemaBuilderVisitor(
         schemaSource,
         typeOverrides,
+        enumFallbackConfig,
       ),
     );
 
 class _SchemaBuilderVisitor extends SimpleVisitor<Spec> {
   final SourceNode schemaSource;
   final Map<String, Reference> typeOverrides;
+  final EnumFallbackConfig enumFallbackConfig;
 
   _SchemaBuilderVisitor(
     this.schemaSource,
     this.typeOverrides,
+    this.enumFallbackConfig,
   );
 
   Spec _acceptOne(
@@ -70,5 +75,5 @@ class _SchemaBuilderVisitor extends SimpleVisitor<Spec> {
   Spec visitEnumTypeDefinitionNode(
     EnumTypeDefinitionNode node,
   ) =>
-      buildEnumClass(node);
+      buildEnumClass(node, enumFallbackConfig);
 }

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -6,14 +6,15 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   analyzer: ^0.39.14
-  gql: ^0.12.1
+  gql: ^0.12.3
   code_builder: ^3.3.0
   meta: ^1.1.7
   built_collection: ^4.0.0
   built_value: ^7.0.9
   path: ^1.6.4
   recase: ^3.0.0
-  gql_exec: ^0.2.4
+  gql_exec: ^0.2.5
 dev_dependencies: 
-  gql_pedantic: ^1.0.1
+  gql_pedantic: ^1.0.2
   build_runner: ^1.7.4
+  test: ^1.0.0

--- a/codegen/gql_code_builder/test/enum/enum_fallback_test.dart
+++ b/codegen/gql_code_builder/test/enum/enum_fallback_test.dart
@@ -11,7 +11,7 @@ void main() {
     EnumValueDefinitionNode(name: NameNode(value: "val2"))
   ]);
 
-  test("does note generate fallback value when no fallback set in config", () {
+  test("does not generate fallback value when no fallback set in config", () {
     final clazz = buildEnumClass(
         simpleEnum,
         EnumFallbackConfig(

--- a/codegen/gql_code_builder/test/enum/enum_fallback_test.dart
+++ b/codegen/gql_code_builder/test/enum/enum_fallback_test.dart
@@ -1,0 +1,167 @@
+import "package:code_builder/code_builder.dart";
+import "package:gql/ast.dart";
+import "package:gql_code_builder/schema.dart";
+import "package:gql_code_builder/src/schema/enum.dart";
+import "package:test/test.dart";
+
+void main() {
+  final simpleEnum =
+      EnumTypeDefinitionNode(name: NameNode(value: "testEnum"), values: [
+    EnumValueDefinitionNode(name: NameNode(value: "val1")),
+    EnumValueDefinitionNode(name: NameNode(value: "val2"))
+  ]);
+
+  test("does note generate fallback value when no fallback set in config", () {
+    final clazz = buildEnumClass(
+        simpleEnum,
+        EnumFallbackConfig(
+            generateFallbackValuesGlobally: false, fallbackValueMap: {}));
+
+    expect(clazz.fields.length, 2);
+
+    for (final field in clazz.fields) {
+      final annotation = getBuiltValueEnumConstAnnotation(field);
+      if (annotation != null) {
+        expect(annotation.namedArguments["fallback"], isNot(literalTrue));
+      }
+    }
+  });
+
+  test("does generate global fallback value when fallback set in config", () {
+    final clazz = buildEnumClass(
+        simpleEnum,
+        EnumFallbackConfig(
+            generateFallbackValuesGlobally: true,
+            globalEnumFallbackName: "fallback",
+            fallbackValueMap: {}));
+
+    expect(clazz.fields.length, 3);
+    final fallbackvalue =
+        clazz.fields.firstWhere((field) => field.name == "fallback");
+    final enumAnnotation = getBuiltValueEnumConstAnnotation(fallbackvalue);
+
+    expect(enumAnnotation, isNotNull);
+
+    expect(enumAnnotation.namedArguments["fallback"], literalTrue);
+
+    for (final otherField
+        in clazz.fields.where((field) => field != fallbackvalue)) {
+      final annotation = getBuiltValueEnumConstAnnotation(otherField);
+      if (annotation != null) {
+        expect(annotation.namedArguments["fallback"], isNot(literalTrue));
+      }
+    }
+  });
+
+  test("does generate fallback value when custom fallback set in config", () {
+    final clazz = buildEnumClass(
+        simpleEnum,
+        EnumFallbackConfig(
+            generateFallbackValuesGlobally: false,
+            fallbackValueMap: {"testEnum": "val2"}));
+
+    expect(clazz.fields.length, 2);
+    final fallbackvalue =
+        clazz.fields.firstWhere((field) => field.name == "val2");
+    final enumAnnotation = getBuiltValueEnumConstAnnotation(fallbackvalue);
+
+    expect(enumAnnotation, isNotNull);
+
+    expect(enumAnnotation.namedArguments["fallback"], literalTrue);
+
+    for (final otherField
+        in clazz.fields.where((field) => field != fallbackvalue)) {
+      final annotation = getBuiltValueEnumConstAnnotation(otherField);
+      if (annotation != null) {
+        expect(annotation.namedArguments["fallback"], isNot(literalTrue));
+      }
+    }
+  });
+
+  test("custom fallback overwrites global fallback", () {
+    final clazz = buildEnumClass(
+        simpleEnum,
+        EnumFallbackConfig(
+            generateFallbackValuesGlobally: true,
+            globalEnumFallbackName: "fallbackValue",
+            fallbackValueMap: {"testEnum": "val2"}));
+
+    expect(clazz.fields.length, 2);
+    final fallbackvalue =
+        clazz.fields.firstWhere((field) => field.name == "val2");
+    final enumAnnotation = getBuiltValueEnumConstAnnotation(fallbackvalue);
+
+    expect(enumAnnotation, isNotNull);
+
+    expect(enumAnnotation.namedArguments["fallback"], literalTrue);
+
+    for (final otherField
+        in clazz.fields.where((field) => field != fallbackvalue)) {
+      final annotation = getBuiltValueEnumConstAnnotation(otherField);
+      if (annotation != null) {
+        expect(annotation.namedArguments["fallback"], isNot(literalTrue));
+      }
+    }
+  });
+
+  test("handles name clashes", () {
+    final clazz = buildEnumClass(
+        simpleEnum,
+        EnumFallbackConfig(
+            generateFallbackValuesGlobally: true,
+            globalEnumFallbackName: "val2",
+            fallbackValueMap: {}));
+
+    expect(clazz.fields.length, 3);
+    final fallbackvalue =
+        clazz.fields.firstWhere((field) => field.name == "gval2");
+    final enumAnnotation = getBuiltValueEnumConstAnnotation(fallbackvalue);
+
+    expect(enumAnnotation, isNotNull);
+
+    expect(enumAnnotation.namedArguments["fallback"], literalTrue);
+
+    for (final otherField
+        in clazz.fields.where((field) => field != fallbackvalue)) {
+      final annotation = getBuiltValueEnumConstAnnotation(otherField);
+      if (annotation != null) {
+        expect(annotation.namedArguments["fallback"], isNot(literalTrue));
+      }
+    }
+  });
+
+  test("works with escaped names", () {
+    final clazz = buildEnumClass(
+        EnumTypeDefinitionNode(name: NameNode(value: "testEnum"), values: [
+          EnumValueDefinitionNode(name: NameNode(value: "name")),
+          EnumValueDefinitionNode(name: NameNode(value: "default"))
+        ]),
+        EnumFallbackConfig(
+            generateFallbackValuesGlobally: false,
+            fallbackValueMap: {"testEnum": "default"}));
+
+    expect(clazz.fields.length, 2);
+    final fallbackvalue =
+        clazz.fields.firstWhere((field) => field.name == "Gdefault");
+    final enumAnnotation = getBuiltValueEnumConstAnnotation(fallbackvalue);
+
+    expect(enumAnnotation, isNotNull);
+
+    expect(enumAnnotation.namedArguments["fallback"], literalTrue);
+
+    for (final otherField
+        in clazz.fields.where((field) => field != fallbackvalue)) {
+      final annotation = getBuiltValueEnumConstAnnotation(otherField);
+      if (annotation != null) {
+        expect(annotation.namedArguments["fallback"], isNot(literalTrue));
+      }
+    }
+  });
+}
+
+InvokeExpression getBuiltValueEnumConstAnnotation(Field field) =>
+    field.annotations.whereType<InvokeExpression>().singleWhere(
+        (annotation) =>
+            (annotation.target is Reference) &&
+            (annotation.target as Reference).symbol == "BuiltValueEnumConst",
+        orElse: () => null);

--- a/docs/gql.svg
+++ b/docs/gql.svg
@@ -569,19 +569,19 @@
 <text text-anchor="middle" x="89" y="-1474.8077" font-family="Times,serif" font-size="14.00" fill="#000000">end_to_end_test</text>
 </g>
 <!-- end_to_end_test&#45;&gt;gql_exec -->
-<g id="edge73" class="edge">
+<g id="edge71" class="edge">
 <title>end_to_end_test&#45;&gt;gql_exec</title>
 <path fill="none" stroke="#5b9240" d="M156.271,-1470.9705C386.5304,-1443.6602 1136.6045,-1341.7242 1277,-1158.5077 1361.4296,-1048.3268 1139.187,-611.7457 1078.7171,-497.8173"/>
 <polygon fill="#5b9240" stroke="#5b9240" points="1081.6464,-495.872 1073.8537,-488.694 1075.4693,-499.1649 1081.6464,-495.872"/>
 </g>
 <!-- end_to_end_test&#45;&gt;gql_code_builder -->
-<g id="edge72" class="edge">
+<g id="edge73" class="edge">
 <title>end_to_end_test&#45;&gt;gql_code_builder</title>
 <path fill="none" stroke="#1da059" d="M86.4241,-1460.393C78.859,-1405.1363 57.5705,-1233.8261 63,-1091.5077 66.8319,-991.0665 77.8311,-872.1828 83.108,-818.8626"/>
 <polygon fill="#1da059" stroke="#1da059" points="86.6014,-819.1018 84.1129,-808.8034 79.6361,-818.4059 86.6014,-819.1018"/>
 </g>
 <!-- end_to_end_test&#45;&gt;gql_build -->
-<g id="edge71" class="edge">
+<g id="edge72" class="edge">
 <title>end_to_end_test&#45;&gt;gql_build</title>
 <path fill="none" stroke="#3380b0" d="M90.2227,-1460.4603C94.2602,-1400.8664 107.1878,-1210.056 112.0903,-1137.6942"/>
 <polygon fill="#3380b0" stroke="#3380b0" points="115.5956,-1137.7341 112.7796,-1127.5204 108.6116,-1137.2609 115.5956,-1137.7341"/>

--- a/examples/gql_example_build/pubspec.yaml
+++ b/examples/gql_example_build/pubspec.yaml
@@ -4,5 +4,5 @@ environment:
 dev_dependencies: 
   build_runner: ^1.10.1
   gql_pedantic: ^1.0.2
-  gql_build: ^0.1.1
+  gql_build: ^0.1.3
   test: ^1.0.0

--- a/examples/gql_example_cli/pubspec.yaml
+++ b/examples/gql_example_cli/pubspec.yaml
@@ -4,10 +4,10 @@ environment:
 dependencies: 
   args: any
   gql: ^0.12.3
-  gql_link: ^0.3.0
-  gql_exec: ^0.2.4
-  gql_http_link: ^0.2.9
+  gql_link: ^0.3.1
+  gql_exec: ^0.2.5
+  gql_http_link: ^0.3.2
 dev_dependencies: 
   build_runner: ^1.10.1
   gql_pedantic: ^1.0.2
-  gql_build: ^0.1.1
+  gql_build: ^0.1.3

--- a/examples/gql_example_cli_github/pubspec.yaml
+++ b/examples/gql_example_cli_github/pubspec.yaml
@@ -4,11 +4,11 @@ environment:
 dependencies: 
   args: any
   gql: ^0.12.3
-  gql_link: ^0.3.0
-  gql_exec: ^0.2.4
-  gql_http_link: ^0.2.9
+  gql_link: ^0.3.1
+  gql_exec: ^0.2.5
+  gql_http_link: ^0.3.2
   gql_transform_link: ^0.1.5
 dev_dependencies: 
   build_runner: ^1.10.1
   gql_pedantic: ^1.0.2
-  gql_build: ^0.1.1
+  gql_build: ^0.1.3

--- a/examples/gql_example_dio_link/pubspec.yaml
+++ b/examples/gql_example_dio_link/pubspec.yaml
@@ -5,6 +5,6 @@ environment:
 dependencies: 
   dio: ^3.0.9
   gql: ^0.12.3
-  gql_link: ^0.3.0
-  gql_exec: ^0.2.4
+  gql_link: ^0.3.1
+  gql_exec: ^0.2.5
   gql_dio_link: ^0.0.4

--- a/examples/gql_example_flutter/pubspec.yaml
+++ b/examples/gql_example_flutter/pubspec.yaml
@@ -4,16 +4,16 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   gql: ^0.12.3
-  gql_link: ^0.3.0
-  gql_http_link: ^0.2.9
-  gql_exec: ^0.2.4
+  gql_link: ^0.3.1
+  gql_http_link: ^0.3.2
+  gql_exec: ^0.2.5
   cupertino_icons: ^0.1.2
   flutter: 
     sdk: flutter
 dev_dependencies: 
   build_runner: ^1.10.1
   gql_pedantic: ^1.0.2
-  gql_build: ^0.1.1
+  gql_build: ^0.1.3
   flutter_test: 
     sdk: flutter
 flutter: 

--- a/examples/gql_example_http_auth_link/pubspec.yaml
+++ b/examples/gql_example_http_auth_link/pubspec.yaml
@@ -3,12 +3,12 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies: 
   gql: ^0.12.3
-  gql_link: ^0.3.0
-  gql_exec: ^0.2.4
+  gql_link: ^0.3.1
+  gql_exec: ^0.2.5
   gql_error_link: ^0.1.0
   gql_transform_link: ^0.1.5
-  gql_http_link: ^0.2.9
+  gql_http_link: ^0.3.2
   http: ^0.12.0+2
 dev_dependencies: 
   gql_pedantic: ^1.0.2
-  gql_build: ^0.1.1
+  gql_build: ^0.1.3

--- a/gql/lib/src/ast/ast.dart
+++ b/gql/lib/src/ast/ast.dart
@@ -993,13 +993,17 @@ class EnumTypeDefinitionNode extends TypeDefinitionNode {
 }
 
 class EnumValueDefinitionNode extends TypeDefinitionNode {
+  final bool fallback;
+
   const EnumValueDefinitionNode({
     StringValueNode description,
     @required NameNode name,
     List<DirectiveNode> directives = const [],
     FileSpan span,
+    this.fallback = false,
   })  : assert(name != null),
         assert(directives != null),
+        assert(fallback != null),
         super(
           span: span,
           name: name,

--- a/links/gql_dedupe_link/pubspec.yaml
+++ b/links/gql_dedupe_link/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   meta: ^1.1.7
-  gql_exec: ^0.2.2
-  gql_link: ^0.3.0
+  gql_exec: ^0.2.5
+  gql_link: ^0.3.1
   async: ^2.3.0
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
-  gql: ^0.12.1
-  gql_pedantic: ^1.0.1
+  gql: ^0.12.3
+  gql_pedantic: ^1.0.2

--- a/links/gql_dio_link/pubspec.yaml
+++ b/links/gql_dio_link/pubspec.yaml
@@ -6,12 +6,12 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   dio: ^3.0.9
-  gql_link: ^0.3.0
-  gql_exec: ^0.2.4
+  gql_link: ^0.3.1
+  gql_exec: ^0.2.5
   meta: ^1.1.8
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
-  gql: ^0.12.1
-  gql_pedantic: ^1.0.1
+  gql: ^0.12.3
+  gql_pedantic: ^1.0.2
   collection: ^1.14.12

--- a/links/gql_error_link/pubspec.yaml
+++ b/links/gql_error_link/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   async: ^2.3.0
-  gql_exec: ^0.2.2
-  gql_link: ^0.3.0
+  gql_exec: ^0.2.5
+  gql_link: ^0.3.1
   meta: ^1.1.7
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
-  gql: ^0.12.1
-  gql_pedantic: ^1.0.1
+  gql: ^0.12.3
+  gql_pedantic: ^1.0.2

--- a/links/gql_exec/pubspec.yaml
+++ b/links/gql_exec/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   collection: ^1.14.11
 dev_dependencies: 
   test: ^1.0.0
-  gql_pedantic: ^1.0.1
+  gql_pedantic: ^1.0.2

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -6,13 +6,13 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   meta: ^1.1.7
-  gql: ^0.12.1
-  gql_exec: ^0.2.4
+  gql: ^0.12.3
+  gql_exec: ^0.2.5
   gql_link: ^0.3.1
   http: ^0.12.1
   http_parser: ^3.1.4
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
-  gql_pedantic: ^1.0.1
+  gql_pedantic: ^1.0.2
   http_parser: ^3.1.4

--- a/links/gql_link/pubspec.yaml
+++ b/links/gql_link/pubspec.yaml
@@ -6,9 +6,9 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   meta: ^1.1.7
-  gql: ^0.12.1
-  gql_exec: ^0.2.4
+  gql: ^0.12.3
+  gql_exec: ^0.2.5
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
-  gql_pedantic: ^1.0.1
+  gql_pedantic: ^1.0.2

--- a/links/gql_transform_link/pubspec.yaml
+++ b/links/gql_transform_link/pubspec.yaml
@@ -5,10 +5,10 @@ repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
-  gql_exec: ^0.2.2
-  gql_link: ^0.3.0
+  gql_exec: ^0.2.5
+  gql_link: ^0.3.1
 dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
-  gql: ^0.12.1
-  gql_pedantic: ^1.0.1
+  gql: ^0.12.3
+  gql_pedantic: ^1.0.2

--- a/links/gql_websocket_link/pubspec.yaml
+++ b/links/gql_websocket_link/pubspec.yaml
@@ -6,8 +6,8 @@ environment:
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
   meta: ^1.1.8
-  gql_exec: ^0.2.4
-  gql_link: ^0.3.0
+  gql_exec: ^0.2.5
+  gql_link: ^0.3.1
   uuid_enhanced: ^3.0.2
   rxdart: ^0.24.0
   gql: ^0.12.3


### PR DESCRIPTION
as discussed on discord.

Add forward-compatibility of enums via configuration of the build.yaml.
Also, update the README of gql_build.

Since it's not possible to test different build.yaml configs via just one end_to_end_test project, I added tests to gql_builder, I think that makes more sense than adding multiple end_to_end_test projects just for that purpose.