### PR TITLE
avoid using nullable name where name is mandatory

### DIFF
--- a/gql/example/visit_types.dart
+++ b/gql/example/visit_types.dart
@@ -31,7 +31,7 @@ void main() {
   print(
     v.types
         .map(
-          (t) => t.name!.value,
+          (t) => t.name.value,
         )
         .join("\n"),
   );

--- a/gql/lib/src/ast/ast.dart
+++ b/gql/lib/src/ast/ast.dart
@@ -80,22 +80,11 @@ class DocumentNode extends Node {
 }
 
 abstract class DefinitionNode extends Node {
-  final NameNode? name;
-
-  const DefinitionNode({
-    required this.name,
-    FileSpan? span,
-  }) : super(span);
+  const DefinitionNode(FileSpan? span) : super(span);
 }
 
 abstract class ExecutableDefinitionNode extends DefinitionNode {
-  const ExecutableDefinitionNode({
-    required NameNode? name,
-    FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  const ExecutableDefinitionNode(FileSpan? span) : super(span);
 }
 
 /// Enumeration of all known GraphQL operation types.
@@ -128,6 +117,8 @@ enum DirectiveLocation {
 }
 
 class OperationDefinitionNode extends ExecutableDefinitionNode {
+  final NameNode? name;
+
   final OperationType type;
 
   final List<VariableDefinitionNode> variableDefinitions;
@@ -138,15 +129,12 @@ class OperationDefinitionNode extends ExecutableDefinitionNode {
 
   const OperationDefinitionNode({
     required this.type,
-    NameNode? name,
+    this.name,
     this.variableDefinitions = const [],
     this.directives = const [],
     required this.selectionSet,
     FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  }) : super(span);
 
   @override
   R accept<R>(Visitor<R> v) => v.visitOperationDefinitionNode(this);
@@ -283,6 +271,8 @@ class InlineFragmentNode extends SelectionNode {
 }
 
 class FragmentDefinitionNode extends ExecutableDefinitionNode {
+  final NameNode name;
+
   final TypeConditionNode typeCondition;
 
   final List<DirectiveNode> directives;
@@ -290,15 +280,12 @@ class FragmentDefinitionNode extends ExecutableDefinitionNode {
   final SelectionSetNode selectionSet;
 
   const FragmentDefinitionNode({
-    required NameNode name,
+    required this.name,
     required this.typeCondition,
     this.directives = const [],
     required this.selectionSet,
     FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  }) : super(span);
 
   @override
   R accept<R>(Visitor<R> v) => v.visitFragmentDefinitionNode(this);
@@ -635,51 +622,37 @@ class NameNode extends Node {
 }
 
 abstract class TypeSystemDefinitionNode extends DefinitionNode {
-  const TypeSystemDefinitionNode({
-    required NameNode? name,
-    FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  const TypeSystemDefinitionNode(FileSpan? span) : super(span);
 }
 
 abstract class TypeDefinitionNode extends TypeSystemDefinitionNode {
+  final NameNode name;
   final StringValueNode? description;
   final List<DirectiveNode> directives;
 
   const TypeDefinitionNode({
     this.description,
-    required NameNode name,
+    required this.name,
     this.directives = const [],
     FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  }) : super(span);
 }
 
 abstract class TypeSystemExtensionNode extends TypeSystemDefinitionNode {
-  const TypeSystemExtensionNode({
-    required NameNode? name,
+  const TypeSystemExtensionNode(
     FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  ) : super(span);
 }
 
 abstract class TypeExtensionNode extends TypeSystemExtensionNode {
+  final NameNode name;
   final List<DirectiveNode> directives;
 
   const TypeExtensionNode({
     FileSpan? span,
-    required NameNode name,
+    required this.name,
     this.directives = const [],
-  }) : super(
-          name: name,
-          span: span,
-        );
+  }) : super(span);
 }
 
 class SchemaDefinitionNode extends TypeSystemDefinitionNode {
@@ -690,10 +663,7 @@ class SchemaDefinitionNode extends TypeSystemDefinitionNode {
     this.directives = const [],
     this.operationTypes = const [],
     FileSpan? span,
-  }) : super(
-          name: null,
-          span: span,
-        );
+  }) : super(span);
 
   @override
   R accept<R>(Visitor<R> v) => v.visitSchemaDefinitionNode(this);
@@ -978,6 +948,7 @@ class InputObjectTypeDefinitionNode extends TypeDefinitionNode {
 }
 
 class DirectiveDefinitionNode extends TypeSystemDefinitionNode {
+  final NameNode name;
   final StringValueNode? description;
   final List<InputValueDefinitionNode> args;
   final List<DirectiveLocation> locations;
@@ -985,15 +956,12 @@ class DirectiveDefinitionNode extends TypeSystemDefinitionNode {
 
   const DirectiveDefinitionNode({
     this.description,
-    required NameNode name,
+    required this.name,
     this.args = const [],
     this.locations = const [],
     this.repeatable = false,
     FileSpan? span,
-  }) : super(
-          name: name,
-          span: span,
-        );
+  }) : super(span);
 
   @override
   R accept<R>(Visitor<R> v) => v.visitDirectiveDefinitionNode(this);
@@ -1016,17 +984,13 @@ class SchemaExtensionNode extends TypeSystemExtensionNode {
     this.directives = const [],
     this.operationTypes = const [],
     FileSpan? span,
-  }) : super(
-          name: null,
-          span: span,
-        );
+  }) : super(span);
 
   @override
   R accept<R>(Visitor<R> v) => v.visitSchemaExtensionNode(this);
 
   @override
   List<Object?> get _children => <Object?>[
-        name,
         directives,
         operationTypes,
       ];

--- a/gql/lib/src/ast/transformer.dart
+++ b/gql/lib/src/ast/transformer.dart
@@ -376,7 +376,7 @@ class _Transformer extends Visitor<Node> {
     DirectiveDefinitionNode node,
   ) {
     final updatedNode = DirectiveDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       locations: node.locations,
       repeatable: node.repeatable,
@@ -409,7 +409,7 @@ class _Transformer extends Visitor<Node> {
     EnumTypeDefinitionNode node,
   ) {
     final updatedNode = EnumTypeDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
       values: _visitAll(node.values),
@@ -426,7 +426,7 @@ class _Transformer extends Visitor<Node> {
     EnumTypeExtensionNode node,
   ) {
     final updatedNode = EnumTypeExtensionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
       values: _visitAll(node.values),
     );
@@ -442,7 +442,7 @@ class _Transformer extends Visitor<Node> {
     EnumValueDefinitionNode node,
   ) {
     final updatedNode = EnumValueDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
     );
@@ -522,7 +522,7 @@ class _Transformer extends Visitor<Node> {
     FragmentDefinitionNode node,
   ) {
     final updatedNode = FragmentDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
       selectionSet: _visitOne(node.selectionSet),
       typeCondition: _visitOne(node.typeCondition),
@@ -570,7 +570,7 @@ class _Transformer extends Visitor<Node> {
     InputObjectTypeDefinitionNode node,
   ) {
     final updatedNode = InputObjectTypeDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
       fields: _visitAll(node.fields),
@@ -587,7 +587,7 @@ class _Transformer extends Visitor<Node> {
     InputObjectTypeExtensionNode node,
   ) {
     final updatedNode = InputObjectTypeExtensionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
       fields: _visitAll(node.fields),
     );
@@ -635,7 +635,7 @@ class _Transformer extends Visitor<Node> {
     InterfaceTypeDefinitionNode node,
   ) {
     final updatedNode = InterfaceTypeDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
       fields: _visitAll(node.fields),
@@ -652,7 +652,7 @@ class _Transformer extends Visitor<Node> {
     InterfaceTypeExtensionNode node,
   ) {
     final updatedNode = InterfaceTypeExtensionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
       fields: _visitAll(node.fields),
     );
@@ -751,7 +751,7 @@ class _Transformer extends Visitor<Node> {
     ObjectTypeDefinitionNode node,
   ) {
     final updatedNode = ObjectTypeDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
       fields: _visitAll(node.fields),
@@ -769,7 +769,7 @@ class _Transformer extends Visitor<Node> {
     ObjectTypeExtensionNode node,
   ) {
     final updatedNode = ObjectTypeExtensionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
       fields: _visitAll(node.fields),
       interfaces: _visitAll(node.interfaces),
@@ -833,7 +833,7 @@ class _Transformer extends Visitor<Node> {
     ScalarTypeDefinitionNode node,
   ) {
     final updatedNode = ScalarTypeDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
     );
@@ -849,7 +849,7 @@ class _Transformer extends Visitor<Node> {
     ScalarTypeExtensionNode node,
   ) {
     final updatedNode = ScalarTypeExtensionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
     );
 
@@ -937,7 +937,7 @@ class _Transformer extends Visitor<Node> {
     UnionTypeDefinitionNode node,
   ) {
     final updatedNode = UnionTypeDefinitionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       description: _visitOne(node.description),
       directives: _visitAll(node.directives),
       types: _visitAll(node.types),
@@ -954,7 +954,7 @@ class _Transformer extends Visitor<Node> {
     UnionTypeExtensionNode node,
   ) {
     final updatedNode = UnionTypeExtensionNode(
-      name: _visitOne(node.name!),
+      name: _visitOne(node.name),
       directives: _visitAll(node.directives),
       types: _visitAll(node.types),
     );

--- a/gql/lib/src/language/printer.dart
+++ b/gql/lib/src/language/printer.dart
@@ -207,7 +207,7 @@ class _PrintVisitor extends Visitor<String> {
           FragmentDefinitionNode fragmentDefinitionNode) =>
       [
         "fragment ",
-        fragmentDefinitionNode.name!.accept(this),
+        fragmentDefinitionNode.name.accept(this),
         " ",
         fragmentDefinitionNode.typeCondition.accept(this),
         if (fragmentDefinitionNode.directives.isNotEmpty) ...[
@@ -309,7 +309,7 @@ class _PrintVisitor extends Visitor<String> {
         ],
         "scalar",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),
@@ -324,7 +324,7 @@ class _PrintVisitor extends Visitor<String> {
         ],
         "type",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         " ",
         visitImplementsSetNode(node.interfaces),
         visitDirectiveSetNode(node.directives),
@@ -433,7 +433,7 @@ class _PrintVisitor extends Visitor<String> {
         ],
         "interface",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         " ",
         visitDirectiveSetNode(node.directives),
         visitFieldSetNode(node.fields),
@@ -447,7 +447,7 @@ class _PrintVisitor extends Visitor<String> {
         ],
         "union",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),
@@ -486,7 +486,7 @@ class _PrintVisitor extends Visitor<String> {
         ],
         "enum",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),
@@ -524,7 +524,7 @@ class _PrintVisitor extends Visitor<String> {
           "\n",
           _indent(_tabs),
         ],
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) " ",
         visitDirectiveSetNode(node.directives),
       ].join();
@@ -539,7 +539,7 @@ class _PrintVisitor extends Visitor<String> {
         ],
         "input",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         " ",
         visitDirectiveSetNode(node.directives),
         visitInputValueDefinitionSetNode(node.fields),
@@ -576,7 +576,7 @@ class _PrintVisitor extends Visitor<String> {
         "directive",
         " ",
         "@",
-        node.name!.accept(this),
+        node.name.accept(this),
         visitArgumentDefinitionSetNode(node.args),
         if (node.repeatable) ...[
           " ",
@@ -630,7 +630,7 @@ class _PrintVisitor extends Visitor<String> {
         " ",
         "scalar",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),
@@ -643,7 +643,7 @@ class _PrintVisitor extends Visitor<String> {
         " ",
         "type",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         " ",
         visitImplementsSetNode(node.interfaces),
         visitDirectiveSetNode(node.directives),
@@ -656,7 +656,7 @@ class _PrintVisitor extends Visitor<String> {
         " ",
         "interface",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         " ",
         visitDirectiveSetNode(node.directives),
         visitFieldSetNode(node.fields),
@@ -668,7 +668,7 @@ class _PrintVisitor extends Visitor<String> {
         " ",
         "union",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),
@@ -682,7 +682,7 @@ class _PrintVisitor extends Visitor<String> {
         " ",
         "enum",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),
@@ -697,7 +697,7 @@ class _PrintVisitor extends Visitor<String> {
         " ",
         "input",
         " ",
-        node.name!.accept(this),
+        node.name.accept(this),
         if (node.directives.isNotEmpty) ...[
           " ",
           visitDirectiveSetNode(node.directives),

--- a/gql/lib/src/operation/definitions/definitions.dart
+++ b/gql/lib/src/operation/definitions/definitions.dart
@@ -14,7 +14,7 @@ abstract class ExecutableDefinition extends ExecutableWithResolver {
   @override
   ExecutableDefinitionNode get astNode;
 
-  String? get name => astNode.name?.value;
+  String? get name;
 
   static ExecutableDefinition fromNode(ExecutableDefinitionNode astNode,
       [GetExecutableType? getType]) {
@@ -45,6 +45,9 @@ class OperationDefinition extends ExecutableDefinition {
 
   @override
   final OperationDefinitionNode astNode;
+
+  @override
+  String? get name => astNode.name?.value;
 
   OperationType get type => astNode.type;
 
@@ -77,6 +80,9 @@ class FragmentDefinition extends ExecutableDefinition {
 
   @override
   final FragmentDefinitionNode astNode;
+
+  @override
+  String? get name => astNode.name.value;
 
   TypeCondition get _typeCondition => TypeCondition(astNode.typeCondition);
 

--- a/gql/lib/src/operation/executable.dart
+++ b/gql/lib/src/operation/executable.dart
@@ -65,7 +65,7 @@ Map<String, FragmentDefinitionNode> _collectImportedFragmentNodes(
           .whereType<FragmentDefinitionNode>()
           .map(
             (fragmentNode) => MapEntry(
-              fragmentNode.name!.value,
+              fragmentNode.name.value,
               fragmentNode,
             ),
           ),

--- a/gql/lib/src/schema/definitions/base_types.dart
+++ b/gql/lib/src/schema/definitions/base_types.dart
@@ -224,7 +224,7 @@ abstract class TypeSystemDefinition extends GraphQLEntity {
   @override
   TypeSystemDefinitionNode? get astNode;
 
-  String? get name => astNode!.name!.value;
+  String? get name;
 }
 
 /// The fundamental unit of any GraphQL Schema ([spec](https://spec.graphql.org/June2018/#TypeDefinition)).
@@ -261,6 +261,9 @@ abstract class TypeDefinition extends TypeSystemDefinition {
 
   @override
   TypeDefinitionNode get astNode;
+
+  @override
+  String? get name => astNode.name.value;
 
   String? get description => astNode.description?.value;
 

--- a/gql/lib/src/schema/definitions/definitions.dart
+++ b/gql/lib/src/schema/definitions/definitions.dart
@@ -342,6 +342,9 @@ class DirectiveDefinition extends TypeSystemDefinition {
   @override
   final DirectiveDefinitionNode? astNode;
 
+  @override
+  String? get name => astNode!.name.value;
+
   String? get description => astNode!.description?.value;
 
   List<InputValueDefinition>? get args => astNode!.args

--- a/gql/lib/src/schema/schema.dart
+++ b/gql/lib/src/schema/schema.dart
@@ -29,6 +29,9 @@ class GraphQLSchema extends TypeSystemDefinition {
   @override
   final SchemaDefinitionNode? astNode;
 
+  @override
+  String? get name => null;
+
   final DocumentNode? fullDocumentAst;
 
   final List<DirectiveDefinition>? directives;

--- a/gql/lib/src/validation/rules/unique_directive_names.dart
+++ b/gql/lib/src/validation/rules/unique_directive_names.dart
@@ -16,13 +16,13 @@ class UniqueDirectiveNames extends ValidatingVisitor {
   @override
   List<ValidationError> visitDirectiveDefinitionNode(
       DirectiveDefinitionNode node) {
-    if (directiveNames.contains(node.name!.value)) {
+    if (directiveNames.contains(node.name.value)) {
       return [
         DuplicateDirectiveNameError(node: node),
       ];
     }
 
-    directiveNames.add(node.name!.value);
+    directiveNames.add(node.name.value);
 
     return [];
   }

--- a/gql/lib/src/validation/rules/unique_enum_value_names.dart
+++ b/gql/lib/src/validation/rules/unique_enum_value_names.dart
@@ -31,7 +31,7 @@ class UniqueEnumValueNames extends ValidatingVisitor {
       node.values.fold<_Accumulator>(
         _Accumulator(),
         (fold, node) {
-          if (fold.valueNames.contains(node.name!.value)) {
+          if (fold.valueNames.contains(node.name.value)) {
             return _Accumulator(
               valueNames: fold.valueNames,
               errors: [
@@ -47,7 +47,7 @@ class UniqueEnumValueNames extends ValidatingVisitor {
           return _Accumulator(
             valueNames: [
               ...fold.valueNames,
-              node.name!.value,
+              node.name.value,
             ],
             errors: fold.errors,
           );

--- a/gql/lib/src/validation/rules/unique_type_names.dart
+++ b/gql/lib/src/validation/rules/unique_type_names.dart
@@ -14,13 +14,13 @@ class UniqueTypeNames extends ValidatingVisitor {
   List<String> typeDefinitionsNames = [];
 
   List<ValidationError> _visitTypeDefinitionNode(TypeDefinitionNode node) {
-    if (typeDefinitionsNames.contains(node.name!.value)) {
+    if (typeDefinitionsNames.contains(node.name.value)) {
       return [
         DuplicateTypeNameError(node: node),
       ];
     }
 
-    typeDefinitionsNames.add(node.name!.value);
+    typeDefinitionsNames.add(node.name.value);
 
     return [];
   }

--- a/gql/pubspec.yaml
+++ b/gql/pubspec.yaml
@@ -8,8 +8,8 @@ dependencies:
   collection: ^1.15.0
   meta: ^1.3.0
   source_span: ^1.8.1
-dev_dependencies: 
+dev_dependencies:
+  cats:
+    path: ../cats
   gql_pedantic: ^1.0.2
   test: ^1.16.2
-  cats: 
-    path: ../cats


### PR DESCRIPTION
This should get rid of the abuse of `!` operator.