### PR TITLE
CDN redirect fix (status code 301 & 302)

### DIFF
--- a/links/gql_http_link/lib/src/link.dart
+++ b/links/gql_http_link/lib/src/link.dart
@@ -62,7 +62,7 @@ class HttpLinkResponseContext extends ContextEntry {
 /// [http.Client] to the constructor.
 class HttpLink extends Link {
   /// Endpoint of the GraphQL service
-  final Uri uri;
+  Uri uri;
 
   /// Default HTTP headers
   final Map<String, String> defaultHeaders;
@@ -167,6 +167,10 @@ class HttpLink extends Link {
     final httpRequest = _prepareRequest(request);
     try {
       final response = await _httpClient.send(httpRequest);
+      if (response.statusCode == 301 || response.statusCode == 302) {
+        uri = Uri.parse(response.headers["location"]);
+        return _executeRequest(request);
+      }
       return http.Response.fromStream(response);
     } catch (e) {
       throw ServerException(


### PR DESCRIPTION
my domain is behind a CDN( Cloudflare ) and every time I request to the domain my request status code will be 301.so I added a new  loop for http request if the response status is 301 or 302 for handling redirects. the goal is if the mentioned status codes occurred try to request with the new location that exists in the header of response. this method will recursively request to the new location till the status code changes to something else. if its not a way to handle redirects please let me know about it.

I followed this solution :  https://github.com/zino-app/graphql-flutter/issues/576#issuecomment-626246953