### PR TITLE
[gql_websocket_link] Add onDisconnect callback + discussion on websocket link lifecycle [WIP]

### DIFF
--- a/links/gql_websocket_link/pubspec.yaml
+++ b/links/gql_websocket_link/pubspec.yaml
@@ -5,14 +5,14 @@ repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.7.2 <3.0.0'
 dependencies: 
-  meta: ^1.1.8
+  meta: ^1.2.4
   gql_exec: ^0.2.5
   gql_link: ^0.3.1
   uuid_enhanced: ^3.0.2
-  rxdart: ^0.24.0
-  gql: ^0.12.3
+  rxdart: ^0.25.0
+  gql: ^0.12.4
   web_socket_channel: ^1.1.0
 dev_dependencies: 
-  test: ^1.14.3
-  mockito: ^4.1.1
+  test: ^1.15.7
+  mockito: ^4.1.3
   gql_pedantic: ^1.0.2


### PR DESCRIPTION
As I was working with the websocket link I ran into the situation where my code was not aware of the client closing itself because of a network cutoff or some other reason.
I had to add a callback for disconnection so I can re-create the link for my dependencies tree. (this is the PR, I don't expect it to be merged, just to create a discussion)

The best solution I think would be to have some ReconnectingWebSocketLink that will do it within itself, but it will have to re-send the previously sent subscriptions to the server or otherwise they will stop arriving. (because the server sees the reconnection as a brand new client/socket) fix me if I'm wrong here.

I went through [this](https://github.com/enisdenjo/graphql-ws/blob/master/src/client.ts) implementation and I didn't see anything regarding resending the subscriptions. (this code is not so readable and full of closures that return closures so I'm not confident that I understood it fully)

Maybe resending the subscriptions has implications that I'm not aware of. in any case there must be a better way for the library's user to track the lifecycle of the link and act accordingly.

Anyone with an implementation proposal? a better approach?