### PR TITLE
add null safety to codegen libs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -21,7 +21,7 @@ jobs:
           - cats
     runs-on: ubuntu-latest
     container:
-      image: google/dart:2.12-beta
+      image: google/dart
     name: Check ${{ matrix.package }}
     env:
       PACKAGE: ${{ matrix.package }}
@@ -73,7 +73,7 @@ jobs:
           # gql_example_flutter would require flutter
     runs-on: ubuntu-latest
     container:
-      image: google/dart:2.12-beta
+      image: google/dart
     name: Check ${{ matrix.package }}
     env:
       PACKAGE: ${{ matrix.package }}
@@ -119,7 +119,7 @@ jobs:
           - end_to_end_test
     runs-on: ubuntu-latest
     container:
-      image: google/dart:2.12-beta
+      image: google/dart
     name: Check ${{ matrix.package }}
     env:
       PACKAGE: ${{ matrix.package }}
@@ -165,7 +165,7 @@ jobs:
   publish_dry_run:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:2.12-beta
+      image: google/dart
     env:
       PACKAGES: 'gql,gql_build,gql_code_builder,gql_dedupe_link,gql_dio_link,gql_exec,gql_http_link,gql_link,gql_pedantic,gql_transform_link,gql_error_link,gql_websocket_link'
       PUB_ACCESS_TOKEN: ${{ secrets.PUB_ACCESS_TOKEN }}
@@ -190,7 +190,7 @@ jobs:
   check_svg:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:2.12-beta
+      image: google/dart
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/cats/pubspec.yaml
+++ b/cats/pubspec.yaml
@@ -2,7 +2,7 @@ name: cats
 description: A starting point for Dart libraries or applications.
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   test: ^1.16.0
 dev_dependencies: 

--- a/codegen/end_to_end_test/lib/aliases/aliased_hero.data.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/aliased_hero.data.gql.dart
@@ -19,15 +19,14 @@ abstract class GAliasedHeroData
       b..G__typename = 'Query';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GAliasedHeroData_empireHero get empireHero;
-  @nullable
-  GAliasedHeroData_jediHero get jediHero;
+  GAliasedHeroData_empireHero? get empireHero;
+  GAliasedHeroData_jediHero? get jediHero;
   static Serializer<GAliasedHeroData> get serializer =>
       _$gAliasedHeroDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GAliasedHeroData.serializer, this);
-  static GAliasedHeroData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GAliasedHeroData.serializer, this)
+          as Map<String, dynamic>);
+  static GAliasedHeroData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GAliasedHeroData.serializer, json);
 }
 
@@ -46,13 +45,12 @@ abstract class GAliasedHeroData_empireHero
   String get G__typename;
   String get id;
   String get name;
-  @nullable
   BuiltList<_i2.GEpisode> get from;
   static Serializer<GAliasedHeroData_empireHero> get serializer =>
       _$gAliasedHeroDataEmpireHeroSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GAliasedHeroData_empireHero.serializer, this);
-  static GAliasedHeroData_empireHero fromJson(Map<String, dynamic> json) =>
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+      GAliasedHeroData_empireHero.serializer, this) as Map<String, dynamic>);
+  static GAliasedHeroData_empireHero? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GAliasedHeroData_empireHero.serializer, json);
 }
@@ -72,13 +70,13 @@ abstract class GAliasedHeroData_jediHero
   String get G__typename;
   String get id;
   String get name;
-  @nullable
   BuiltList<_i2.GEpisode> get from;
   static Serializer<GAliasedHeroData_jediHero> get serializer =>
       _$gAliasedHeroDataJediHeroSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GAliasedHeroData_jediHero.serializer, this);
-  static GAliasedHeroData_jediHero fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GAliasedHeroData_jediHero.serializer, this)
+          as Map<String, dynamic>);
+  static GAliasedHeroData_jediHero? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GAliasedHeroData_jediHero.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/aliases/aliased_hero.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/aliases/aliased_hero.data.gql.g.dart
@@ -21,23 +21,26 @@ class _$GAliasedHeroDataSerializer
   final String wireName = 'GAliasedHeroData';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GAliasedHeroData object,
+  Iterable<Object?> serialize(Serializers serializers, GAliasedHeroData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.empireHero != null) {
+    Object? value;
+    value = object.empireHero;
+    if (value != null) {
       result
         ..add('empireHero')
-        ..add(serializers.serialize(object.empireHero,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GAliasedHeroData_empireHero)));
     }
-    if (object.jediHero != null) {
+    value = object.jediHero;
+    if (value != null) {
       result
         ..add('jediHero')
-        ..add(serializers.serialize(object.jediHero,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GAliasedHeroData_jediHero)));
     }
     return result;
@@ -45,7 +48,7 @@ class _$GAliasedHeroDataSerializer
 
   @override
   GAliasedHeroData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GAliasedHeroDataBuilder();
 
@@ -53,7 +56,7 @@ class _$GAliasedHeroDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -61,12 +64,12 @@ class _$GAliasedHeroDataSerializer
           break;
         case 'empireHero':
           result.empireHero.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(GAliasedHeroData_empireHero))
+                  specifiedType: const FullType(GAliasedHeroData_empireHero))!
               as GAliasedHeroData_empireHero);
           break;
         case 'jediHero':
           result.jediHero.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(GAliasedHeroData_jediHero))
+                  specifiedType: const FullType(GAliasedHeroData_jediHero))!
               as GAliasedHeroData_jediHero);
           break;
       }
@@ -87,10 +90,10 @@ class _$GAliasedHeroData_empireHeroSerializer
   final String wireName = 'GAliasedHeroData_empireHero';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GAliasedHeroData_empireHero object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -98,20 +101,18 @@ class _$GAliasedHeroData_empireHeroSerializer
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'from',
+      serializers.serialize(object.from,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(_i2.GEpisode)])),
     ];
-    if (object.from != null) {
-      result
-        ..add('from')
-        ..add(serializers.serialize(object.from,
-            specifiedType: const FullType(
-                BuiltList, const [const FullType(_i2.GEpisode)])));
-    }
+
     return result;
   }
 
   @override
   GAliasedHeroData_empireHero deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GAliasedHeroData_empireHeroBuilder();
 
@@ -119,7 +120,7 @@ class _$GAliasedHeroData_empireHeroSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -136,7 +137,7 @@ class _$GAliasedHeroData_empireHeroSerializer
         case 'from':
           result.from.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      BuiltList, const [const FullType(_i2.GEpisode)]))
+                      BuiltList, const [const FullType(_i2.GEpisode)]))!
               as BuiltList<Object>);
           break;
       }
@@ -157,10 +158,10 @@ class _$GAliasedHeroData_jediHeroSerializer
   final String wireName = 'GAliasedHeroData_jediHero';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GAliasedHeroData_jediHero object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -168,20 +169,18 @@ class _$GAliasedHeroData_jediHeroSerializer
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'from',
+      serializers.serialize(object.from,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(_i2.GEpisode)])),
     ];
-    if (object.from != null) {
-      result
-        ..add('from')
-        ..add(serializers.serialize(object.from,
-            specifiedType: const FullType(
-                BuiltList, const [const FullType(_i2.GEpisode)])));
-    }
+
     return result;
   }
 
   @override
   GAliasedHeroData_jediHero deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GAliasedHeroData_jediHeroBuilder();
 
@@ -189,7 +188,7 @@ class _$GAliasedHeroData_jediHeroSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -206,7 +205,7 @@ class _$GAliasedHeroData_jediHeroSerializer
         case 'from':
           result.from.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      BuiltList, const [const FullType(_i2.GEpisode)]))
+                      BuiltList, const [const FullType(_i2.GEpisode)]))!
               as BuiltList<Object>);
           break;
       }
@@ -220,19 +219,19 @@ class _$GAliasedHeroData extends GAliasedHeroData {
   @override
   final String G__typename;
   @override
-  final GAliasedHeroData_empireHero empireHero;
+  final GAliasedHeroData_empireHero? empireHero;
   @override
-  final GAliasedHeroData_jediHero jediHero;
+  final GAliasedHeroData_jediHero? jediHero;
 
   factory _$GAliasedHeroData(
-          [void Function(GAliasedHeroDataBuilder) updates]) =>
+          [void Function(GAliasedHeroDataBuilder)? updates]) =>
       (new GAliasedHeroDataBuilder()..update(updates)).build();
 
-  _$GAliasedHeroData._({this.G__typename, this.empireHero, this.jediHero})
+  _$GAliasedHeroData._(
+      {required this.G__typename, this.empireHero, this.jediHero})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GAliasedHeroData', 'G__typename');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GAliasedHeroData', 'G__typename');
   }
 
   @override
@@ -270,22 +269,22 @@ class _$GAliasedHeroData extends GAliasedHeroData {
 
 class GAliasedHeroDataBuilder
     implements Builder<GAliasedHeroData, GAliasedHeroDataBuilder> {
-  _$GAliasedHeroData _$v;
+  _$GAliasedHeroData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GAliasedHeroData_empireHeroBuilder _empireHero;
+  GAliasedHeroData_empireHeroBuilder? _empireHero;
   GAliasedHeroData_empireHeroBuilder get empireHero =>
       _$this._empireHero ??= new GAliasedHeroData_empireHeroBuilder();
-  set empireHero(GAliasedHeroData_empireHeroBuilder empireHero) =>
+  set empireHero(GAliasedHeroData_empireHeroBuilder? empireHero) =>
       _$this._empireHero = empireHero;
 
-  GAliasedHeroData_jediHeroBuilder _jediHero;
+  GAliasedHeroData_jediHeroBuilder? _jediHero;
   GAliasedHeroData_jediHeroBuilder get jediHero =>
       _$this._jediHero ??= new GAliasedHeroData_jediHeroBuilder();
-  set jediHero(GAliasedHeroData_jediHeroBuilder jediHero) =>
+  set jediHero(GAliasedHeroData_jediHeroBuilder? jediHero) =>
       _$this._jediHero = jediHero;
 
   GAliasedHeroDataBuilder() {
@@ -293,10 +292,11 @@ class GAliasedHeroDataBuilder
   }
 
   GAliasedHeroDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _empireHero = _$v.empireHero?.toBuilder();
-      _jediHero = _$v.jediHero?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _empireHero = $v.empireHero?.toBuilder();
+      _jediHero = $v.jediHero?.toBuilder();
       _$v = null;
     }
     return this;
@@ -304,14 +304,12 @@ class GAliasedHeroDataBuilder
 
   @override
   void replace(GAliasedHeroData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GAliasedHeroData;
   }
 
   @override
-  void update(void Function(GAliasedHeroDataBuilder) updates) {
+  void update(void Function(GAliasedHeroDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -321,11 +319,12 @@ class GAliasedHeroDataBuilder
     try {
       _$result = _$v ??
           new _$GAliasedHeroData._(
-              G__typename: G__typename,
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GAliasedHeroData', 'G__typename'),
               empireHero: _empireHero?.build(),
               jediHero: _jediHero?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'empireHero';
         _empireHero?.build();
@@ -353,22 +352,23 @@ class _$GAliasedHeroData_empireHero extends GAliasedHeroData_empireHero {
   final BuiltList<_i2.GEpisode> from;
 
   factory _$GAliasedHeroData_empireHero(
-          [void Function(GAliasedHeroData_empireHeroBuilder) updates]) =>
+          [void Function(GAliasedHeroData_empireHeroBuilder)? updates]) =>
       (new GAliasedHeroData_empireHeroBuilder()..update(updates)).build();
 
   _$GAliasedHeroData_empireHero._(
-      {this.G__typename, this.id, this.name, this.from})
+      {required this.G__typename,
+      required this.id,
+      required this.name,
+      required this.from})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GAliasedHeroData_empireHero', 'G__typename');
-    }
-    if (id == null) {
-      throw new BuiltValueNullFieldError('GAliasedHeroData_empireHero', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GAliasedHeroData_empireHero', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GAliasedHeroData_empireHero', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        id, 'GAliasedHeroData_empireHero', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GAliasedHeroData_empireHero', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        from, 'GAliasedHeroData_empireHero', 'from');
   }
 
   @override
@@ -412,35 +412,36 @@ class GAliasedHeroData_empireHeroBuilder
     implements
         Builder<GAliasedHeroData_empireHero,
             GAliasedHeroData_empireHeroBuilder> {
-  _$GAliasedHeroData_empireHero _$v;
+  _$GAliasedHeroData_empireHero? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _id;
-  String get id => _$this._id;
-  set id(String id) => _$this._id = id;
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  ListBuilder<_i2.GEpisode> _from;
+  ListBuilder<_i2.GEpisode>? _from;
   ListBuilder<_i2.GEpisode> get from =>
       _$this._from ??= new ListBuilder<_i2.GEpisode>();
-  set from(ListBuilder<_i2.GEpisode> from) => _$this._from = from;
+  set from(ListBuilder<_i2.GEpisode>? from) => _$this._from = from;
 
   GAliasedHeroData_empireHeroBuilder() {
     GAliasedHeroData_empireHero._initializeBuilder(this);
   }
 
   GAliasedHeroData_empireHeroBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _id = _$v.id;
-      _name = _$v.name;
-      _from = _$v.from?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _id = $v.id;
+      _name = $v.name;
+      _from = $v.from.toBuilder();
       _$v = null;
     }
     return this;
@@ -448,14 +449,12 @@ class GAliasedHeroData_empireHeroBuilder
 
   @override
   void replace(GAliasedHeroData_empireHero other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GAliasedHeroData_empireHero;
   }
 
   @override
-  void update(void Function(GAliasedHeroData_empireHeroBuilder) updates) {
+  void update(void Function(GAliasedHeroData_empireHeroBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -465,15 +464,18 @@ class GAliasedHeroData_empireHeroBuilder
     try {
       _$result = _$v ??
           new _$GAliasedHeroData_empireHero._(
-              G__typename: G__typename,
-              id: id,
-              name: name,
-              from: _from?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GAliasedHeroData_empireHero', 'G__typename'),
+              id: BuiltValueNullFieldError.checkNotNull(
+                  id, 'GAliasedHeroData_empireHero', 'id'),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'GAliasedHeroData_empireHero', 'name'),
+              from: from.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'from';
-        _from?.build();
+        from.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             'GAliasedHeroData_empireHero', _$failedField, e.toString());
@@ -496,22 +498,23 @@ class _$GAliasedHeroData_jediHero extends GAliasedHeroData_jediHero {
   final BuiltList<_i2.GEpisode> from;
 
   factory _$GAliasedHeroData_jediHero(
-          [void Function(GAliasedHeroData_jediHeroBuilder) updates]) =>
+          [void Function(GAliasedHeroData_jediHeroBuilder)? updates]) =>
       (new GAliasedHeroData_jediHeroBuilder()..update(updates)).build();
 
   _$GAliasedHeroData_jediHero._(
-      {this.G__typename, this.id, this.name, this.from})
+      {required this.G__typename,
+      required this.id,
+      required this.name,
+      required this.from})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GAliasedHeroData_jediHero', 'G__typename');
-    }
-    if (id == null) {
-      throw new BuiltValueNullFieldError('GAliasedHeroData_jediHero', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GAliasedHeroData_jediHero', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GAliasedHeroData_jediHero', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        id, 'GAliasedHeroData_jediHero', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GAliasedHeroData_jediHero', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        from, 'GAliasedHeroData_jediHero', 'from');
   }
 
   @override
@@ -554,35 +557,36 @@ class _$GAliasedHeroData_jediHero extends GAliasedHeroData_jediHero {
 class GAliasedHeroData_jediHeroBuilder
     implements
         Builder<GAliasedHeroData_jediHero, GAliasedHeroData_jediHeroBuilder> {
-  _$GAliasedHeroData_jediHero _$v;
+  _$GAliasedHeroData_jediHero? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _id;
-  String get id => _$this._id;
-  set id(String id) => _$this._id = id;
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  ListBuilder<_i2.GEpisode> _from;
+  ListBuilder<_i2.GEpisode>? _from;
   ListBuilder<_i2.GEpisode> get from =>
       _$this._from ??= new ListBuilder<_i2.GEpisode>();
-  set from(ListBuilder<_i2.GEpisode> from) => _$this._from = from;
+  set from(ListBuilder<_i2.GEpisode>? from) => _$this._from = from;
 
   GAliasedHeroData_jediHeroBuilder() {
     GAliasedHeroData_jediHero._initializeBuilder(this);
   }
 
   GAliasedHeroData_jediHeroBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _id = _$v.id;
-      _name = _$v.name;
-      _from = _$v.from?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _id = $v.id;
+      _name = $v.name;
+      _from = $v.from.toBuilder();
       _$v = null;
     }
     return this;
@@ -590,14 +594,12 @@ class GAliasedHeroData_jediHeroBuilder
 
   @override
   void replace(GAliasedHeroData_jediHero other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GAliasedHeroData_jediHero;
   }
 
   @override
-  void update(void Function(GAliasedHeroData_jediHeroBuilder) updates) {
+  void update(void Function(GAliasedHeroData_jediHeroBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -607,15 +609,18 @@ class GAliasedHeroData_jediHeroBuilder
     try {
       _$result = _$v ??
           new _$GAliasedHeroData_jediHero._(
-              G__typename: G__typename,
-              id: id,
-              name: name,
-              from: _from?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GAliasedHeroData_jediHero', 'G__typename'),
+              id: BuiltValueNullFieldError.checkNotNull(
+                  id, 'GAliasedHeroData_jediHero', 'id'),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'GAliasedHeroData_jediHero', 'name'),
+              from: from.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'from';
-        _from?.build();
+        from.build();
       } catch (e) {
         throw new BuiltValueNestedFieldError(
             'GAliasedHeroData_jediHero', _$failedField, e.toString());

--- a/codegen/end_to_end_test/lib/aliases/aliased_hero.req.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/aliased_hero.req.gql.dart
@@ -23,7 +23,8 @@ abstract class GAliasedHero
   _i1.Operation get operation;
   static Serializer<GAliasedHero> get serializer => _$gAliasedHeroSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GAliasedHero.serializer, this);
-  static GAliasedHero fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GAliasedHero.serializer, this)
+          as Map<String, dynamic>);
+  static GAliasedHero? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GAliasedHero.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/aliases/aliased_hero.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/aliases/aliased_hero.req.gql.g.dart
@@ -16,9 +16,9 @@ class _$GAliasedHeroSerializer implements StructuredSerializer<GAliasedHero> {
   final String wireName = 'GAliasedHero';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GAliasedHero object,
+  Iterable<Object?> serialize(Serializers serializers, GAliasedHero object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GAliasedHeroVars)),
@@ -31,7 +31,8 @@ class _$GAliasedHeroSerializer implements StructuredSerializer<GAliasedHero> {
   }
 
   @override
-  GAliasedHero deserialize(Serializers serializers, Iterable<Object> serialized,
+  GAliasedHero deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GAliasedHeroBuilder();
 
@@ -39,11 +40,11 @@ class _$GAliasedHeroSerializer implements StructuredSerializer<GAliasedHero> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GAliasedHeroVars))
+                  specifiedType: const FullType(_i3.GAliasedHeroVars))!
               as _i3.GAliasedHeroVars);
           break;
         case 'operation':
@@ -63,16 +64,13 @@ class _$GAliasedHero extends GAliasedHero {
   @override
   final _i1.Operation operation;
 
-  factory _$GAliasedHero([void Function(GAliasedHeroBuilder) updates]) =>
+  factory _$GAliasedHero([void Function(GAliasedHeroBuilder)? updates]) =>
       (new GAliasedHeroBuilder()..update(updates)).build();
 
-  _$GAliasedHero._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GAliasedHero', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GAliasedHero', 'operation');
-    }
+  _$GAliasedHero._({required this.vars, required this.operation}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GAliasedHero', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GAliasedHero', 'operation');
   }
 
   @override
@@ -106,25 +104,26 @@ class _$GAliasedHero extends GAliasedHero {
 
 class GAliasedHeroBuilder
     implements Builder<GAliasedHero, GAliasedHeroBuilder> {
-  _$GAliasedHero _$v;
+  _$GAliasedHero? _$v;
 
-  _i3.GAliasedHeroVarsBuilder _vars;
+  _i3.GAliasedHeroVarsBuilder? _vars;
   _i3.GAliasedHeroVarsBuilder get vars =>
       _$this._vars ??= new _i3.GAliasedHeroVarsBuilder();
-  set vars(_i3.GAliasedHeroVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GAliasedHeroVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GAliasedHeroBuilder() {
     GAliasedHero._initializeBuilder(this);
   }
 
   GAliasedHeroBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -132,14 +131,12 @@ class GAliasedHeroBuilder
 
   @override
   void replace(GAliasedHero other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GAliasedHero;
   }
 
   @override
-  void update(void Function(GAliasedHeroBuilder) updates) {
+  void update(void Function(GAliasedHeroBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -147,10 +144,13 @@ class GAliasedHeroBuilder
   _$GAliasedHero build() {
     _$GAliasedHero _$result;
     try {
-      _$result =
-          _$v ?? new _$GAliasedHero._(vars: vars.build(), operation: operation);
+      _$result = _$v ??
+          new _$GAliasedHero._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GAliasedHero', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/aliases/aliased_hero.var.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/aliased_hero.var.gql.dart
@@ -18,7 +18,8 @@ abstract class GAliasedHeroVars
   static Serializer<GAliasedHeroVars> get serializer =>
       _$gAliasedHeroVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i2.serializers.serializeWith(GAliasedHeroVars.serializer, this);
-  static GAliasedHeroVars fromJson(Map<String, dynamic> json) =>
+      (_i2.serializers.serializeWith(GAliasedHeroVars.serializer, this)
+          as Map<String, dynamic>);
+  static GAliasedHeroVars? fromJson(Map<String, dynamic> json) =>
       _i2.serializers.deserializeWith(GAliasedHeroVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/aliases/aliased_hero.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/aliases/aliased_hero.var.gql.g.dart
@@ -17,9 +17,9 @@ class _$GAliasedHeroVarsSerializer
   final String wireName = 'GAliasedHeroVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GAliasedHeroVars object,
+  Iterable<Object?> serialize(Serializers serializers, GAliasedHeroVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'ep',
       serializers.serialize(object.ep,
           specifiedType: const FullType(_i1.GEpisode)),
@@ -30,7 +30,7 @@ class _$GAliasedHeroVarsSerializer
 
   @override
   GAliasedHeroVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GAliasedHeroVarsBuilder();
 
@@ -38,7 +38,7 @@ class _$GAliasedHeroVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'ep':
           result.ep = serializers.deserialize(value,
@@ -56,13 +56,11 @@ class _$GAliasedHeroVars extends GAliasedHeroVars {
   final _i1.GEpisode ep;
 
   factory _$GAliasedHeroVars(
-          [void Function(GAliasedHeroVarsBuilder) updates]) =>
+          [void Function(GAliasedHeroVarsBuilder)? updates]) =>
       (new GAliasedHeroVarsBuilder()..update(updates)).build();
 
-  _$GAliasedHeroVars._({this.ep}) : super._() {
-    if (ep == null) {
-      throw new BuiltValueNullFieldError('GAliasedHeroVars', 'ep');
-    }
+  _$GAliasedHeroVars._({required this.ep}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(ep, 'GAliasedHeroVars', 'ep');
   }
 
   @override
@@ -93,17 +91,18 @@ class _$GAliasedHeroVars extends GAliasedHeroVars {
 
 class GAliasedHeroVarsBuilder
     implements Builder<GAliasedHeroVars, GAliasedHeroVarsBuilder> {
-  _$GAliasedHeroVars _$v;
+  _$GAliasedHeroVars? _$v;
 
-  _i1.GEpisode _ep;
-  _i1.GEpisode get ep => _$this._ep;
-  set ep(_i1.GEpisode ep) => _$this._ep = ep;
+  _i1.GEpisode? _ep;
+  _i1.GEpisode? get ep => _$this._ep;
+  set ep(_i1.GEpisode? ep) => _$this._ep = ep;
 
   GAliasedHeroVarsBuilder();
 
   GAliasedHeroVarsBuilder get _$this {
-    if (_$v != null) {
-      _ep = _$v.ep;
+    final $v = _$v;
+    if ($v != null) {
+      _ep = $v.ep;
       _$v = null;
     }
     return this;
@@ -111,20 +110,21 @@ class GAliasedHeroVarsBuilder
 
   @override
   void replace(GAliasedHeroVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GAliasedHeroVars;
   }
 
   @override
-  void update(void Function(GAliasedHeroVarsBuilder) updates) {
+  void update(void Function(GAliasedHeroVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GAliasedHeroVars build() {
-    final _$result = _$v ?? new _$GAliasedHeroVars._(ep: ep);
+    final _$result = _$v ??
+        new _$GAliasedHeroVars._(
+            ep: BuiltValueNullFieldError.checkNotNull(
+                ep, 'GAliasedHeroVars', 'ep'));
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/date_serializer.dart
+++ b/codegen/end_to_end_test/lib/date_serializer.dart
@@ -7,8 +7,11 @@ class DateSerializer implements PrimitiveSerializer<DateTime> {
     Object serialized, {
     FullType specifiedType = FullType.unspecified,
   }) {
-    assert(serialized is int,
-        "DateSerializer expected 'int' but got ${serialized.runtimeType}");
+    if (!(serialized is int)) {
+      throw Exception(
+        "DateSerializer expected 'int' but got ${serialized.runtimeType}",
+      );
+    }
     return DateTime.fromMillisecondsSinceEpoch(serialized);
   }
 

--- a/codegen/end_to_end_test/lib/fragments/hero_with_fragments.data.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/hero_with_fragments.data.gql.dart
@@ -19,13 +19,13 @@ abstract class GHeroWithFragmentsData
       b..G__typename = 'Query';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GHeroWithFragmentsData_hero get hero;
+  GHeroWithFragmentsData_hero? get hero;
   static Serializer<GHeroWithFragmentsData> get serializer =>
       _$gHeroWithFragmentsDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroWithFragmentsData.serializer, this);
-  static GHeroWithFragmentsData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroWithFragmentsData.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroWithFragmentsData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHeroWithFragmentsData.serializer, json);
 }
 
@@ -48,9 +48,9 @@ abstract class GHeroWithFragmentsData_hero
   GHeroWithFragmentsData_hero_friendsConnection get friendsConnection;
   static Serializer<GHeroWithFragmentsData_hero> get serializer =>
       _$gHeroWithFragmentsDataHeroSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GHeroWithFragmentsData_hero.serializer, this);
-  static GHeroWithFragmentsData_hero fromJson(Map<String, dynamic> json) =>
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+      GHeroWithFragmentsData_hero.serializer, this) as Map<String, dynamic>);
+  static GHeroWithFragmentsData_hero? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GHeroWithFragmentsData_hero.serializer, json);
 }
@@ -71,15 +71,14 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection
       b..G__typename = 'FriendsConnection';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  int get totalCount;
-  @nullable
-  BuiltList<GHeroWithFragmentsData_hero_friendsConnection_edges> get edges;
+  int? get totalCount;
+  BuiltList<GHeroWithFragmentsData_hero_friendsConnection_edges>? get edges;
   static Serializer<GHeroWithFragmentsData_hero_friendsConnection>
       get serializer => _$gHeroWithFragmentsDataHeroFriendsConnectionSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers.serializeWith(
-      GHeroWithFragmentsData_hero_friendsConnection.serializer, this);
-  static GHeroWithFragmentsData_hero_friendsConnection fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GHeroWithFragmentsData_hero_friendsConnection.serializer, this)
+      as Map<String, dynamic>);
+  static GHeroWithFragmentsData_hero_friendsConnection? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GHeroWithFragmentsData_hero_friendsConnection.serializer, json);
@@ -101,14 +100,14 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection_edges
       b..G__typename = 'FriendsEdge';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GHeroWithFragmentsData_hero_friendsConnection_edges_node get node;
+  GHeroWithFragmentsData_hero_friendsConnection_edges_node? get node;
   static Serializer<GHeroWithFragmentsData_hero_friendsConnection_edges>
       get serializer =>
           _$gHeroWithFragmentsDataHeroFriendsConnectionEdgesSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers.serializeWith(
-      GHeroWithFragmentsData_hero_friendsConnection_edges.serializer, this);
-  static GHeroWithFragmentsData_hero_friendsConnection_edges fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GHeroWithFragmentsData_hero_friendsConnection_edges.serializer, this)
+      as Map<String, dynamic>);
+  static GHeroWithFragmentsData_hero_friendsConnection_edges? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GHeroWithFragmentsData_hero_friendsConnection_edges.serializer, json);
@@ -136,10 +135,10 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection_edges_node
   static Serializer<GHeroWithFragmentsData_hero_friendsConnection_edges_node>
       get serializer =>
           _$gHeroWithFragmentsDataHeroFriendsConnectionEdgesNodeSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers.serializeWith(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
       GHeroWithFragmentsData_hero_friendsConnection_edges_node.serializer,
-      this);
-  static GHeroWithFragmentsData_hero_friendsConnection_edges_node fromJson(
+      this) as Map<String, dynamic>);
+  static GHeroWithFragmentsData_hero_friendsConnection_edges_node? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GHeroWithFragmentsData_hero_friendsConnection_edges_node.serializer,
@@ -166,8 +165,9 @@ abstract class GheroDataData
   String get name;
   static Serializer<GheroDataData> get serializer => _$gheroDataDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GheroDataData.serializer, this);
-  static GheroDataData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GheroDataData.serializer, this)
+          as Map<String, dynamic>);
+  static GheroDataData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GheroDataData.serializer, json);
 }
 
@@ -181,14 +181,14 @@ abstract class GcomparisonFields implements GheroData {
 
 abstract class GcomparisonFields_friendsConnection {
   String get G__typename;
-  int get totalCount;
-  BuiltList<GcomparisonFields_friendsConnection_edges> get edges;
+  int? get totalCount;
+  BuiltList<GcomparisonFields_friendsConnection_edges>? get edges;
   Map<String, dynamic> toJson();
 }
 
 abstract class GcomparisonFields_friendsConnection_edges {
   String get G__typename;
-  GcomparisonFields_friendsConnection_edges_node get node;
+  GcomparisonFields_friendsConnection_edges_node? get node;
   Map<String, dynamic> toJson();
 }
 
@@ -220,8 +220,9 @@ abstract class GcomparisonFieldsData
   static Serializer<GcomparisonFieldsData> get serializer =>
       _$gcomparisonFieldsDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GcomparisonFieldsData.serializer, this);
-  static GcomparisonFieldsData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GcomparisonFieldsData.serializer, this)
+          as Map<String, dynamic>);
+  static GcomparisonFieldsData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GcomparisonFieldsData.serializer, json);
 }
 
@@ -241,15 +242,14 @@ abstract class GcomparisonFieldsData_friendsConnection
       b..G__typename = 'FriendsConnection';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  int get totalCount;
-  @nullable
-  BuiltList<GcomparisonFieldsData_friendsConnection_edges> get edges;
+  int? get totalCount;
+  BuiltList<GcomparisonFieldsData_friendsConnection_edges>? get edges;
   static Serializer<GcomparisonFieldsData_friendsConnection> get serializer =>
       _$gcomparisonFieldsDataFriendsConnectionSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GcomparisonFieldsData_friendsConnection.serializer, this);
-  static GcomparisonFieldsData_friendsConnection fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GcomparisonFieldsData_friendsConnection.serializer, this)
+      as Map<String, dynamic>);
+  static GcomparisonFieldsData_friendsConnection? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GcomparisonFieldsData_friendsConnection.serializer, json);
@@ -271,13 +271,13 @@ abstract class GcomparisonFieldsData_friendsConnection_edges
       b..G__typename = 'FriendsEdge';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GcomparisonFieldsData_friendsConnection_edges_node get node;
+  GcomparisonFieldsData_friendsConnection_edges_node? get node;
   static Serializer<GcomparisonFieldsData_friendsConnection_edges>
       get serializer => _$gcomparisonFieldsDataFriendsConnectionEdgesSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers.serializeWith(
-      GcomparisonFieldsData_friendsConnection_edges.serializer, this);
-  static GcomparisonFieldsData_friendsConnection_edges fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GcomparisonFieldsData_friendsConnection_edges.serializer, this)
+      as Map<String, dynamic>);
+  static GcomparisonFieldsData_friendsConnection_edges? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GcomparisonFieldsData_friendsConnection_edges.serializer, json);
@@ -304,9 +304,10 @@ abstract class GcomparisonFieldsData_friendsConnection_edges_node
   static Serializer<GcomparisonFieldsData_friendsConnection_edges_node>
       get serializer =>
           _$gcomparisonFieldsDataFriendsConnectionEdgesNodeSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers.serializeWith(
-      GcomparisonFieldsData_friendsConnection_edges_node.serializer, this);
-  static GcomparisonFieldsData_friendsConnection_edges_node fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GcomparisonFieldsData_friendsConnection_edges_node.serializer, this)
+      as Map<String, dynamic>);
+  static GcomparisonFieldsData_friendsConnection_edges_node? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GcomparisonFieldsData_friendsConnection_edges_node.serializer, json);

--- a/codegen/end_to_end_test/lib/fragments/hero_with_fragments.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/hero_with_fragments.data.gql.g.dart
@@ -44,18 +44,20 @@ class _$GHeroWithFragmentsDataSerializer
   final String wireName = 'GHeroWithFragmentsData';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroWithFragmentsData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.hero != null) {
+    Object? value;
+    value = object.hero;
+    if (value != null) {
       result
         ..add('hero')
-        ..add(serializers.serialize(object.hero,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GHeroWithFragmentsData_hero)));
     }
     return result;
@@ -63,7 +65,7 @@ class _$GHeroWithFragmentsDataSerializer
 
   @override
   GHeroWithFragmentsData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroWithFragmentsDataBuilder();
 
@@ -71,7 +73,7 @@ class _$GHeroWithFragmentsDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -79,7 +81,7 @@ class _$GHeroWithFragmentsDataSerializer
           break;
         case 'hero':
           result.hero.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(GHeroWithFragmentsData_hero))
+                  specifiedType: const FullType(GHeroWithFragmentsData_hero))!
               as GHeroWithFragmentsData_hero);
           break;
       }
@@ -100,10 +102,10 @@ class _$GHeroWithFragmentsData_heroSerializer
   final String wireName = 'GHeroWithFragmentsData_hero';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroWithFragmentsData_hero object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -122,7 +124,7 @@ class _$GHeroWithFragmentsData_heroSerializer
 
   @override
   GHeroWithFragmentsData_hero deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroWithFragmentsData_heroBuilder();
 
@@ -130,7 +132,7 @@ class _$GHeroWithFragmentsData_heroSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -147,7 +149,7 @@ class _$GHeroWithFragmentsData_heroSerializer
         case 'friendsConnection':
           result.friendsConnection.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      GHeroWithFragmentsData_hero_friendsConnection))
+                      GHeroWithFragmentsData_hero_friendsConnection))!
               as GHeroWithFragmentsData_hero_friendsConnection);
           break;
       }
@@ -169,24 +171,26 @@ class _$GHeroWithFragmentsData_hero_friendsConnectionSerializer
   final String wireName = 'GHeroWithFragmentsData_hero_friendsConnection';
 
   @override
-  Iterable<Object> serialize(Serializers serializers,
+  Iterable<Object?> serialize(Serializers serializers,
       GHeroWithFragmentsData_hero_friendsConnection object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.totalCount != null) {
+    Object? value;
+    value = object.totalCount;
+    if (value != null) {
       result
         ..add('totalCount')
-        ..add(serializers.serialize(object.totalCount,
-            specifiedType: const FullType(int)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
     }
-    if (object.edges != null) {
+    value = object.edges;
+    if (value != null) {
       result
         ..add('edges')
-        ..add(serializers.serialize(object.edges,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(BuiltList, const [
               const FullType(
                   GHeroWithFragmentsData_hero_friendsConnection_edges)
@@ -197,7 +201,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnectionSerializer
 
   @override
   GHeroWithFragmentsData_hero_friendsConnection deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroWithFragmentsData_hero_friendsConnectionBuilder();
 
@@ -205,7 +209,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnectionSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -220,7 +224,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnectionSerializer
               specifiedType: const FullType(BuiltList, const [
                 const FullType(
                     GHeroWithFragmentsData_hero_friendsConnection_edges)
-              ])) as BuiltList<Object>);
+              ]))! as BuiltList<Object>);
           break;
       }
     }
@@ -242,18 +246,20 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edgesSerializer
   final String wireName = 'GHeroWithFragmentsData_hero_friendsConnection_edges';
 
   @override
-  Iterable<Object> serialize(Serializers serializers,
+  Iterable<Object?> serialize(Serializers serializers,
       GHeroWithFragmentsData_hero_friendsConnection_edges object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.node != null) {
+    Object? value;
+    value = object.node;
+    if (value != null) {
       result
         ..add('node')
-        ..add(serializers.serialize(object.node,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(
                 GHeroWithFragmentsData_hero_friendsConnection_edges_node)));
     }
@@ -262,7 +268,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edgesSerializer
 
   @override
   GHeroWithFragmentsData_hero_friendsConnection_edges deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result =
         new GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder();
@@ -271,7 +277,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edgesSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -280,7 +286,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edgesSerializer
         case 'node':
           result.node.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      GHeroWithFragmentsData_hero_friendsConnection_edges_node))
+                      GHeroWithFragmentsData_hero_friendsConnection_edges_node))!
               as GHeroWithFragmentsData_hero_friendsConnection_edges_node);
           break;
       }
@@ -304,10 +310,10 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges_nodeSerializer
       'GHeroWithFragmentsData_hero_friendsConnection_edges_node';
 
   @override
-  Iterable<Object> serialize(Serializers serializers,
+  Iterable<Object?> serialize(Serializers serializers,
       GHeroWithFragmentsData_hero_friendsConnection_edges_node object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -320,7 +326,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges_nodeSerializer
 
   @override
   GHeroWithFragmentsData_hero_friendsConnection_edges_node deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result =
         new GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder();
@@ -329,7 +335,7 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges_nodeSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -353,9 +359,9 @@ class _$GheroDataDataSerializer implements StructuredSerializer<GheroDataData> {
   final String wireName = 'GheroDataData';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GheroDataData object,
+  Iterable<Object?> serialize(Serializers serializers, GheroDataData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -368,7 +374,7 @@ class _$GheroDataDataSerializer implements StructuredSerializer<GheroDataData> {
 
   @override
   GheroDataData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GheroDataDataBuilder();
 
@@ -376,7 +382,7 @@ class _$GheroDataDataSerializer implements StructuredSerializer<GheroDataData> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -404,10 +410,10 @@ class _$GcomparisonFieldsDataSerializer
   final String wireName = 'GcomparisonFieldsData';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GcomparisonFieldsData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -426,7 +432,7 @@ class _$GcomparisonFieldsDataSerializer
 
   @override
   GcomparisonFieldsData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GcomparisonFieldsDataBuilder();
 
@@ -434,7 +440,7 @@ class _$GcomparisonFieldsDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -451,7 +457,7 @@ class _$GcomparisonFieldsDataSerializer
         case 'friendsConnection':
           result.friendsConnection.replace(serializers.deserialize(value,
                   specifiedType:
-                      const FullType(GcomparisonFieldsData_friendsConnection))
+                      const FullType(GcomparisonFieldsData_friendsConnection))!
               as GcomparisonFieldsData_friendsConnection);
           break;
       }
@@ -472,24 +478,26 @@ class _$GcomparisonFieldsData_friendsConnectionSerializer
   final String wireName = 'GcomparisonFieldsData_friendsConnection';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GcomparisonFieldsData_friendsConnection object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.totalCount != null) {
+    Object? value;
+    value = object.totalCount;
+    if (value != null) {
       result
         ..add('totalCount')
-        ..add(serializers.serialize(object.totalCount,
-            specifiedType: const FullType(int)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
     }
-    if (object.edges != null) {
+    value = object.edges;
+    if (value != null) {
       result
         ..add('edges')
-        ..add(serializers.serialize(object.edges,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(BuiltList, const [
               const FullType(GcomparisonFieldsData_friendsConnection_edges)
             ])));
@@ -499,7 +507,7 @@ class _$GcomparisonFieldsData_friendsConnectionSerializer
 
   @override
   GcomparisonFieldsData_friendsConnection deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GcomparisonFieldsData_friendsConnectionBuilder();
 
@@ -507,7 +515,7 @@ class _$GcomparisonFieldsData_friendsConnectionSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -521,7 +529,7 @@ class _$GcomparisonFieldsData_friendsConnectionSerializer
           result.edges.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltList, const [
                 const FullType(GcomparisonFieldsData_friendsConnection_edges)
-              ])) as BuiltList<Object>);
+              ]))! as BuiltList<Object>);
           break;
       }
     }
@@ -542,18 +550,20 @@ class _$GcomparisonFieldsData_friendsConnection_edgesSerializer
   final String wireName = 'GcomparisonFieldsData_friendsConnection_edges';
 
   @override
-  Iterable<Object> serialize(Serializers serializers,
+  Iterable<Object?> serialize(Serializers serializers,
       GcomparisonFieldsData_friendsConnection_edges object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.node != null) {
+    Object? value;
+    value = object.node;
+    if (value != null) {
       result
         ..add('node')
-        ..add(serializers.serialize(object.node,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(
                 GcomparisonFieldsData_friendsConnection_edges_node)));
     }
@@ -562,7 +572,7 @@ class _$GcomparisonFieldsData_friendsConnection_edgesSerializer
 
   @override
   GcomparisonFieldsData_friendsConnection_edges deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GcomparisonFieldsData_friendsConnection_edgesBuilder();
 
@@ -570,7 +580,7 @@ class _$GcomparisonFieldsData_friendsConnection_edgesSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -579,7 +589,7 @@ class _$GcomparisonFieldsData_friendsConnection_edgesSerializer
         case 'node':
           result.node.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      GcomparisonFieldsData_friendsConnection_edges_node))
+                      GcomparisonFieldsData_friendsConnection_edges_node))!
               as GcomparisonFieldsData_friendsConnection_edges_node);
           break;
       }
@@ -602,10 +612,10 @@ class _$GcomparisonFieldsData_friendsConnection_edges_nodeSerializer
   final String wireName = 'GcomparisonFieldsData_friendsConnection_edges_node';
 
   @override
-  Iterable<Object> serialize(Serializers serializers,
+  Iterable<Object?> serialize(Serializers serializers,
       GcomparisonFieldsData_friendsConnection_edges_node object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -618,7 +628,7 @@ class _$GcomparisonFieldsData_friendsConnection_edges_nodeSerializer
 
   @override
   GcomparisonFieldsData_friendsConnection_edges_node deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result =
         new GcomparisonFieldsData_friendsConnection_edges_nodeBuilder();
@@ -627,7 +637,7 @@ class _$GcomparisonFieldsData_friendsConnection_edges_nodeSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -648,17 +658,16 @@ class _$GHeroWithFragmentsData extends GHeroWithFragmentsData {
   @override
   final String G__typename;
   @override
-  final GHeroWithFragmentsData_hero hero;
+  final GHeroWithFragmentsData_hero? hero;
 
   factory _$GHeroWithFragmentsData(
-          [void Function(GHeroWithFragmentsDataBuilder) updates]) =>
+          [void Function(GHeroWithFragmentsDataBuilder)? updates]) =>
       (new GHeroWithFragmentsDataBuilder()..update(updates)).build();
 
-  _$GHeroWithFragmentsData._({this.G__typename, this.hero}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData', 'G__typename');
-    }
+  _$GHeroWithFragmentsData._({required this.G__typename, this.hero})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroWithFragmentsData', 'G__typename');
   }
 
   @override
@@ -694,25 +703,26 @@ class _$GHeroWithFragmentsData extends GHeroWithFragmentsData {
 
 class GHeroWithFragmentsDataBuilder
     implements Builder<GHeroWithFragmentsData, GHeroWithFragmentsDataBuilder> {
-  _$GHeroWithFragmentsData _$v;
+  _$GHeroWithFragmentsData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GHeroWithFragmentsData_heroBuilder _hero;
+  GHeroWithFragmentsData_heroBuilder? _hero;
   GHeroWithFragmentsData_heroBuilder get hero =>
       _$this._hero ??= new GHeroWithFragmentsData_heroBuilder();
-  set hero(GHeroWithFragmentsData_heroBuilder hero) => _$this._hero = hero;
+  set hero(GHeroWithFragmentsData_heroBuilder? hero) => _$this._hero = hero;
 
   GHeroWithFragmentsDataBuilder() {
     GHeroWithFragmentsData._initializeBuilder(this);
   }
 
   GHeroWithFragmentsDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _hero = _$v.hero?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _hero = $v.hero?.toBuilder();
       _$v = null;
     }
     return this;
@@ -720,14 +730,12 @@ class GHeroWithFragmentsDataBuilder
 
   @override
   void replace(GHeroWithFragmentsData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragmentsData;
   }
 
   @override
-  void update(void Function(GHeroWithFragmentsDataBuilder) updates) {
+  void update(void Function(GHeroWithFragmentsDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -737,9 +745,11 @@ class GHeroWithFragmentsDataBuilder
     try {
       _$result = _$v ??
           new _$GHeroWithFragmentsData._(
-              G__typename: G__typename, hero: _hero?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GHeroWithFragmentsData', 'G__typename'),
+              hero: _hero?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'hero';
         _hero?.build();
@@ -765,26 +775,23 @@ class _$GHeroWithFragmentsData_hero extends GHeroWithFragmentsData_hero {
   final GHeroWithFragmentsData_hero_friendsConnection friendsConnection;
 
   factory _$GHeroWithFragmentsData_hero(
-          [void Function(GHeroWithFragmentsData_heroBuilder) updates]) =>
+          [void Function(GHeroWithFragmentsData_heroBuilder)? updates]) =>
       (new GHeroWithFragmentsData_heroBuilder()..update(updates)).build();
 
   _$GHeroWithFragmentsData_hero._(
-      {this.G__typename, this.id, this.name, this.friendsConnection})
+      {required this.G__typename,
+      required this.id,
+      required this.name,
+      required this.friendsConnection})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData_hero', 'G__typename');
-    }
-    if (id == null) {
-      throw new BuiltValueNullFieldError('GHeroWithFragmentsData_hero', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GHeroWithFragmentsData_hero', 'name');
-    }
-    if (friendsConnection == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData_hero', 'friendsConnection');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroWithFragmentsData_hero', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        id, 'GHeroWithFragmentsData_hero', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GHeroWithFragmentsData_hero', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        friendsConnection, 'GHeroWithFragmentsData_hero', 'friendsConnection');
   }
 
   @override
@@ -828,26 +835,26 @@ class GHeroWithFragmentsData_heroBuilder
     implements
         Builder<GHeroWithFragmentsData_hero,
             GHeroWithFragmentsData_heroBuilder> {
-  _$GHeroWithFragmentsData_hero _$v;
+  _$GHeroWithFragmentsData_hero? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _id;
-  String get id => _$this._id;
-  set id(String id) => _$this._id = id;
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  GHeroWithFragmentsData_hero_friendsConnectionBuilder _friendsConnection;
+  GHeroWithFragmentsData_hero_friendsConnectionBuilder? _friendsConnection;
   GHeroWithFragmentsData_hero_friendsConnectionBuilder get friendsConnection =>
       _$this._friendsConnection ??=
           new GHeroWithFragmentsData_hero_friendsConnectionBuilder();
   set friendsConnection(
-          GHeroWithFragmentsData_hero_friendsConnectionBuilder
+          GHeroWithFragmentsData_hero_friendsConnectionBuilder?
               friendsConnection) =>
       _$this._friendsConnection = friendsConnection;
 
@@ -856,11 +863,12 @@ class GHeroWithFragmentsData_heroBuilder
   }
 
   GHeroWithFragmentsData_heroBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _id = _$v.id;
-      _name = _$v.name;
-      _friendsConnection = _$v.friendsConnection?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _id = $v.id;
+      _name = $v.name;
+      _friendsConnection = $v.friendsConnection.toBuilder();
       _$v = null;
     }
     return this;
@@ -868,14 +876,12 @@ class GHeroWithFragmentsData_heroBuilder
 
   @override
   void replace(GHeroWithFragmentsData_hero other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragmentsData_hero;
   }
 
   @override
-  void update(void Function(GHeroWithFragmentsData_heroBuilder) updates) {
+  void update(void Function(GHeroWithFragmentsData_heroBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -885,12 +891,15 @@ class GHeroWithFragmentsData_heroBuilder
     try {
       _$result = _$v ??
           new _$GHeroWithFragmentsData_hero._(
-              G__typename: G__typename,
-              id: id,
-              name: name,
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GHeroWithFragmentsData_hero', 'G__typename'),
+              id: BuiltValueNullFieldError.checkNotNull(
+                  id, 'GHeroWithFragmentsData_hero', 'id'),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'GHeroWithFragmentsData_hero', 'name'),
               friendsConnection: friendsConnection.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'friendsConnection';
         friendsConnection.build();
@@ -910,24 +919,22 @@ class _$GHeroWithFragmentsData_hero_friendsConnection
   @override
   final String G__typename;
   @override
-  final int totalCount;
+  final int? totalCount;
   @override
-  final BuiltList<GHeroWithFragmentsData_hero_friendsConnection_edges> edges;
+  final BuiltList<GHeroWithFragmentsData_hero_friendsConnection_edges>? edges;
 
   factory _$GHeroWithFragmentsData_hero_friendsConnection(
-          [void Function(GHeroWithFragmentsData_hero_friendsConnectionBuilder)
+          [void Function(GHeroWithFragmentsData_hero_friendsConnectionBuilder)?
               updates]) =>
       (new GHeroWithFragmentsData_hero_friendsConnectionBuilder()
             ..update(updates))
           .build();
 
   _$GHeroWithFragmentsData_hero_friendsConnection._(
-      {this.G__typename, this.totalCount, this.edges})
+      {required this.G__typename, this.totalCount, this.edges})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData_hero_friendsConnection', 'G__typename');
-    }
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        'GHeroWithFragmentsData_hero_friendsConnection', 'G__typename');
   }
 
   @override
@@ -970,23 +977,23 @@ class GHeroWithFragmentsData_hero_friendsConnectionBuilder
     implements
         Builder<GHeroWithFragmentsData_hero_friendsConnection,
             GHeroWithFragmentsData_hero_friendsConnectionBuilder> {
-  _$GHeroWithFragmentsData_hero_friendsConnection _$v;
+  _$GHeroWithFragmentsData_hero_friendsConnection? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  int _totalCount;
-  int get totalCount => _$this._totalCount;
-  set totalCount(int totalCount) => _$this._totalCount = totalCount;
+  int? _totalCount;
+  int? get totalCount => _$this._totalCount;
+  set totalCount(int? totalCount) => _$this._totalCount = totalCount;
 
-  ListBuilder<GHeroWithFragmentsData_hero_friendsConnection_edges> _edges;
+  ListBuilder<GHeroWithFragmentsData_hero_friendsConnection_edges>? _edges;
   ListBuilder<
       GHeroWithFragmentsData_hero_friendsConnection_edges> get edges => _$this
           ._edges ??=
       new ListBuilder<GHeroWithFragmentsData_hero_friendsConnection_edges>();
   set edges(
-          ListBuilder<GHeroWithFragmentsData_hero_friendsConnection_edges>
+          ListBuilder<GHeroWithFragmentsData_hero_friendsConnection_edges>?
               edges) =>
       _$this._edges = edges;
 
@@ -995,10 +1002,11 @@ class GHeroWithFragmentsData_hero_friendsConnectionBuilder
   }
 
   GHeroWithFragmentsData_hero_friendsConnectionBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _totalCount = _$v.totalCount;
-      _edges = _$v.edges?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _totalCount = $v.totalCount;
+      _edges = $v.edges?.toBuilder();
       _$v = null;
     }
     return this;
@@ -1006,15 +1014,13 @@ class GHeroWithFragmentsData_hero_friendsConnectionBuilder
 
   @override
   void replace(GHeroWithFragmentsData_hero_friendsConnection other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragmentsData_hero_friendsConnection;
   }
 
   @override
   void update(
-      void Function(GHeroWithFragmentsData_hero_friendsConnectionBuilder)
+      void Function(GHeroWithFragmentsData_hero_friendsConnectionBuilder)?
           updates) {
     if (updates != null) updates(this);
   }
@@ -1025,11 +1031,14 @@ class GHeroWithFragmentsData_hero_friendsConnectionBuilder
     try {
       _$result = _$v ??
           new _$GHeroWithFragmentsData_hero_friendsConnection._(
-              G__typename: G__typename,
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename,
+                  'GHeroWithFragmentsData_hero_friendsConnection',
+                  'G__typename'),
               totalCount: totalCount,
               edges: _edges?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'edges';
         _edges?.build();
@@ -1051,23 +1060,21 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges
   @override
   final String G__typename;
   @override
-  final GHeroWithFragmentsData_hero_friendsConnection_edges_node node;
+  final GHeroWithFragmentsData_hero_friendsConnection_edges_node? node;
 
   factory _$GHeroWithFragmentsData_hero_friendsConnection_edges(
           [void Function(
-                  GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder)
+                  GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder)?
               updates]) =>
       (new GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder()
             ..update(updates))
           .build();
 
   _$GHeroWithFragmentsData_hero_friendsConnection_edges._(
-      {this.G__typename, this.node})
+      {required this.G__typename, this.node})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData_hero_friendsConnection_edges', 'G__typename');
-    }
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        'GHeroWithFragmentsData_hero_friendsConnection_edges', 'G__typename');
   }
 
   @override
@@ -1109,18 +1116,18 @@ class GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder
     implements
         Builder<GHeroWithFragmentsData_hero_friendsConnection_edges,
             GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder> {
-  _$GHeroWithFragmentsData_hero_friendsConnection_edges _$v;
+  _$GHeroWithFragmentsData_hero_friendsConnection_edges? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder _node;
+  GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder? _node;
   GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder get node =>
       _$this._node ??=
           new GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder();
   set node(
-          GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder
+          GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder?
               node) =>
       _$this._node = node;
 
@@ -1130,9 +1137,10 @@ class GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder
   }
 
   GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _node = _$v.node?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _node = $v.node?.toBuilder();
       _$v = null;
     }
     return this;
@@ -1140,15 +1148,13 @@ class GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder
 
   @override
   void replace(GHeroWithFragmentsData_hero_friendsConnection_edges other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragmentsData_hero_friendsConnection_edges;
   }
 
   @override
   void update(
-      void Function(GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder)
+      void Function(GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder)?
           updates) {
     if (updates != null) updates(this);
   }
@@ -1159,9 +1165,13 @@ class GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder
     try {
       _$result = _$v ??
           new _$GHeroWithFragmentsData_hero_friendsConnection_edges._(
-              G__typename: G__typename, node: _node?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename,
+                  'GHeroWithFragmentsData_hero_friendsConnection_edges',
+                  'G__typename'),
+              node: _node?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'node';
         _node?.build();
@@ -1187,24 +1197,21 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges_node
 
   factory _$GHeroWithFragmentsData_hero_friendsConnection_edges_node(
           [void Function(
-                  GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder)
+                  GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder)?
               updates]) =>
       (new GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder()
             ..update(updates))
           .build();
 
   _$GHeroWithFragmentsData_hero_friendsConnection_edges_node._(
-      {this.G__typename, this.name})
+      {required this.G__typename, required this.name})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData_hero_friendsConnection_edges_node',
-          'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroWithFragmentsData_hero_friendsConnection_edges_node', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename,
+        'GHeroWithFragmentsData_hero_friendsConnection_edges_node',
+        'G__typename');
+    BuiltValueNullFieldError.checkNotNull(name,
+        'GHeroWithFragmentsData_hero_friendsConnection_edges_node', 'name');
   }
 
   @override
@@ -1246,15 +1253,15 @@ class GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder
     implements
         Builder<GHeroWithFragmentsData_hero_friendsConnection_edges_node,
             GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder> {
-  _$GHeroWithFragmentsData_hero_friendsConnection_edges_node _$v;
+  _$GHeroWithFragmentsData_hero_friendsConnection_edges_node? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder() {
     GHeroWithFragmentsData_hero_friendsConnection_edges_node._initializeBuilder(
@@ -1262,9 +1269,10 @@ class GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder
   }
 
   GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -1272,16 +1280,14 @@ class GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder
 
   @override
   void replace(GHeroWithFragmentsData_hero_friendsConnection_edges_node other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragmentsData_hero_friendsConnection_edges_node;
   }
 
   @override
   void update(
       void Function(
-              GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder)
+              GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder)?
           updates) {
     if (updates != null) updates(this);
   }
@@ -1290,7 +1296,14 @@ class GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder
   _$GHeroWithFragmentsData_hero_friendsConnection_edges_node build() {
     final _$result = _$v ??
         new _$GHeroWithFragmentsData_hero_friendsConnection_edges_node._(
-            G__typename: G__typename, name: name);
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                'GHeroWithFragmentsData_hero_friendsConnection_edges_node',
+                'G__typename'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name,
+                'GHeroWithFragmentsData_hero_friendsConnection_edges_node',
+                'name'));
     replace(_$result);
     return _$result;
   }
@@ -1302,16 +1315,14 @@ class _$GheroDataData extends GheroDataData {
   @override
   final String name;
 
-  factory _$GheroDataData([void Function(GheroDataDataBuilder) updates]) =>
+  factory _$GheroDataData([void Function(GheroDataDataBuilder)? updates]) =>
       (new GheroDataDataBuilder()..update(updates)).build();
 
-  _$GheroDataData._({this.G__typename, this.name}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GheroDataData', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GheroDataData', 'name');
-    }
+  _$GheroDataData._({required this.G__typename, required this.name})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GheroDataData', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(name, 'GheroDataData', 'name');
   }
 
   @override
@@ -1345,24 +1356,25 @@ class _$GheroDataData extends GheroDataData {
 
 class GheroDataDataBuilder
     implements Builder<GheroDataData, GheroDataDataBuilder> {
-  _$GheroDataData _$v;
+  _$GheroDataData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GheroDataDataBuilder() {
     GheroDataData._initializeBuilder(this);
   }
 
   GheroDataDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -1370,21 +1382,23 @@ class GheroDataDataBuilder
 
   @override
   void replace(GheroDataData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GheroDataData;
   }
 
   @override
-  void update(void Function(GheroDataDataBuilder) updates) {
+  void update(void Function(GheroDataDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GheroDataData build() {
-    final _$result =
-        _$v ?? new _$GheroDataData._(G__typename: G__typename, name: name);
+    final _$result = _$v ??
+        new _$GheroDataData._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, 'GheroDataData', 'G__typename'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, 'GheroDataData', 'name'));
     replace(_$result);
     return _$result;
   }
@@ -1401,26 +1415,22 @@ class _$GcomparisonFieldsData extends GcomparisonFieldsData {
   final GcomparisonFieldsData_friendsConnection friendsConnection;
 
   factory _$GcomparisonFieldsData(
-          [void Function(GcomparisonFieldsDataBuilder) updates]) =>
+          [void Function(GcomparisonFieldsDataBuilder)? updates]) =>
       (new GcomparisonFieldsDataBuilder()..update(updates)).build();
 
   _$GcomparisonFieldsData._(
-      {this.G__typename, this.id, this.name, this.friendsConnection})
+      {required this.G__typename,
+      required this.id,
+      required this.name,
+      required this.friendsConnection})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GcomparisonFieldsData', 'G__typename');
-    }
-    if (id == null) {
-      throw new BuiltValueNullFieldError('GcomparisonFieldsData', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GcomparisonFieldsData', 'name');
-    }
-    if (friendsConnection == null) {
-      throw new BuiltValueNullFieldError(
-          'GcomparisonFieldsData', 'friendsConnection');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GcomparisonFieldsData', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(id, 'GcomparisonFieldsData', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GcomparisonFieldsData', 'name');
+    BuiltValueNullFieldError.checkNotNull(
+        friendsConnection, 'GcomparisonFieldsData', 'friendsConnection');
   }
 
   @override
@@ -1462,26 +1472,26 @@ class _$GcomparisonFieldsData extends GcomparisonFieldsData {
 
 class GcomparisonFieldsDataBuilder
     implements Builder<GcomparisonFieldsData, GcomparisonFieldsDataBuilder> {
-  _$GcomparisonFieldsData _$v;
+  _$GcomparisonFieldsData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _id;
-  String get id => _$this._id;
-  set id(String id) => _$this._id = id;
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  GcomparisonFieldsData_friendsConnectionBuilder _friendsConnection;
+  GcomparisonFieldsData_friendsConnectionBuilder? _friendsConnection;
   GcomparisonFieldsData_friendsConnectionBuilder get friendsConnection =>
       _$this._friendsConnection ??=
           new GcomparisonFieldsData_friendsConnectionBuilder();
   set friendsConnection(
-          GcomparisonFieldsData_friendsConnectionBuilder friendsConnection) =>
+          GcomparisonFieldsData_friendsConnectionBuilder? friendsConnection) =>
       _$this._friendsConnection = friendsConnection;
 
   GcomparisonFieldsDataBuilder() {
@@ -1489,11 +1499,12 @@ class GcomparisonFieldsDataBuilder
   }
 
   GcomparisonFieldsDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _id = _$v.id;
-      _name = _$v.name;
-      _friendsConnection = _$v.friendsConnection?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _id = $v.id;
+      _name = $v.name;
+      _friendsConnection = $v.friendsConnection.toBuilder();
       _$v = null;
     }
     return this;
@@ -1501,14 +1512,12 @@ class GcomparisonFieldsDataBuilder
 
   @override
   void replace(GcomparisonFieldsData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GcomparisonFieldsData;
   }
 
   @override
-  void update(void Function(GcomparisonFieldsDataBuilder) updates) {
+  void update(void Function(GcomparisonFieldsDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -1518,12 +1527,15 @@ class GcomparisonFieldsDataBuilder
     try {
       _$result = _$v ??
           new _$GcomparisonFieldsData._(
-              G__typename: G__typename,
-              id: id,
-              name: name,
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GcomparisonFieldsData', 'G__typename'),
+              id: BuiltValueNullFieldError.checkNotNull(
+                  id, 'GcomparisonFieldsData', 'id'),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'GcomparisonFieldsData', 'name'),
               friendsConnection: friendsConnection.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'friendsConnection';
         friendsConnection.build();
@@ -1543,23 +1555,21 @@ class _$GcomparisonFieldsData_friendsConnection
   @override
   final String G__typename;
   @override
-  final int totalCount;
+  final int? totalCount;
   @override
-  final BuiltList<GcomparisonFieldsData_friendsConnection_edges> edges;
+  final BuiltList<GcomparisonFieldsData_friendsConnection_edges>? edges;
 
   factory _$GcomparisonFieldsData_friendsConnection(
-          [void Function(GcomparisonFieldsData_friendsConnectionBuilder)
+          [void Function(GcomparisonFieldsData_friendsConnectionBuilder)?
               updates]) =>
       (new GcomparisonFieldsData_friendsConnectionBuilder()..update(updates))
           .build();
 
   _$GcomparisonFieldsData_friendsConnection._(
-      {this.G__typename, this.totalCount, this.edges})
+      {required this.G__typename, this.totalCount, this.edges})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GcomparisonFieldsData_friendsConnection', 'G__typename');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GcomparisonFieldsData_friendsConnection', 'G__typename');
   }
 
   @override
@@ -1602,21 +1612,22 @@ class GcomparisonFieldsData_friendsConnectionBuilder
     implements
         Builder<GcomparisonFieldsData_friendsConnection,
             GcomparisonFieldsData_friendsConnectionBuilder> {
-  _$GcomparisonFieldsData_friendsConnection _$v;
+  _$GcomparisonFieldsData_friendsConnection? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  int _totalCount;
-  int get totalCount => _$this._totalCount;
-  set totalCount(int totalCount) => _$this._totalCount = totalCount;
+  int? _totalCount;
+  int? get totalCount => _$this._totalCount;
+  set totalCount(int? totalCount) => _$this._totalCount = totalCount;
 
-  ListBuilder<GcomparisonFieldsData_friendsConnection_edges> _edges;
+  ListBuilder<GcomparisonFieldsData_friendsConnection_edges>? _edges;
   ListBuilder<GcomparisonFieldsData_friendsConnection_edges> get edges =>
       _$this._edges ??=
           new ListBuilder<GcomparisonFieldsData_friendsConnection_edges>();
-  set edges(ListBuilder<GcomparisonFieldsData_friendsConnection_edges> edges) =>
+  set edges(
+          ListBuilder<GcomparisonFieldsData_friendsConnection_edges>? edges) =>
       _$this._edges = edges;
 
   GcomparisonFieldsData_friendsConnectionBuilder() {
@@ -1624,10 +1635,11 @@ class GcomparisonFieldsData_friendsConnectionBuilder
   }
 
   GcomparisonFieldsData_friendsConnectionBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _totalCount = _$v.totalCount;
-      _edges = _$v.edges?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _totalCount = $v.totalCount;
+      _edges = $v.edges?.toBuilder();
       _$v = null;
     }
     return this;
@@ -1635,15 +1647,13 @@ class GcomparisonFieldsData_friendsConnectionBuilder
 
   @override
   void replace(GcomparisonFieldsData_friendsConnection other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GcomparisonFieldsData_friendsConnection;
   }
 
   @override
   void update(
-      void Function(GcomparisonFieldsData_friendsConnectionBuilder) updates) {
+      void Function(GcomparisonFieldsData_friendsConnectionBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -1653,11 +1663,12 @@ class GcomparisonFieldsData_friendsConnectionBuilder
     try {
       _$result = _$v ??
           new _$GcomparisonFieldsData_friendsConnection._(
-              G__typename: G__typename,
+              G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                  'GcomparisonFieldsData_friendsConnection', 'G__typename'),
               totalCount: totalCount,
               edges: _edges?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'edges';
         _edges?.build();
@@ -1679,22 +1690,20 @@ class _$GcomparisonFieldsData_friendsConnection_edges
   @override
   final String G__typename;
   @override
-  final GcomparisonFieldsData_friendsConnection_edges_node node;
+  final GcomparisonFieldsData_friendsConnection_edges_node? node;
 
   factory _$GcomparisonFieldsData_friendsConnection_edges(
-          [void Function(GcomparisonFieldsData_friendsConnection_edgesBuilder)
+          [void Function(GcomparisonFieldsData_friendsConnection_edgesBuilder)?
               updates]) =>
       (new GcomparisonFieldsData_friendsConnection_edgesBuilder()
             ..update(updates))
           .build();
 
   _$GcomparisonFieldsData_friendsConnection_edges._(
-      {this.G__typename, this.node})
+      {required this.G__typename, this.node})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GcomparisonFieldsData_friendsConnection_edges', 'G__typename');
-    }
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        'GcomparisonFieldsData_friendsConnection_edges', 'G__typename');
   }
 
   @override
@@ -1734,17 +1743,17 @@ class GcomparisonFieldsData_friendsConnection_edgesBuilder
     implements
         Builder<GcomparisonFieldsData_friendsConnection_edges,
             GcomparisonFieldsData_friendsConnection_edgesBuilder> {
-  _$GcomparisonFieldsData_friendsConnection_edges _$v;
+  _$GcomparisonFieldsData_friendsConnection_edges? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GcomparisonFieldsData_friendsConnection_edges_nodeBuilder _node;
+  GcomparisonFieldsData_friendsConnection_edges_nodeBuilder? _node;
   GcomparisonFieldsData_friendsConnection_edges_nodeBuilder get node =>
       _$this._node ??=
           new GcomparisonFieldsData_friendsConnection_edges_nodeBuilder();
-  set node(GcomparisonFieldsData_friendsConnection_edges_nodeBuilder node) =>
+  set node(GcomparisonFieldsData_friendsConnection_edges_nodeBuilder? node) =>
       _$this._node = node;
 
   GcomparisonFieldsData_friendsConnection_edgesBuilder() {
@@ -1752,9 +1761,10 @@ class GcomparisonFieldsData_friendsConnection_edgesBuilder
   }
 
   GcomparisonFieldsData_friendsConnection_edgesBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _node = _$v.node?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _node = $v.node?.toBuilder();
       _$v = null;
     }
     return this;
@@ -1762,15 +1772,13 @@ class GcomparisonFieldsData_friendsConnection_edgesBuilder
 
   @override
   void replace(GcomparisonFieldsData_friendsConnection_edges other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GcomparisonFieldsData_friendsConnection_edges;
   }
 
   @override
   void update(
-      void Function(GcomparisonFieldsData_friendsConnection_edgesBuilder)
+      void Function(GcomparisonFieldsData_friendsConnection_edgesBuilder)?
           updates) {
     if (updates != null) updates(this);
   }
@@ -1781,9 +1789,13 @@ class GcomparisonFieldsData_friendsConnection_edgesBuilder
     try {
       _$result = _$v ??
           new _$GcomparisonFieldsData_friendsConnection_edges._(
-              G__typename: G__typename, node: _node?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename,
+                  'GcomparisonFieldsData_friendsConnection_edges',
+                  'G__typename'),
+              node: _node?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'node';
         _node?.build();
@@ -1809,23 +1821,19 @@ class _$GcomparisonFieldsData_friendsConnection_edges_node
 
   factory _$GcomparisonFieldsData_friendsConnection_edges_node(
           [void Function(
-                  GcomparisonFieldsData_friendsConnection_edges_nodeBuilder)
+                  GcomparisonFieldsData_friendsConnection_edges_nodeBuilder)?
               updates]) =>
       (new GcomparisonFieldsData_friendsConnection_edges_nodeBuilder()
             ..update(updates))
           .build();
 
   _$GcomparisonFieldsData_friendsConnection_edges_node._(
-      {this.G__typename, this.name})
+      {required this.G__typename, required this.name})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GcomparisonFieldsData_friendsConnection_edges_node', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError(
-          'GcomparisonFieldsData_friendsConnection_edges_node', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        'GcomparisonFieldsData_friendsConnection_edges_node', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GcomparisonFieldsData_friendsConnection_edges_node', 'name');
   }
 
   @override
@@ -1867,24 +1875,25 @@ class GcomparisonFieldsData_friendsConnection_edges_nodeBuilder
     implements
         Builder<GcomparisonFieldsData_friendsConnection_edges_node,
             GcomparisonFieldsData_friendsConnection_edges_nodeBuilder> {
-  _$GcomparisonFieldsData_friendsConnection_edges_node _$v;
+  _$GcomparisonFieldsData_friendsConnection_edges_node? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GcomparisonFieldsData_friendsConnection_edges_nodeBuilder() {
     GcomparisonFieldsData_friendsConnection_edges_node._initializeBuilder(this);
   }
 
   GcomparisonFieldsData_friendsConnection_edges_nodeBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -1892,15 +1901,13 @@ class GcomparisonFieldsData_friendsConnection_edges_nodeBuilder
 
   @override
   void replace(GcomparisonFieldsData_friendsConnection_edges_node other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GcomparisonFieldsData_friendsConnection_edges_node;
   }
 
   @override
   void update(
-      void Function(GcomparisonFieldsData_friendsConnection_edges_nodeBuilder)
+      void Function(GcomparisonFieldsData_friendsConnection_edges_nodeBuilder)?
           updates) {
     if (updates != null) updates(this);
   }
@@ -1909,7 +1916,12 @@ class GcomparisonFieldsData_friendsConnection_edges_nodeBuilder
   _$GcomparisonFieldsData_friendsConnection_edges_node build() {
     final _$result = _$v ??
         new _$GcomparisonFieldsData_friendsConnection_edges_node._(
-            G__typename: G__typename, name: name);
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                'GcomparisonFieldsData_friendsConnection_edges_node',
+                'G__typename'),
+            name: BuiltValueNullFieldError.checkNotNull(name,
+                'GcomparisonFieldsData_friendsConnection_edges_node', 'name'));
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/fragments/hero_with_fragments.req.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/hero_with_fragments.req.gql.dart
@@ -26,7 +26,8 @@ abstract class GHeroWithFragments
   static Serializer<GHeroWithFragments> get serializer =>
       _$gHeroWithFragmentsSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GHeroWithFragments.serializer, this);
-  static GHeroWithFragments fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GHeroWithFragments.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroWithFragments? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GHeroWithFragments.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/fragments/hero_with_fragments.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/hero_with_fragments.req.gql.g.dart
@@ -17,9 +17,10 @@ class _$GHeroWithFragmentsSerializer
   final String wireName = 'GHeroWithFragments';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHeroWithFragments object,
+  Iterable<Object?> serialize(
+      Serializers serializers, GHeroWithFragments object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GHeroWithFragmentsVars)),
@@ -33,7 +34,7 @@ class _$GHeroWithFragmentsSerializer
 
   @override
   GHeroWithFragments deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroWithFragmentsBuilder();
 
@@ -41,11 +42,11 @@ class _$GHeroWithFragmentsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GHeroWithFragmentsVars))
+                  specifiedType: const FullType(_i3.GHeroWithFragmentsVars))!
               as _i3.GHeroWithFragmentsVars);
           break;
         case 'operation':
@@ -66,16 +67,14 @@ class _$GHeroWithFragments extends GHeroWithFragments {
   final _i1.Operation operation;
 
   factory _$GHeroWithFragments(
-          [void Function(GHeroWithFragmentsBuilder) updates]) =>
+          [void Function(GHeroWithFragmentsBuilder)? updates]) =>
       (new GHeroWithFragmentsBuilder()..update(updates)).build();
 
-  _$GHeroWithFragments._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GHeroWithFragments', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GHeroWithFragments', 'operation');
-    }
+  _$GHeroWithFragments._({required this.vars, required this.operation})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GHeroWithFragments', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GHeroWithFragments', 'operation');
   }
 
   @override
@@ -111,25 +110,26 @@ class _$GHeroWithFragments extends GHeroWithFragments {
 
 class GHeroWithFragmentsBuilder
     implements Builder<GHeroWithFragments, GHeroWithFragmentsBuilder> {
-  _$GHeroWithFragments _$v;
+  _$GHeroWithFragments? _$v;
 
-  _i3.GHeroWithFragmentsVarsBuilder _vars;
+  _i3.GHeroWithFragmentsVarsBuilder? _vars;
   _i3.GHeroWithFragmentsVarsBuilder get vars =>
       _$this._vars ??= new _i3.GHeroWithFragmentsVarsBuilder();
-  set vars(_i3.GHeroWithFragmentsVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GHeroWithFragmentsVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GHeroWithFragmentsBuilder() {
     GHeroWithFragments._initializeBuilder(this);
   }
 
   GHeroWithFragmentsBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -137,14 +137,12 @@ class GHeroWithFragmentsBuilder
 
   @override
   void replace(GHeroWithFragments other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragments;
   }
 
   @override
-  void update(void Function(GHeroWithFragmentsBuilder) updates) {
+  void update(void Function(GHeroWithFragmentsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -153,9 +151,12 @@ class GHeroWithFragmentsBuilder
     _$GHeroWithFragments _$result;
     try {
       _$result = _$v ??
-          new _$GHeroWithFragments._(vars: vars.build(), operation: operation);
+          new _$GHeroWithFragments._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GHeroWithFragments', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/fragments/hero_with_fragments.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/hero_with_fragments.var.gql.dart
@@ -14,13 +14,13 @@ abstract class GHeroWithFragmentsVars
           [Function(GHeroWithFragmentsVarsBuilder b) updates]) =
       _$GHeroWithFragmentsVars;
 
-  @nullable
-  int get first;
+  int? get first;
   static Serializer<GHeroWithFragmentsVars> get serializer =>
       _$gHeroWithFragmentsVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroWithFragmentsVars.serializer, this);
-  static GHeroWithFragmentsVars fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroWithFragmentsVars.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroWithFragmentsVars? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHeroWithFragmentsVars.serializer, json);
 }
 
@@ -33,8 +33,9 @@ abstract class GheroDataVars
 
   static Serializer<GheroDataVars> get serializer => _$gheroDataVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GheroDataVars.serializer, this);
-  static GheroDataVars fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GheroDataVars.serializer, this)
+          as Map<String, dynamic>);
+  static GheroDataVars? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GheroDataVars.serializer, json);
 }
 
@@ -46,12 +47,12 @@ abstract class GcomparisonFieldsVars
           [Function(GcomparisonFieldsVarsBuilder b) updates]) =
       _$GcomparisonFieldsVars;
 
-  @nullable
-  int get first;
+  int? get first;
   static Serializer<GcomparisonFieldsVars> get serializer =>
       _$gcomparisonFieldsVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GcomparisonFieldsVars.serializer, this);
-  static GcomparisonFieldsVars fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GcomparisonFieldsVars.serializer, this)
+          as Map<String, dynamic>);
+  static GcomparisonFieldsVars? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GcomparisonFieldsVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/fragments/hero_with_fragments.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/hero_with_fragments.var.gql.g.dart
@@ -24,22 +24,23 @@ class _$GHeroWithFragmentsVarsSerializer
   final String wireName = 'GHeroWithFragmentsVars';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroWithFragmentsVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[];
-    if (object.first != null) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.first;
+    if (value != null) {
       result
         ..add('first')
-        ..add(serializers.serialize(object.first,
-            specifiedType: const FullType(int)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
     }
     return result;
   }
 
   @override
   GHeroWithFragmentsVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroWithFragmentsVarsBuilder();
 
@@ -47,7 +48,7 @@ class _$GHeroWithFragmentsVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'first':
           result.first = serializers.deserialize(value,
@@ -67,14 +68,14 @@ class _$GheroDataVarsSerializer implements StructuredSerializer<GheroDataVars> {
   final String wireName = 'GheroDataVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GheroDataVars object,
+  Iterable<Object?> serialize(Serializers serializers, GheroDataVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    return <Object>[];
+    return <Object?>[];
   }
 
   @override
   GheroDataVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     return new GheroDataVarsBuilder().build();
   }
@@ -91,22 +92,23 @@ class _$GcomparisonFieldsVarsSerializer
   final String wireName = 'GcomparisonFieldsVars';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GcomparisonFieldsVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[];
-    if (object.first != null) {
+    final result = <Object?>[];
+    Object? value;
+    value = object.first;
+    if (value != null) {
       result
         ..add('first')
-        ..add(serializers.serialize(object.first,
-            specifiedType: const FullType(int)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
     }
     return result;
   }
 
   @override
   GcomparisonFieldsVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GcomparisonFieldsVarsBuilder();
 
@@ -114,7 +116,7 @@ class _$GcomparisonFieldsVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'first':
           result.first = serializers.deserialize(value,
@@ -129,10 +131,10 @@ class _$GcomparisonFieldsVarsSerializer
 
 class _$GHeroWithFragmentsVars extends GHeroWithFragmentsVars {
   @override
-  final int first;
+  final int? first;
 
   factory _$GHeroWithFragmentsVars(
-          [void Function(GHeroWithFragmentsVarsBuilder) updates]) =>
+          [void Function(GHeroWithFragmentsVarsBuilder)? updates]) =>
       (new GHeroWithFragmentsVarsBuilder()..update(updates)).build();
 
   _$GHeroWithFragmentsVars._({this.first}) : super._();
@@ -167,17 +169,18 @@ class _$GHeroWithFragmentsVars extends GHeroWithFragmentsVars {
 
 class GHeroWithFragmentsVarsBuilder
     implements Builder<GHeroWithFragmentsVars, GHeroWithFragmentsVarsBuilder> {
-  _$GHeroWithFragmentsVars _$v;
+  _$GHeroWithFragmentsVars? _$v;
 
-  int _first;
-  int get first => _$this._first;
-  set first(int first) => _$this._first = first;
+  int? _first;
+  int? get first => _$this._first;
+  set first(int? first) => _$this._first = first;
 
   GHeroWithFragmentsVarsBuilder();
 
   GHeroWithFragmentsVarsBuilder get _$this {
-    if (_$v != null) {
-      _first = _$v.first;
+    final $v = _$v;
+    if ($v != null) {
+      _first = $v.first;
       _$v = null;
     }
     return this;
@@ -185,14 +188,12 @@ class GHeroWithFragmentsVarsBuilder
 
   @override
   void replace(GHeroWithFragmentsVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroWithFragmentsVars;
   }
 
   @override
-  void update(void Function(GHeroWithFragmentsVarsBuilder) updates) {
+  void update(void Function(GHeroWithFragmentsVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -205,7 +206,7 @@ class GHeroWithFragmentsVarsBuilder
 }
 
 class _$GheroDataVars extends GheroDataVars {
-  factory _$GheroDataVars([void Function(GheroDataVarsBuilder) updates]) =>
+  factory _$GheroDataVars([void Function(GheroDataVarsBuilder)? updates]) =>
       (new GheroDataVarsBuilder()..update(updates)).build();
 
   _$GheroDataVars._() : super._();
@@ -236,20 +237,18 @@ class _$GheroDataVars extends GheroDataVars {
 
 class GheroDataVarsBuilder
     implements Builder<GheroDataVars, GheroDataVarsBuilder> {
-  _$GheroDataVars _$v;
+  _$GheroDataVars? _$v;
 
   GheroDataVarsBuilder();
 
   @override
   void replace(GheroDataVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GheroDataVars;
   }
 
   @override
-  void update(void Function(GheroDataVarsBuilder) updates) {
+  void update(void Function(GheroDataVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -263,10 +262,10 @@ class GheroDataVarsBuilder
 
 class _$GcomparisonFieldsVars extends GcomparisonFieldsVars {
   @override
-  final int first;
+  final int? first;
 
   factory _$GcomparisonFieldsVars(
-          [void Function(GcomparisonFieldsVarsBuilder) updates]) =>
+          [void Function(GcomparisonFieldsVarsBuilder)? updates]) =>
       (new GcomparisonFieldsVarsBuilder()..update(updates)).build();
 
   _$GcomparisonFieldsVars._({this.first}) : super._();
@@ -301,17 +300,18 @@ class _$GcomparisonFieldsVars extends GcomparisonFieldsVars {
 
 class GcomparisonFieldsVarsBuilder
     implements Builder<GcomparisonFieldsVars, GcomparisonFieldsVarsBuilder> {
-  _$GcomparisonFieldsVars _$v;
+  _$GcomparisonFieldsVars? _$v;
 
-  int _first;
-  int get first => _$this._first;
-  set first(int first) => _$this._first = first;
+  int? _first;
+  int? get first => _$this._first;
+  set first(int? first) => _$this._first = first;
 
   GcomparisonFieldsVarsBuilder();
 
   GcomparisonFieldsVarsBuilder get _$this {
-    if (_$v != null) {
-      _first = _$v.first;
+    final $v = _$v;
+    if ($v != null) {
+      _first = $v.first;
       _$v = null;
     }
     return this;
@@ -319,14 +319,12 @@ class GcomparisonFieldsVarsBuilder
 
   @override
   void replace(GcomparisonFieldsVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GcomparisonFieldsVars;
   }
 
   @override
-  void update(void Function(GcomparisonFieldsVarsBuilder) updates) {
+  void update(void Function(GcomparisonFieldsVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 

--- a/codegen/end_to_end_test/lib/graphql/schema.schema.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/schema.schema.gql.dart
@@ -44,16 +44,14 @@ abstract class GReviewInput
       _$GReviewInput;
 
   int get stars;
-  @nullable
-  String get commentary;
-  @nullable
-  GColorInput get favorite_color;
-  @nullable
-  BuiltList<DateTime> get seenOn;
+  String? get commentary;
+  GColorInput? get favorite_color;
+  BuiltList<DateTime>? get seenOn;
   static Serializer<GReviewInput> get serializer => _$gReviewInputSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GReviewInput.serializer, this);
-  static GReviewInput fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GReviewInput.serializer, this)
+          as Map<String, dynamic>);
+  static GReviewInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GReviewInput.serializer, json);
 }
 
@@ -67,20 +65,21 @@ abstract class GColorInput implements Built<GColorInput, GColorInputBuilder> {
   int get blue;
   static Serializer<GColorInput> get serializer => _$gColorInputSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GColorInput.serializer, this);
-  static GColorInput fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GColorInput.serializer, this)
+          as Map<String, dynamic>);
+  static GColorInput? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GColorInput.serializer, json);
 }
 
 abstract class GISODate implements Built<GISODate, GISODateBuilder> {
   GISODate._();
 
-  factory GISODate([String value]) =>
+  factory GISODate([String? value]) =>
       _$GISODate((b) => value != null ? (b..value = value) : b);
 
   String get value;
   @BuiltValueSerializer(custom: true)
   static Serializer<GISODate> get serializer =>
       _i2.DefaultScalarSerializer<GISODate>(
-          (Object serialized) => GISODate(serialized));
+          (Object serialized) => GISODate((serialized as String?)));
 }

--- a/codegen/end_to_end_test/lib/graphql/schema.schema.gql.g.dart
+++ b/codegen/end_to_end_test/lib/graphql/schema.schema.gql.g.dart
@@ -104,28 +104,32 @@ class _$GReviewInputSerializer implements StructuredSerializer<GReviewInput> {
   final String wireName = 'GReviewInput';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GReviewInput object,
+  Iterable<Object?> serialize(Serializers serializers, GReviewInput object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'stars',
       serializers.serialize(object.stars, specifiedType: const FullType(int)),
     ];
-    if (object.commentary != null) {
+    Object? value;
+    value = object.commentary;
+    if (value != null) {
       result
         ..add('commentary')
-        ..add(serializers.serialize(object.commentary,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
-    if (object.favorite_color != null) {
+    value = object.favorite_color;
+    if (value != null) {
       result
         ..add('favorite_color')
-        ..add(serializers.serialize(object.favorite_color,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GColorInput)));
     }
-    if (object.seenOn != null) {
+    value = object.seenOn;
+    if (value != null) {
       result
         ..add('seenOn')
-        ..add(serializers.serialize(object.seenOn,
+        ..add(serializers.serialize(value,
             specifiedType:
                 const FullType(BuiltList, const [const FullType(DateTime)])));
     }
@@ -133,7 +137,8 @@ class _$GReviewInputSerializer implements StructuredSerializer<GReviewInput> {
   }
 
   @override
-  GReviewInput deserialize(Serializers serializers, Iterable<Object> serialized,
+  GReviewInput deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GReviewInputBuilder();
 
@@ -141,7 +146,7 @@ class _$GReviewInputSerializer implements StructuredSerializer<GReviewInput> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'stars':
           result.stars = serializers.deserialize(value,
@@ -153,12 +158,12 @@ class _$GReviewInputSerializer implements StructuredSerializer<GReviewInput> {
           break;
         case 'favorite_color':
           result.favorite_color.replace(serializers.deserialize(value,
-              specifiedType: const FullType(GColorInput)) as GColorInput);
+              specifiedType: const FullType(GColorInput))! as GColorInput);
           break;
         case 'seenOn':
           result.seenOn.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      BuiltList, const [const FullType(DateTime)]))
+                      BuiltList, const [const FullType(DateTime)]))!
               as BuiltList<Object>);
           break;
       }
@@ -175,9 +180,9 @@ class _$GColorInputSerializer implements StructuredSerializer<GColorInput> {
   final String wireName = 'GColorInput';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GColorInput object,
+  Iterable<Object?> serialize(Serializers serializers, GColorInput object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'red',
       serializers.serialize(object.red, specifiedType: const FullType(int)),
       'green',
@@ -190,7 +195,7 @@ class _$GColorInputSerializer implements StructuredSerializer<GColorInput> {
   }
 
   @override
-  GColorInput deserialize(Serializers serializers, Iterable<Object> serialized,
+  GColorInput deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GColorInputBuilder();
 
@@ -198,7 +203,7 @@ class _$GColorInputSerializer implements StructuredSerializer<GColorInput> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'red':
           result.red = serializers.deserialize(value,
@@ -223,21 +228,19 @@ class _$GReviewInput extends GReviewInput {
   @override
   final int stars;
   @override
-  final String commentary;
+  final String? commentary;
   @override
-  final GColorInput favorite_color;
+  final GColorInput? favorite_color;
   @override
-  final BuiltList<DateTime> seenOn;
+  final BuiltList<DateTime>? seenOn;
 
-  factory _$GReviewInput([void Function(GReviewInputBuilder) updates]) =>
+  factory _$GReviewInput([void Function(GReviewInputBuilder)? updates]) =>
       (new GReviewInputBuilder()..update(updates)).build();
 
   _$GReviewInput._(
-      {this.stars, this.commentary, this.favorite_color, this.seenOn})
+      {required this.stars, this.commentary, this.favorite_color, this.seenOn})
       : super._() {
-    if (stars == null) {
-      throw new BuiltValueNullFieldError('GReviewInput', 'stars');
-    }
+    BuiltValueNullFieldError.checkNotNull(stars, 'GReviewInput', 'stars');
   }
 
   @override
@@ -278,35 +281,36 @@ class _$GReviewInput extends GReviewInput {
 
 class GReviewInputBuilder
     implements Builder<GReviewInput, GReviewInputBuilder> {
-  _$GReviewInput _$v;
+  _$GReviewInput? _$v;
 
-  int _stars;
-  int get stars => _$this._stars;
-  set stars(int stars) => _$this._stars = stars;
+  int? _stars;
+  int? get stars => _$this._stars;
+  set stars(int? stars) => _$this._stars = stars;
 
-  String _commentary;
-  String get commentary => _$this._commentary;
-  set commentary(String commentary) => _$this._commentary = commentary;
+  String? _commentary;
+  String? get commentary => _$this._commentary;
+  set commentary(String? commentary) => _$this._commentary = commentary;
 
-  GColorInputBuilder _favorite_color;
+  GColorInputBuilder? _favorite_color;
   GColorInputBuilder get favorite_color =>
       _$this._favorite_color ??= new GColorInputBuilder();
-  set favorite_color(GColorInputBuilder favorite_color) =>
+  set favorite_color(GColorInputBuilder? favorite_color) =>
       _$this._favorite_color = favorite_color;
 
-  ListBuilder<DateTime> _seenOn;
+  ListBuilder<DateTime>? _seenOn;
   ListBuilder<DateTime> get seenOn =>
       _$this._seenOn ??= new ListBuilder<DateTime>();
-  set seenOn(ListBuilder<DateTime> seenOn) => _$this._seenOn = seenOn;
+  set seenOn(ListBuilder<DateTime>? seenOn) => _$this._seenOn = seenOn;
 
   GReviewInputBuilder();
 
   GReviewInputBuilder get _$this {
-    if (_$v != null) {
-      _stars = _$v.stars;
-      _commentary = _$v.commentary;
-      _favorite_color = _$v.favorite_color?.toBuilder();
-      _seenOn = _$v.seenOn?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _stars = $v.stars;
+      _commentary = $v.commentary;
+      _favorite_color = $v.favorite_color?.toBuilder();
+      _seenOn = $v.seenOn?.toBuilder();
       _$v = null;
     }
     return this;
@@ -314,14 +318,12 @@ class GReviewInputBuilder
 
   @override
   void replace(GReviewInput other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GReviewInput;
   }
 
   @override
-  void update(void Function(GReviewInputBuilder) updates) {
+  void update(void Function(GReviewInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -331,12 +333,13 @@ class GReviewInputBuilder
     try {
       _$result = _$v ??
           new _$GReviewInput._(
-              stars: stars,
+              stars: BuiltValueNullFieldError.checkNotNull(
+                  stars, 'GReviewInput', 'stars'),
               commentary: commentary,
               favorite_color: _favorite_color?.build(),
               seenOn: _seenOn?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'favorite_color';
         _favorite_color?.build();
@@ -361,19 +364,14 @@ class _$GColorInput extends GColorInput {
   @override
   final int blue;
 
-  factory _$GColorInput([void Function(GColorInputBuilder) updates]) =>
+  factory _$GColorInput([void Function(GColorInputBuilder)? updates]) =>
       (new GColorInputBuilder()..update(updates)).build();
 
-  _$GColorInput._({this.red, this.green, this.blue}) : super._() {
-    if (red == null) {
-      throw new BuiltValueNullFieldError('GColorInput', 'red');
-    }
-    if (green == null) {
-      throw new BuiltValueNullFieldError('GColorInput', 'green');
-    }
-    if (blue == null) {
-      throw new BuiltValueNullFieldError('GColorInput', 'blue');
-    }
+  _$GColorInput._({required this.red, required this.green, required this.blue})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(red, 'GColorInput', 'red');
+    BuiltValueNullFieldError.checkNotNull(green, 'GColorInput', 'green');
+    BuiltValueNullFieldError.checkNotNull(blue, 'GColorInput', 'blue');
   }
 
   @override
@@ -408,27 +406,28 @@ class _$GColorInput extends GColorInput {
 }
 
 class GColorInputBuilder implements Builder<GColorInput, GColorInputBuilder> {
-  _$GColorInput _$v;
+  _$GColorInput? _$v;
 
-  int _red;
-  int get red => _$this._red;
-  set red(int red) => _$this._red = red;
+  int? _red;
+  int? get red => _$this._red;
+  set red(int? red) => _$this._red = red;
 
-  int _green;
-  int get green => _$this._green;
-  set green(int green) => _$this._green = green;
+  int? _green;
+  int? get green => _$this._green;
+  set green(int? green) => _$this._green = green;
 
-  int _blue;
-  int get blue => _$this._blue;
-  set blue(int blue) => _$this._blue = blue;
+  int? _blue;
+  int? get blue => _$this._blue;
+  set blue(int? blue) => _$this._blue = blue;
 
   GColorInputBuilder();
 
   GColorInputBuilder get _$this {
-    if (_$v != null) {
-      _red = _$v.red;
-      _green = _$v.green;
-      _blue = _$v.blue;
+    final $v = _$v;
+    if ($v != null) {
+      _red = $v.red;
+      _green = $v.green;
+      _blue = $v.blue;
       _$v = null;
     }
     return this;
@@ -436,21 +435,25 @@ class GColorInputBuilder implements Builder<GColorInput, GColorInputBuilder> {
 
   @override
   void replace(GColorInput other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GColorInput;
   }
 
   @override
-  void update(void Function(GColorInputBuilder) updates) {
+  void update(void Function(GColorInputBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GColorInput build() {
-    final _$result =
-        _$v ?? new _$GColorInput._(red: red, green: green, blue: blue);
+    final _$result = _$v ??
+        new _$GColorInput._(
+            red: BuiltValueNullFieldError.checkNotNull(
+                red, 'GColorInput', 'red'),
+            green: BuiltValueNullFieldError.checkNotNull(
+                green, 'GColorInput', 'green'),
+            blue: BuiltValueNullFieldError.checkNotNull(
+                blue, 'GColorInput', 'blue'));
     replace(_$result);
     return _$result;
   }
@@ -460,13 +463,11 @@ class _$GISODate extends GISODate {
   @override
   final String value;
 
-  factory _$GISODate([void Function(GISODateBuilder) updates]) =>
+  factory _$GISODate([void Function(GISODateBuilder)? updates]) =>
       (new GISODateBuilder()..update(updates)).build();
 
-  _$GISODate._({this.value}) : super._() {
-    if (value == null) {
-      throw new BuiltValueNullFieldError('GISODate', 'value');
-    }
+  _$GISODate._({required this.value}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(value, 'GISODate', 'value');
   }
 
   @override
@@ -495,17 +496,18 @@ class _$GISODate extends GISODate {
 }
 
 class GISODateBuilder implements Builder<GISODate, GISODateBuilder> {
-  _$GISODate _$v;
+  _$GISODate? _$v;
 
-  String _value;
-  String get value => _$this._value;
-  set value(String value) => _$this._value = value;
+  String? _value;
+  String? get value => _$this._value;
+  set value(String? value) => _$this._value = value;
 
   GISODateBuilder();
 
   GISODateBuilder get _$this {
-    if (_$v != null) {
-      _value = _$v.value;
+    final $v = _$v;
+    if ($v != null) {
+      _value = $v.value;
       _$v = null;
     }
     return this;
@@ -513,20 +515,21 @@ class GISODateBuilder implements Builder<GISODate, GISODateBuilder> {
 
   @override
   void replace(GISODate other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GISODate;
   }
 
   @override
-  void update(void Function(GISODateBuilder) updates) {
+  void update(void Function(GISODateBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GISODate build() {
-    final _$result = _$v ?? new _$GISODate._(value: value);
+    final _$result = _$v ??
+        new _$GISODate._(
+            value: BuiltValueNullFieldError.checkNotNull(
+                value, 'GISODate', 'value'));
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.dart
@@ -20,13 +20,13 @@ abstract class GHeroForEpisodeData
       b..G__typename = 'Query';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GHeroForEpisodeData_hero get hero;
+  GHeroForEpisodeData_hero? get hero;
   static Serializer<GHeroForEpisodeData> get serializer =>
       _$gHeroForEpisodeDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroForEpisodeData.serializer, this);
-  static GHeroForEpisodeData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroForEpisodeData.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroForEpisodeData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHeroForEpisodeData.serializer, json);
 }
 
@@ -34,16 +34,16 @@ abstract class GHeroForEpisodeData_hero {
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
   String get name;
-  @nullable
-  BuiltList<GHeroForEpisodeData_hero_friends> get friends;
+  BuiltList<GHeroForEpisodeData_hero_friends>? get friends;
   static Serializer<GHeroForEpisodeData_hero> get serializer =>
       _i2.InlineFragmentSerializer<GHeroForEpisodeData_hero>(
           'GHeroForEpisodeData_hero',
           GHeroForEpisodeData_hero__base,
           [GHeroForEpisodeData_hero__asDroid]);
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroForEpisodeData_hero.serializer, this);
-  static GHeroForEpisodeData_hero fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroForEpisodeData_hero.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroForEpisodeData_hero? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GHeroForEpisodeData_hero.serializer, json);
 }
@@ -64,13 +64,12 @@ abstract class GHeroForEpisodeData_hero__base
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
   String get name;
-  @nullable
-  BuiltList<GHeroForEpisodeData_hero__base_friends> get friends;
+  BuiltList<GHeroForEpisodeData_hero__base_friends>? get friends;
   static Serializer<GHeroForEpisodeData_hero__base> get serializer =>
       _$gHeroForEpisodeDataHeroBaseSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GHeroForEpisodeData_hero__base.serializer, this);
-  static GHeroForEpisodeData_hero__base fromJson(Map<String, dynamic> json) =>
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+      GHeroForEpisodeData_hero__base.serializer, this) as Map<String, dynamic>);
+  static GHeroForEpisodeData_hero__base? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GHeroForEpisodeData_hero__base.serializer, json);
 }
@@ -94,9 +93,10 @@ abstract class GHeroForEpisodeData_hero__base_friends
   String get name;
   static Serializer<GHeroForEpisodeData_hero__base_friends> get serializer =>
       _$gHeroForEpisodeDataHeroBaseFriendsSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GHeroForEpisodeData_hero__base_friends.serializer, this);
-  static GHeroForEpisodeData_hero__base_friends fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GHeroForEpisodeData_hero__base_friends.serializer, this)
+      as Map<String, dynamic>);
+  static GHeroForEpisodeData_hero__base_friends? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GHeroForEpisodeData_hero__base_friends.serializer, json);
@@ -119,15 +119,14 @@ abstract class GHeroForEpisodeData_hero__asDroid
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
   String get name;
-  @nullable
-  BuiltList<GHeroForEpisodeData_hero__asDroid_friends> get friends;
-  @nullable
-  String get primaryFunction;
+  BuiltList<GHeroForEpisodeData_hero__asDroid_friends>? get friends;
+  String? get primaryFunction;
   static Serializer<GHeroForEpisodeData_hero__asDroid> get serializer =>
       _$gHeroForEpisodeDataHeroAsDroidSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GHeroForEpisodeData_hero__asDroid.serializer, this);
-  static GHeroForEpisodeData_hero__asDroid fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers
+          .serializeWith(GHeroForEpisodeData_hero__asDroid.serializer, this)
+      as Map<String, dynamic>);
+  static GHeroForEpisodeData_hero__asDroid? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GHeroForEpisodeData_hero__asDroid.serializer, json);
@@ -152,9 +151,10 @@ abstract class GHeroForEpisodeData_hero__asDroid_friends
   String get name;
   static Serializer<GHeroForEpisodeData_hero__asDroid_friends> get serializer =>
       _$gHeroForEpisodeDataHeroAsDroidFriendsSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers.serializeWith(
-      GHeroForEpisodeData_hero__asDroid_friends.serializer, this);
-  static GHeroForEpisodeData_hero__asDroid_friends fromJson(
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+          GHeroForEpisodeData_hero__asDroid_friends.serializer, this)
+      as Map<String, dynamic>);
+  static GHeroForEpisodeData_hero__asDroid_friends? fromJson(
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
           GHeroForEpisodeData_hero__asDroid_friends.serializer, json);
@@ -168,7 +168,7 @@ abstract class GHeroForEpisodeData_hero_friends {
 
 abstract class GDroidFragment {
   String get G__typename;
-  String get primaryFunction;
+  String? get primaryFunction;
   Map<String, dynamic> toJson();
 }
 
@@ -185,12 +185,12 @@ abstract class GDroidFragmentData
       b..G__typename = 'Droid';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  String get primaryFunction;
+  String? get primaryFunction;
   static Serializer<GDroidFragmentData> get serializer =>
       _$gDroidFragmentDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GDroidFragmentData.serializer, this);
-  static GDroidFragmentData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GDroidFragmentData.serializer, this)
+          as Map<String, dynamic>);
+  static GDroidFragmentData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GDroidFragmentData.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.g.dart
@@ -34,18 +34,20 @@ class _$GHeroForEpisodeDataSerializer
   final String wireName = 'GHeroForEpisodeData';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroForEpisodeData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.hero != null) {
+    Object? value;
+    value = object.hero;
+    if (value != null) {
       result
         ..add('hero')
-        ..add(serializers.serialize(object.hero,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GHeroForEpisodeData_hero)));
     }
     return result;
@@ -53,7 +55,7 @@ class _$GHeroForEpisodeDataSerializer
 
   @override
   GHeroForEpisodeData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeDataBuilder();
 
@@ -61,7 +63,7 @@ class _$GHeroForEpisodeDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -90,20 +92,22 @@ class _$GHeroForEpisodeData_hero__baseSerializer
   final String wireName = 'GHeroForEpisodeData_hero__base';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroForEpisodeData_hero__base object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
     ];
-    if (object.friends != null) {
+    Object? value;
+    value = object.friends;
+    if (value != null) {
       result
         ..add('friends')
-        ..add(serializers.serialize(object.friends,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(BuiltList, const [
               const FullType(GHeroForEpisodeData_hero__base_friends)
             ])));
@@ -113,7 +117,7 @@ class _$GHeroForEpisodeData_hero__baseSerializer
 
   @override
   GHeroForEpisodeData_hero__base deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeData_hero__baseBuilder();
 
@@ -121,7 +125,7 @@ class _$GHeroForEpisodeData_hero__baseSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -135,7 +139,7 @@ class _$GHeroForEpisodeData_hero__baseSerializer
           result.friends.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltList, const [
                 const FullType(GHeroForEpisodeData_hero__base_friends)
-              ])) as BuiltList<Object>);
+              ]))! as BuiltList<Object>);
           break;
       }
     }
@@ -155,10 +159,10 @@ class _$GHeroForEpisodeData_hero__base_friendsSerializer
   final String wireName = 'GHeroForEpisodeData_hero__base_friends';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroForEpisodeData_hero__base_friends object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -171,7 +175,7 @@ class _$GHeroForEpisodeData_hero__base_friendsSerializer
 
   @override
   GHeroForEpisodeData_hero__base_friends deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeData_hero__base_friendsBuilder();
 
@@ -179,7 +183,7 @@ class _$GHeroForEpisodeData_hero__base_friendsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -207,28 +211,31 @@ class _$GHeroForEpisodeData_hero__asDroidSerializer
   final String wireName = 'GHeroForEpisodeData_hero__asDroid';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroForEpisodeData_hero__asDroid object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
     ];
-    if (object.friends != null) {
+    Object? value;
+    value = object.friends;
+    if (value != null) {
       result
         ..add('friends')
-        ..add(serializers.serialize(object.friends,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(BuiltList, const [
               const FullType(GHeroForEpisodeData_hero__asDroid_friends)
             ])));
     }
-    if (object.primaryFunction != null) {
+    value = object.primaryFunction;
+    if (value != null) {
       result
         ..add('primaryFunction')
-        ..add(serializers.serialize(object.primaryFunction,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
     return result;
@@ -236,7 +243,7 @@ class _$GHeroForEpisodeData_hero__asDroidSerializer
 
   @override
   GHeroForEpisodeData_hero__asDroid deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeData_hero__asDroidBuilder();
 
@@ -244,7 +251,7 @@ class _$GHeroForEpisodeData_hero__asDroidSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -258,7 +265,7 @@ class _$GHeroForEpisodeData_hero__asDroidSerializer
           result.friends.replace(serializers.deserialize(value,
               specifiedType: const FullType(BuiltList, const [
                 const FullType(GHeroForEpisodeData_hero__asDroid_friends)
-              ])) as BuiltList<Object>);
+              ]))! as BuiltList<Object>);
           break;
         case 'primaryFunction':
           result.primaryFunction = serializers.deserialize(value,
@@ -282,10 +289,10 @@ class _$GHeroForEpisodeData_hero__asDroid_friendsSerializer
   final String wireName = 'GHeroForEpisodeData_hero__asDroid_friends';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroForEpisodeData_hero__asDroid_friends object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -298,7 +305,7 @@ class _$GHeroForEpisodeData_hero__asDroid_friendsSerializer
 
   @override
   GHeroForEpisodeData_hero__asDroid_friends deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeData_hero__asDroid_friendsBuilder();
 
@@ -306,7 +313,7 @@ class _$GHeroForEpisodeData_hero__asDroid_friendsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -331,17 +338,20 @@ class _$GDroidFragmentDataSerializer
   final String wireName = 'GDroidFragmentData';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GDroidFragmentData object,
+  Iterable<Object?> serialize(
+      Serializers serializers, GDroidFragmentData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.primaryFunction != null) {
+    Object? value;
+    value = object.primaryFunction;
+    if (value != null) {
       result
         ..add('primaryFunction')
-        ..add(serializers.serialize(object.primaryFunction,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
     return result;
@@ -349,7 +359,7 @@ class _$GDroidFragmentDataSerializer
 
   @override
   GDroidFragmentData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GDroidFragmentDataBuilder();
 
@@ -357,7 +367,7 @@ class _$GDroidFragmentDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -378,16 +388,15 @@ class _$GHeroForEpisodeData extends GHeroForEpisodeData {
   @override
   final String G__typename;
   @override
-  final GHeroForEpisodeData_hero hero;
+  final GHeroForEpisodeData_hero? hero;
 
   factory _$GHeroForEpisodeData(
-          [void Function(GHeroForEpisodeDataBuilder) updates]) =>
+          [void Function(GHeroForEpisodeDataBuilder)? updates]) =>
       (new GHeroForEpisodeDataBuilder()..update(updates)).build();
 
-  _$GHeroForEpisodeData._({this.G__typename, this.hero}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GHeroForEpisodeData', 'G__typename');
-    }
+  _$GHeroForEpisodeData._({required this.G__typename, this.hero}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroForEpisodeData', 'G__typename');
   }
 
   @override
@@ -423,24 +432,25 @@ class _$GHeroForEpisodeData extends GHeroForEpisodeData {
 
 class GHeroForEpisodeDataBuilder
     implements Builder<GHeroForEpisodeData, GHeroForEpisodeDataBuilder> {
-  _$GHeroForEpisodeData _$v;
+  _$GHeroForEpisodeData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GHeroForEpisodeData_hero _hero;
-  GHeroForEpisodeData_hero get hero => _$this._hero;
-  set hero(GHeroForEpisodeData_hero hero) => _$this._hero = hero;
+  GHeroForEpisodeData_hero? _hero;
+  GHeroForEpisodeData_hero? get hero => _$this._hero;
+  set hero(GHeroForEpisodeData_hero? hero) => _$this._hero = hero;
 
   GHeroForEpisodeDataBuilder() {
     GHeroForEpisodeData._initializeBuilder(this);
   }
 
   GHeroForEpisodeDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _hero = _$v.hero;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _hero = $v.hero;
       _$v = null;
     }
     return this;
@@ -448,21 +458,22 @@ class GHeroForEpisodeDataBuilder
 
   @override
   void replace(GHeroForEpisodeData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisodeData;
   }
 
   @override
-  void update(void Function(GHeroForEpisodeDataBuilder) updates) {
+  void update(void Function(GHeroForEpisodeDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GHeroForEpisodeData build() {
     final _$result = _$v ??
-        new _$GHeroForEpisodeData._(G__typename: G__typename, hero: hero);
+        new _$GHeroForEpisodeData._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, 'GHeroForEpisodeData', 'G__typename'),
+            hero: hero);
     replace(_$result);
     return _$result;
   }
@@ -474,23 +485,19 @@ class _$GHeroForEpisodeData_hero__base extends GHeroForEpisodeData_hero__base {
   @override
   final String name;
   @override
-  final BuiltList<GHeroForEpisodeData_hero__base_friends> friends;
+  final BuiltList<GHeroForEpisodeData_hero__base_friends>? friends;
 
   factory _$GHeroForEpisodeData_hero__base(
-          [void Function(GHeroForEpisodeData_hero__baseBuilder) updates]) =>
+          [void Function(GHeroForEpisodeData_hero__baseBuilder)? updates]) =>
       (new GHeroForEpisodeData_hero__baseBuilder()..update(updates)).build();
 
   _$GHeroForEpisodeData_hero__base._(
-      {this.G__typename, this.name, this.friends})
+      {required this.G__typename, required this.name, this.friends})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__base', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__base', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroForEpisodeData_hero__base', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GHeroForEpisodeData_hero__base', 'name');
   }
 
   @override
@@ -531,21 +538,21 @@ class GHeroForEpisodeData_hero__baseBuilder
     implements
         Builder<GHeroForEpisodeData_hero__base,
             GHeroForEpisodeData_hero__baseBuilder> {
-  _$GHeroForEpisodeData_hero__base _$v;
+  _$GHeroForEpisodeData_hero__base? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  ListBuilder<GHeroForEpisodeData_hero__base_friends> _friends;
+  ListBuilder<GHeroForEpisodeData_hero__base_friends>? _friends;
   ListBuilder<GHeroForEpisodeData_hero__base_friends> get friends =>
       _$this._friends ??=
           new ListBuilder<GHeroForEpisodeData_hero__base_friends>();
-  set friends(ListBuilder<GHeroForEpisodeData_hero__base_friends> friends) =>
+  set friends(ListBuilder<GHeroForEpisodeData_hero__base_friends>? friends) =>
       _$this._friends = friends;
 
   GHeroForEpisodeData_hero__baseBuilder() {
@@ -553,10 +560,11 @@ class GHeroForEpisodeData_hero__baseBuilder
   }
 
   GHeroForEpisodeData_hero__baseBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
-      _friends = _$v.friends?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
+      _friends = $v.friends?.toBuilder();
       _$v = null;
     }
     return this;
@@ -564,14 +572,12 @@ class GHeroForEpisodeData_hero__baseBuilder
 
   @override
   void replace(GHeroForEpisodeData_hero__base other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisodeData_hero__base;
   }
 
   @override
-  void update(void Function(GHeroForEpisodeData_hero__baseBuilder) updates) {
+  void update(void Function(GHeroForEpisodeData_hero__baseBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -581,9 +587,13 @@ class GHeroForEpisodeData_hero__baseBuilder
     try {
       _$result = _$v ??
           new _$GHeroForEpisodeData_hero__base._(
-              G__typename: G__typename, name: name, friends: _friends?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GHeroForEpisodeData_hero__base', 'G__typename'),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'GHeroForEpisodeData_hero__base', 'name'),
+              friends: _friends?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'friends';
         _friends?.build();
@@ -606,21 +616,18 @@ class _$GHeroForEpisodeData_hero__base_friends
   final String name;
 
   factory _$GHeroForEpisodeData_hero__base_friends(
-          [void Function(GHeroForEpisodeData_hero__base_friendsBuilder)
+          [void Function(GHeroForEpisodeData_hero__base_friendsBuilder)?
               updates]) =>
       (new GHeroForEpisodeData_hero__base_friendsBuilder()..update(updates))
           .build();
 
-  _$GHeroForEpisodeData_hero__base_friends._({this.G__typename, this.name})
+  _$GHeroForEpisodeData_hero__base_friends._(
+      {required this.G__typename, required this.name})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__base_friends', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__base_friends', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroForEpisodeData_hero__base_friends', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GHeroForEpisodeData_hero__base_friends', 'name');
   }
 
   @override
@@ -660,24 +667,25 @@ class GHeroForEpisodeData_hero__base_friendsBuilder
     implements
         Builder<GHeroForEpisodeData_hero__base_friends,
             GHeroForEpisodeData_hero__base_friendsBuilder> {
-  _$GHeroForEpisodeData_hero__base_friends _$v;
+  _$GHeroForEpisodeData_hero__base_friends? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GHeroForEpisodeData_hero__base_friendsBuilder() {
     GHeroForEpisodeData_hero__base_friends._initializeBuilder(this);
   }
 
   GHeroForEpisodeData_hero__base_friendsBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -685,15 +693,13 @@ class GHeroForEpisodeData_hero__base_friendsBuilder
 
   @override
   void replace(GHeroForEpisodeData_hero__base_friends other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisodeData_hero__base_friends;
   }
 
   @override
   void update(
-      void Function(GHeroForEpisodeData_hero__base_friendsBuilder) updates) {
+      void Function(GHeroForEpisodeData_hero__base_friendsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -701,7 +707,10 @@ class GHeroForEpisodeData_hero__base_friendsBuilder
   _$GHeroForEpisodeData_hero__base_friends build() {
     final _$result = _$v ??
         new _$GHeroForEpisodeData_hero__base_friends._(
-            G__typename: G__typename, name: name);
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                'GHeroForEpisodeData_hero__base_friends', 'G__typename'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, 'GHeroForEpisodeData_hero__base_friends', 'name'));
     replace(_$result);
     return _$result;
   }
@@ -714,25 +723,24 @@ class _$GHeroForEpisodeData_hero__asDroid
   @override
   final String name;
   @override
-  final BuiltList<GHeroForEpisodeData_hero__asDroid_friends> friends;
+  final BuiltList<GHeroForEpisodeData_hero__asDroid_friends>? friends;
   @override
-  final String primaryFunction;
+  final String? primaryFunction;
 
   factory _$GHeroForEpisodeData_hero__asDroid(
-          [void Function(GHeroForEpisodeData_hero__asDroidBuilder) updates]) =>
+          [void Function(GHeroForEpisodeData_hero__asDroidBuilder)? updates]) =>
       (new GHeroForEpisodeData_hero__asDroidBuilder()..update(updates)).build();
 
   _$GHeroForEpisodeData_hero__asDroid._(
-      {this.G__typename, this.name, this.friends, this.primaryFunction})
+      {required this.G__typename,
+      required this.name,
+      this.friends,
+      this.primaryFunction})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__asDroid', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__asDroid', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroForEpisodeData_hero__asDroid', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GHeroForEpisodeData_hero__asDroid', 'name');
   }
 
   @override
@@ -776,26 +784,27 @@ class GHeroForEpisodeData_hero__asDroidBuilder
     implements
         Builder<GHeroForEpisodeData_hero__asDroid,
             GHeroForEpisodeData_hero__asDroidBuilder> {
-  _$GHeroForEpisodeData_hero__asDroid _$v;
+  _$GHeroForEpisodeData_hero__asDroid? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  ListBuilder<GHeroForEpisodeData_hero__asDroid_friends> _friends;
+  ListBuilder<GHeroForEpisodeData_hero__asDroid_friends>? _friends;
   ListBuilder<GHeroForEpisodeData_hero__asDroid_friends> get friends =>
       _$this._friends ??=
           new ListBuilder<GHeroForEpisodeData_hero__asDroid_friends>();
-  set friends(ListBuilder<GHeroForEpisodeData_hero__asDroid_friends> friends) =>
+  set friends(
+          ListBuilder<GHeroForEpisodeData_hero__asDroid_friends>? friends) =>
       _$this._friends = friends;
 
-  String _primaryFunction;
-  String get primaryFunction => _$this._primaryFunction;
-  set primaryFunction(String primaryFunction) =>
+  String? _primaryFunction;
+  String? get primaryFunction => _$this._primaryFunction;
+  set primaryFunction(String? primaryFunction) =>
       _$this._primaryFunction = primaryFunction;
 
   GHeroForEpisodeData_hero__asDroidBuilder() {
@@ -803,11 +812,12 @@ class GHeroForEpisodeData_hero__asDroidBuilder
   }
 
   GHeroForEpisodeData_hero__asDroidBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
-      _friends = _$v.friends?.toBuilder();
-      _primaryFunction = _$v.primaryFunction;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
+      _friends = $v.friends?.toBuilder();
+      _primaryFunction = $v.primaryFunction;
       _$v = null;
     }
     return this;
@@ -815,14 +825,13 @@ class GHeroForEpisodeData_hero__asDroidBuilder
 
   @override
   void replace(GHeroForEpisodeData_hero__asDroid other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisodeData_hero__asDroid;
   }
 
   @override
-  void update(void Function(GHeroForEpisodeData_hero__asDroidBuilder) updates) {
+  void update(
+      void Function(GHeroForEpisodeData_hero__asDroidBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -832,12 +841,14 @@ class GHeroForEpisodeData_hero__asDroidBuilder
     try {
       _$result = _$v ??
           new _$GHeroForEpisodeData_hero__asDroid._(
-              G__typename: G__typename,
-              name: name,
+              G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                  'GHeroForEpisodeData_hero__asDroid', 'G__typename'),
+              name: BuiltValueNullFieldError.checkNotNull(
+                  name, 'GHeroForEpisodeData_hero__asDroid', 'name'),
               friends: _friends?.build(),
               primaryFunction: primaryFunction);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'friends';
         _friends?.build();
@@ -860,21 +871,18 @@ class _$GHeroForEpisodeData_hero__asDroid_friends
   final String name;
 
   factory _$GHeroForEpisodeData_hero__asDroid_friends(
-          [void Function(GHeroForEpisodeData_hero__asDroid_friendsBuilder)
+          [void Function(GHeroForEpisodeData_hero__asDroid_friendsBuilder)?
               updates]) =>
       (new GHeroForEpisodeData_hero__asDroid_friendsBuilder()..update(updates))
           .build();
 
-  _$GHeroForEpisodeData_hero__asDroid_friends._({this.G__typename, this.name})
+  _$GHeroForEpisodeData_hero__asDroid_friends._(
+      {required this.G__typename, required this.name})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__asDroid_friends', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError(
-          'GHeroForEpisodeData_hero__asDroid_friends', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(G__typename,
+        'GHeroForEpisodeData_hero__asDroid_friends', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GHeroForEpisodeData_hero__asDroid_friends', 'name');
   }
 
   @override
@@ -914,24 +922,25 @@ class GHeroForEpisodeData_hero__asDroid_friendsBuilder
     implements
         Builder<GHeroForEpisodeData_hero__asDroid_friends,
             GHeroForEpisodeData_hero__asDroid_friendsBuilder> {
-  _$GHeroForEpisodeData_hero__asDroid_friends _$v;
+  _$GHeroForEpisodeData_hero__asDroid_friends? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GHeroForEpisodeData_hero__asDroid_friendsBuilder() {
     GHeroForEpisodeData_hero__asDroid_friends._initializeBuilder(this);
   }
 
   GHeroForEpisodeData_hero__asDroid_friendsBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -939,15 +948,14 @@ class GHeroForEpisodeData_hero__asDroid_friendsBuilder
 
   @override
   void replace(GHeroForEpisodeData_hero__asDroid_friends other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisodeData_hero__asDroid_friends;
   }
 
   @override
   void update(
-      void Function(GHeroForEpisodeData_hero__asDroid_friendsBuilder) updates) {
+      void Function(GHeroForEpisodeData_hero__asDroid_friendsBuilder)?
+          updates) {
     if (updates != null) updates(this);
   }
 
@@ -955,7 +963,10 @@ class GHeroForEpisodeData_hero__asDroid_friendsBuilder
   _$GHeroForEpisodeData_hero__asDroid_friends build() {
     final _$result = _$v ??
         new _$GHeroForEpisodeData_hero__asDroid_friends._(
-            G__typename: G__typename, name: name);
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                'GHeroForEpisodeData_hero__asDroid_friends', 'G__typename'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, 'GHeroForEpisodeData_hero__asDroid_friends', 'name'));
     replace(_$result);
     return _$result;
   }
@@ -965,16 +976,16 @@ class _$GDroidFragmentData extends GDroidFragmentData {
   @override
   final String G__typename;
   @override
-  final String primaryFunction;
+  final String? primaryFunction;
 
   factory _$GDroidFragmentData(
-          [void Function(GDroidFragmentDataBuilder) updates]) =>
+          [void Function(GDroidFragmentDataBuilder)? updates]) =>
       (new GDroidFragmentDataBuilder()..update(updates)).build();
 
-  _$GDroidFragmentData._({this.G__typename, this.primaryFunction}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GDroidFragmentData', 'G__typename');
-    }
+  _$GDroidFragmentData._({required this.G__typename, this.primaryFunction})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GDroidFragmentData', 'G__typename');
   }
 
   @override
@@ -1010,15 +1021,15 @@ class _$GDroidFragmentData extends GDroidFragmentData {
 
 class GDroidFragmentDataBuilder
     implements Builder<GDroidFragmentData, GDroidFragmentDataBuilder> {
-  _$GDroidFragmentData _$v;
+  _$GDroidFragmentData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _primaryFunction;
-  String get primaryFunction => _$this._primaryFunction;
-  set primaryFunction(String primaryFunction) =>
+  String? _primaryFunction;
+  String? get primaryFunction => _$this._primaryFunction;
+  set primaryFunction(String? primaryFunction) =>
       _$this._primaryFunction = primaryFunction;
 
   GDroidFragmentDataBuilder() {
@@ -1026,9 +1037,10 @@ class GDroidFragmentDataBuilder
   }
 
   GDroidFragmentDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _primaryFunction = _$v.primaryFunction;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _primaryFunction = $v.primaryFunction;
       _$v = null;
     }
     return this;
@@ -1036,14 +1048,12 @@ class GDroidFragmentDataBuilder
 
   @override
   void replace(GDroidFragmentData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GDroidFragmentData;
   }
 
   @override
-  void update(void Function(GDroidFragmentDataBuilder) updates) {
+  void update(void Function(GDroidFragmentDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -1051,7 +1061,9 @@ class GDroidFragmentDataBuilder
   _$GDroidFragmentData build() {
     final _$result = _$v ??
         new _$GDroidFragmentData._(
-            G__typename: G__typename, primaryFunction: primaryFunction);
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, 'GDroidFragmentData', 'G__typename'),
+            primaryFunction: primaryFunction);
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.req.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.req.gql.dart
@@ -26,7 +26,8 @@ abstract class GHeroForEpisode
   static Serializer<GHeroForEpisode> get serializer =>
       _$gHeroForEpisodeSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GHeroForEpisode.serializer, this);
-  static GHeroForEpisode fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GHeroForEpisode.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroForEpisode? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GHeroForEpisode.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.req.gql.g.dart
@@ -17,9 +17,9 @@ class _$GHeroForEpisodeSerializer
   final String wireName = 'GHeroForEpisode';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHeroForEpisode object,
+  Iterable<Object?> serialize(Serializers serializers, GHeroForEpisode object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GHeroForEpisodeVars)),
@@ -33,7 +33,7 @@ class _$GHeroForEpisodeSerializer
 
   @override
   GHeroForEpisode deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeBuilder();
 
@@ -41,11 +41,11 @@ class _$GHeroForEpisodeSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GHeroForEpisodeVars))
+                  specifiedType: const FullType(_i3.GHeroForEpisodeVars))!
               as _i3.GHeroForEpisodeVars);
           break;
         case 'operation':
@@ -65,16 +65,14 @@ class _$GHeroForEpisode extends GHeroForEpisode {
   @override
   final _i1.Operation operation;
 
-  factory _$GHeroForEpisode([void Function(GHeroForEpisodeBuilder) updates]) =>
+  factory _$GHeroForEpisode([void Function(GHeroForEpisodeBuilder)? updates]) =>
       (new GHeroForEpisodeBuilder()..update(updates)).build();
 
-  _$GHeroForEpisode._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GHeroForEpisode', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GHeroForEpisode', 'operation');
-    }
+  _$GHeroForEpisode._({required this.vars, required this.operation})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GHeroForEpisode', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GHeroForEpisode', 'operation');
   }
 
   @override
@@ -109,25 +107,26 @@ class _$GHeroForEpisode extends GHeroForEpisode {
 
 class GHeroForEpisodeBuilder
     implements Builder<GHeroForEpisode, GHeroForEpisodeBuilder> {
-  _$GHeroForEpisode _$v;
+  _$GHeroForEpisode? _$v;
 
-  _i3.GHeroForEpisodeVarsBuilder _vars;
+  _i3.GHeroForEpisodeVarsBuilder? _vars;
   _i3.GHeroForEpisodeVarsBuilder get vars =>
       _$this._vars ??= new _i3.GHeroForEpisodeVarsBuilder();
-  set vars(_i3.GHeroForEpisodeVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GHeroForEpisodeVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GHeroForEpisodeBuilder() {
     GHeroForEpisode._initializeBuilder(this);
   }
 
   GHeroForEpisodeBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -135,14 +134,12 @@ class GHeroForEpisodeBuilder
 
   @override
   void replace(GHeroForEpisode other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisode;
   }
 
   @override
-  void update(void Function(GHeroForEpisodeBuilder) updates) {
+  void update(void Function(GHeroForEpisodeBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -151,9 +148,12 @@ class GHeroForEpisodeBuilder
     _$GHeroForEpisode _$result;
     try {
       _$result = _$v ??
-          new _$GHeroForEpisode._(vars: vars.build(), operation: operation);
+          new _$GHeroForEpisode._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GHeroForEpisode', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.var.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.var.gql.dart
@@ -18,8 +18,9 @@ abstract class GHeroForEpisodeVars
   static Serializer<GHeroForEpisodeVars> get serializer =>
       _$gHeroForEpisodeVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i2.serializers.serializeWith(GHeroForEpisodeVars.serializer, this);
-  static GHeroForEpisodeVars fromJson(Map<String, dynamic> json) =>
+      (_i2.serializers.serializeWith(GHeroForEpisodeVars.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroForEpisodeVars? fromJson(Map<String, dynamic> json) =>
       _i2.serializers.deserializeWith(GHeroForEpisodeVars.serializer, json);
 }
 
@@ -33,7 +34,8 @@ abstract class GDroidFragmentVars
   static Serializer<GDroidFragmentVars> get serializer =>
       _$gDroidFragmentVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i2.serializers.serializeWith(GDroidFragmentVars.serializer, this);
-  static GDroidFragmentVars fromJson(Map<String, dynamic> json) =>
+      (_i2.serializers.serializeWith(GDroidFragmentVars.serializer, this)
+          as Map<String, dynamic>);
+  static GDroidFragmentVars? fromJson(Map<String, dynamic> json) =>
       _i2.serializers.deserializeWith(GDroidFragmentVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.var.gql.g.dart
@@ -22,10 +22,10 @@ class _$GHeroForEpisodeVarsSerializer
   final String wireName = 'GHeroForEpisodeVars';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroForEpisodeVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'ep',
       serializers.serialize(object.ep,
           specifiedType: const FullType(_i1.GEpisode)),
@@ -36,7 +36,7 @@ class _$GHeroForEpisodeVarsSerializer
 
   @override
   GHeroForEpisodeVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroForEpisodeVarsBuilder();
 
@@ -44,7 +44,7 @@ class _$GHeroForEpisodeVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'ep':
           result.ep = serializers.deserialize(value,
@@ -65,14 +65,15 @@ class _$GDroidFragmentVarsSerializer
   final String wireName = 'GDroidFragmentVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GDroidFragmentVars object,
+  Iterable<Object?> serialize(
+      Serializers serializers, GDroidFragmentVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    return <Object>[];
+    return <Object?>[];
   }
 
   @override
   GDroidFragmentVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     return new GDroidFragmentVarsBuilder().build();
   }
@@ -83,13 +84,11 @@ class _$GHeroForEpisodeVars extends GHeroForEpisodeVars {
   final _i1.GEpisode ep;
 
   factory _$GHeroForEpisodeVars(
-          [void Function(GHeroForEpisodeVarsBuilder) updates]) =>
+          [void Function(GHeroForEpisodeVarsBuilder)? updates]) =>
       (new GHeroForEpisodeVarsBuilder()..update(updates)).build();
 
-  _$GHeroForEpisodeVars._({this.ep}) : super._() {
-    if (ep == null) {
-      throw new BuiltValueNullFieldError('GHeroForEpisodeVars', 'ep');
-    }
+  _$GHeroForEpisodeVars._({required this.ep}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(ep, 'GHeroForEpisodeVars', 'ep');
   }
 
   @override
@@ -121,17 +120,18 @@ class _$GHeroForEpisodeVars extends GHeroForEpisodeVars {
 
 class GHeroForEpisodeVarsBuilder
     implements Builder<GHeroForEpisodeVars, GHeroForEpisodeVarsBuilder> {
-  _$GHeroForEpisodeVars _$v;
+  _$GHeroForEpisodeVars? _$v;
 
-  _i1.GEpisode _ep;
-  _i1.GEpisode get ep => _$this._ep;
-  set ep(_i1.GEpisode ep) => _$this._ep = ep;
+  _i1.GEpisode? _ep;
+  _i1.GEpisode? get ep => _$this._ep;
+  set ep(_i1.GEpisode? ep) => _$this._ep = ep;
 
   GHeroForEpisodeVarsBuilder();
 
   GHeroForEpisodeVarsBuilder get _$this {
-    if (_$v != null) {
-      _ep = _$v.ep;
+    final $v = _$v;
+    if ($v != null) {
+      _ep = $v.ep;
       _$v = null;
     }
     return this;
@@ -139,20 +139,21 @@ class GHeroForEpisodeVarsBuilder
 
   @override
   void replace(GHeroForEpisodeVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroForEpisodeVars;
   }
 
   @override
-  void update(void Function(GHeroForEpisodeVarsBuilder) updates) {
+  void update(void Function(GHeroForEpisodeVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GHeroForEpisodeVars build() {
-    final _$result = _$v ?? new _$GHeroForEpisodeVars._(ep: ep);
+    final _$result = _$v ??
+        new _$GHeroForEpisodeVars._(
+            ep: BuiltValueNullFieldError.checkNotNull(
+                ep, 'GHeroForEpisodeVars', 'ep'));
     replace(_$result);
     return _$result;
   }
@@ -160,7 +161,7 @@ class GHeroForEpisodeVarsBuilder
 
 class _$GDroidFragmentVars extends GDroidFragmentVars {
   factory _$GDroidFragmentVars(
-          [void Function(GDroidFragmentVarsBuilder) updates]) =>
+          [void Function(GDroidFragmentVarsBuilder)? updates]) =>
       (new GDroidFragmentVarsBuilder()..update(updates)).build();
 
   _$GDroidFragmentVars._() : super._();
@@ -193,20 +194,18 @@ class _$GDroidFragmentVars extends GDroidFragmentVars {
 
 class GDroidFragmentVarsBuilder
     implements Builder<GDroidFragmentVars, GDroidFragmentVarsBuilder> {
-  _$GDroidFragmentVars _$v;
+  _$GDroidFragmentVars? _$v;
 
   GDroidFragmentVarsBuilder();
 
   @override
   void replace(GDroidFragmentVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GDroidFragmentVars;
   }
 
   @override
-  void update(void Function(GDroidFragmentVarsBuilder) updates) {
+  void update(void Function(GDroidFragmentVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 

--- a/codegen/end_to_end_test/lib/no_vars/hero_no_vars.data.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/hero_no_vars.data.gql.dart
@@ -17,13 +17,13 @@ abstract class GHeroNoVarsData
       b..G__typename = 'Query';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GHeroNoVarsData_hero get hero;
+  GHeroNoVarsData_hero? get hero;
   static Serializer<GHeroNoVarsData> get serializer =>
       _$gHeroNoVarsDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroNoVarsData.serializer, this);
-  static GHeroNoVarsData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroNoVarsData.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroNoVarsData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHeroNoVarsData.serializer, json);
 }
 
@@ -44,7 +44,8 @@ abstract class GHeroNoVarsData_hero
   static Serializer<GHeroNoVarsData_hero> get serializer =>
       _$gHeroNoVarsDataHeroSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroNoVarsData_hero.serializer, this);
-  static GHeroNoVarsData_hero fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroNoVarsData_hero.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroNoVarsData_hero? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHeroNoVarsData_hero.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/no_vars/hero_no_vars.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/no_vars/hero_no_vars.data.gql.g.dart
@@ -19,17 +19,19 @@ class _$GHeroNoVarsDataSerializer
   final String wireName = 'GHeroNoVarsData';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHeroNoVarsData object,
+  Iterable<Object?> serialize(Serializers serializers, GHeroNoVarsData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.hero != null) {
+    Object? value;
+    value = object.hero;
+    if (value != null) {
       result
         ..add('hero')
-        ..add(serializers.serialize(object.hero,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GHeroNoVarsData_hero)));
     }
     return result;
@@ -37,7 +39,7 @@ class _$GHeroNoVarsDataSerializer
 
   @override
   GHeroNoVarsData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroNoVarsDataBuilder();
 
@@ -45,7 +47,7 @@ class _$GHeroNoVarsDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -53,7 +55,7 @@ class _$GHeroNoVarsDataSerializer
           break;
         case 'hero':
           result.hero.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(GHeroNoVarsData_hero))
+                  specifiedType: const FullType(GHeroNoVarsData_hero))!
               as GHeroNoVarsData_hero);
           break;
       }
@@ -74,10 +76,10 @@ class _$GHeroNoVarsData_heroSerializer
   final String wireName = 'GHeroNoVarsData_hero';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHeroNoVarsData_hero object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -92,7 +94,7 @@ class _$GHeroNoVarsData_heroSerializer
 
   @override
   GHeroNoVarsData_hero deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroNoVarsData_heroBuilder();
 
@@ -100,7 +102,7 @@ class _$GHeroNoVarsData_heroSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -125,15 +127,14 @@ class _$GHeroNoVarsData extends GHeroNoVarsData {
   @override
   final String G__typename;
   @override
-  final GHeroNoVarsData_hero hero;
+  final GHeroNoVarsData_hero? hero;
 
-  factory _$GHeroNoVarsData([void Function(GHeroNoVarsDataBuilder) updates]) =>
+  factory _$GHeroNoVarsData([void Function(GHeroNoVarsDataBuilder)? updates]) =>
       (new GHeroNoVarsDataBuilder()..update(updates)).build();
 
-  _$GHeroNoVarsData._({this.G__typename, this.hero}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GHeroNoVarsData', 'G__typename');
-    }
+  _$GHeroNoVarsData._({required this.G__typename, this.hero}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroNoVarsData', 'G__typename');
   }
 
   @override
@@ -168,25 +169,26 @@ class _$GHeroNoVarsData extends GHeroNoVarsData {
 
 class GHeroNoVarsDataBuilder
     implements Builder<GHeroNoVarsData, GHeroNoVarsDataBuilder> {
-  _$GHeroNoVarsData _$v;
+  _$GHeroNoVarsData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GHeroNoVarsData_heroBuilder _hero;
+  GHeroNoVarsData_heroBuilder? _hero;
   GHeroNoVarsData_heroBuilder get hero =>
       _$this._hero ??= new GHeroNoVarsData_heroBuilder();
-  set hero(GHeroNoVarsData_heroBuilder hero) => _$this._hero = hero;
+  set hero(GHeroNoVarsData_heroBuilder? hero) => _$this._hero = hero;
 
   GHeroNoVarsDataBuilder() {
     GHeroNoVarsData._initializeBuilder(this);
   }
 
   GHeroNoVarsDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _hero = _$v.hero?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _hero = $v.hero?.toBuilder();
       _$v = null;
     }
     return this;
@@ -194,14 +196,12 @@ class GHeroNoVarsDataBuilder
 
   @override
   void replace(GHeroNoVarsData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroNoVarsData;
   }
 
   @override
-  void update(void Function(GHeroNoVarsDataBuilder) updates) {
+  void update(void Function(GHeroNoVarsDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -211,9 +211,11 @@ class GHeroNoVarsDataBuilder
     try {
       _$result = _$v ??
           new _$GHeroNoVarsData._(
-              G__typename: G__typename, hero: _hero?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GHeroNoVarsData', 'G__typename'),
+              hero: _hero?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'hero';
         _hero?.build();
@@ -237,19 +239,16 @@ class _$GHeroNoVarsData_hero extends GHeroNoVarsData_hero {
   final String name;
 
   factory _$GHeroNoVarsData_hero(
-          [void Function(GHeroNoVarsData_heroBuilder) updates]) =>
+          [void Function(GHeroNoVarsData_heroBuilder)? updates]) =>
       (new GHeroNoVarsData_heroBuilder()..update(updates)).build();
 
-  _$GHeroNoVarsData_hero._({this.G__typename, this.id, this.name}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GHeroNoVarsData_hero', 'G__typename');
-    }
-    if (id == null) {
-      throw new BuiltValueNullFieldError('GHeroNoVarsData_hero', 'id');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GHeroNoVarsData_hero', 'name');
-    }
+  _$GHeroNoVarsData_hero._(
+      {required this.G__typename, required this.id, required this.name})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHeroNoVarsData_hero', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(id, 'GHeroNoVarsData_hero', 'id');
+    BuiltValueNullFieldError.checkNotNull(name, 'GHeroNoVarsData_hero', 'name');
   }
 
   @override
@@ -288,29 +287,30 @@ class _$GHeroNoVarsData_hero extends GHeroNoVarsData_hero {
 
 class GHeroNoVarsData_heroBuilder
     implements Builder<GHeroNoVarsData_hero, GHeroNoVarsData_heroBuilder> {
-  _$GHeroNoVarsData_hero _$v;
+  _$GHeroNoVarsData_hero? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _id;
-  String get id => _$this._id;
-  set id(String id) => _$this._id = id;
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GHeroNoVarsData_heroBuilder() {
     GHeroNoVarsData_hero._initializeBuilder(this);
   }
 
   GHeroNoVarsData_heroBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _id = _$v.id;
-      _name = _$v.name;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _id = $v.id;
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -318,14 +318,12 @@ class GHeroNoVarsData_heroBuilder
 
   @override
   void replace(GHeroNoVarsData_hero other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroNoVarsData_hero;
   }
 
   @override
-  void update(void Function(GHeroNoVarsData_heroBuilder) updates) {
+  void update(void Function(GHeroNoVarsData_heroBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -333,7 +331,12 @@ class GHeroNoVarsData_heroBuilder
   _$GHeroNoVarsData_hero build() {
     final _$result = _$v ??
         new _$GHeroNoVarsData_hero._(
-            G__typename: G__typename, id: id, name: name);
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, 'GHeroNoVarsData_hero', 'G__typename'),
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, 'GHeroNoVarsData_hero', 'id'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, 'GHeroNoVarsData_hero', 'name'));
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/no_vars/hero_no_vars.req.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/hero_no_vars.req.gql.dart
@@ -21,7 +21,8 @@ abstract class GHeroNoVars implements Built<GHeroNoVars, GHeroNoVarsBuilder> {
   _i1.Operation get operation;
   static Serializer<GHeroNoVars> get serializer => _$gHeroNoVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GHeroNoVars.serializer, this);
-  static GHeroNoVars fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GHeroNoVars.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroNoVars? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GHeroNoVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/no_vars/hero_no_vars.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/no_vars/hero_no_vars.req.gql.g.dart
@@ -15,9 +15,9 @@ class _$GHeroNoVarsSerializer implements StructuredSerializer<GHeroNoVars> {
   final String wireName = 'GHeroNoVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHeroNoVars object,
+  Iterable<Object?> serialize(Serializers serializers, GHeroNoVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GHeroNoVarsVars)),
@@ -30,7 +30,7 @@ class _$GHeroNoVarsSerializer implements StructuredSerializer<GHeroNoVars> {
   }
 
   @override
-  GHeroNoVars deserialize(Serializers serializers, Iterable<Object> serialized,
+  GHeroNoVars deserialize(Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHeroNoVarsBuilder();
 
@@ -38,11 +38,11 @@ class _$GHeroNoVarsSerializer implements StructuredSerializer<GHeroNoVars> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GHeroNoVarsVars))
+                  specifiedType: const FullType(_i3.GHeroNoVarsVars))!
               as _i3.GHeroNoVarsVars);
           break;
         case 'operation':
@@ -62,16 +62,13 @@ class _$GHeroNoVars extends GHeroNoVars {
   @override
   final _i1.Operation operation;
 
-  factory _$GHeroNoVars([void Function(GHeroNoVarsBuilder) updates]) =>
+  factory _$GHeroNoVars([void Function(GHeroNoVarsBuilder)? updates]) =>
       (new GHeroNoVarsBuilder()..update(updates)).build();
 
-  _$GHeroNoVars._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GHeroNoVars', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GHeroNoVars', 'operation');
-    }
+  _$GHeroNoVars._({required this.vars, required this.operation}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GHeroNoVars', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GHeroNoVars', 'operation');
   }
 
   @override
@@ -104,25 +101,26 @@ class _$GHeroNoVars extends GHeroNoVars {
 }
 
 class GHeroNoVarsBuilder implements Builder<GHeroNoVars, GHeroNoVarsBuilder> {
-  _$GHeroNoVars _$v;
+  _$GHeroNoVars? _$v;
 
-  _i3.GHeroNoVarsVarsBuilder _vars;
+  _i3.GHeroNoVarsVarsBuilder? _vars;
   _i3.GHeroNoVarsVarsBuilder get vars =>
       _$this._vars ??= new _i3.GHeroNoVarsVarsBuilder();
-  set vars(_i3.GHeroNoVarsVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GHeroNoVarsVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GHeroNoVarsBuilder() {
     GHeroNoVars._initializeBuilder(this);
   }
 
   GHeroNoVarsBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -130,14 +128,12 @@ class GHeroNoVarsBuilder implements Builder<GHeroNoVars, GHeroNoVarsBuilder> {
 
   @override
   void replace(GHeroNoVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroNoVars;
   }
 
   @override
-  void update(void Function(GHeroNoVarsBuilder) updates) {
+  void update(void Function(GHeroNoVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -145,10 +141,13 @@ class GHeroNoVarsBuilder implements Builder<GHeroNoVars, GHeroNoVarsBuilder> {
   _$GHeroNoVars build() {
     _$GHeroNoVars _$result;
     try {
-      _$result =
-          _$v ?? new _$GHeroNoVars._(vars: vars.build(), operation: operation);
+      _$result = _$v ??
+          new _$GHeroNoVars._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GHeroNoVars', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/no_vars/hero_no_vars.var.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/hero_no_vars.var.gql.dart
@@ -16,7 +16,8 @@ abstract class GHeroNoVarsVars
   static Serializer<GHeroNoVarsVars> get serializer =>
       _$gHeroNoVarsVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHeroNoVarsVars.serializer, this);
-  static GHeroNoVarsVars fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHeroNoVarsVars.serializer, this)
+          as Map<String, dynamic>);
+  static GHeroNoVarsVars? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHeroNoVarsVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/no_vars/hero_no_vars.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/no_vars/hero_no_vars.var.gql.g.dart
@@ -17,21 +17,21 @@ class _$GHeroNoVarsVarsSerializer
   final String wireName = 'GHeroNoVarsVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHeroNoVarsVars object,
+  Iterable<Object?> serialize(Serializers serializers, GHeroNoVarsVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    return <Object>[];
+    return <Object?>[];
   }
 
   @override
   GHeroNoVarsVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     return new GHeroNoVarsVarsBuilder().build();
   }
 }
 
 class _$GHeroNoVarsVars extends GHeroNoVarsVars {
-  factory _$GHeroNoVarsVars([void Function(GHeroNoVarsVarsBuilder) updates]) =>
+  factory _$GHeroNoVarsVars([void Function(GHeroNoVarsVarsBuilder)? updates]) =>
       (new GHeroNoVarsVarsBuilder()..update(updates)).build();
 
   _$GHeroNoVarsVars._() : super._();
@@ -63,20 +63,18 @@ class _$GHeroNoVarsVars extends GHeroNoVarsVars {
 
 class GHeroNoVarsVarsBuilder
     implements Builder<GHeroNoVarsVars, GHeroNoVarsVarsBuilder> {
-  _$GHeroNoVarsVars _$v;
+  _$GHeroNoVarsVars? _$v;
 
   GHeroNoVarsVarsBuilder();
 
   @override
   void replace(GHeroNoVarsVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHeroNoVarsVars;
   }
 
   @override
-  void update(void Function(GHeroNoVarsVarsBuilder) updates) {
+  void update(void Function(GHeroNoVarsVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 

--- a/codegen/end_to_end_test/lib/scalars/review_with_date.data.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/review_with_date.data.gql.dart
@@ -20,13 +20,13 @@ abstract class GReviewWithDateData
       b..G__typename = 'Mutation';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GReviewWithDateData_createReview get createReview;
+  GReviewWithDateData_createReview? get createReview;
   static Serializer<GReviewWithDateData> get serializer =>
       _$gReviewWithDateDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GReviewWithDateData.serializer, this);
-  static GReviewWithDateData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GReviewWithDateData.serializer, this)
+          as Map<String, dynamic>);
+  static GReviewWithDateData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GReviewWithDateData.serializer, json);
 }
 
@@ -44,20 +44,19 @@ abstract class GReviewWithDateData_createReview
       b..G__typename = 'Review';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  _i2.GEpisode get episode;
+  _i2.GEpisode? get episode;
   int get stars;
-  @nullable
-  String get commentary;
-  @nullable
-  DateTime get createdAt;
+  String? get commentary;
+  DateTime? get createdAt;
   BuiltList<DateTime> get seenOn;
   BuiltList<_i3.CustomField> get custom;
   static Serializer<GReviewWithDateData_createReview> get serializer =>
       _$gReviewWithDateDataCreateReviewSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GReviewWithDateData_createReview.serializer, this);
-  static GReviewWithDateData_createReview fromJson(Map<String, dynamic> json) =>
+  Map<String, dynamic> toJson() => (_i1.serializers
+          .serializeWith(GReviewWithDateData_createReview.serializer, this)
+      as Map<String, dynamic>);
+  static GReviewWithDateData_createReview? fromJson(
+          Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GReviewWithDateData_createReview.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/scalars/review_with_date.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/scalars/review_with_date.data.gql.g.dart
@@ -23,18 +23,20 @@ class _$GReviewWithDateDataSerializer
   final String wireName = 'GReviewWithDateData';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GReviewWithDateData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.createReview != null) {
+    Object? value;
+    value = object.createReview;
+    if (value != null) {
       result
         ..add('createReview')
-        ..add(serializers.serialize(object.createReview,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GReviewWithDateData_createReview)));
     }
     return result;
@@ -42,7 +44,7 @@ class _$GReviewWithDateDataSerializer
 
   @override
   GReviewWithDateData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GReviewWithDateDataBuilder();
 
@@ -50,7 +52,7 @@ class _$GReviewWithDateDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -59,7 +61,7 @@ class _$GReviewWithDateDataSerializer
         case 'createReview':
           result.createReview.replace(serializers.deserialize(value,
                   specifiedType:
-                      const FullType(GReviewWithDateData_createReview))
+                      const FullType(GReviewWithDateData_createReview))!
               as GReviewWithDateData_createReview);
           break;
       }
@@ -80,10 +82,10 @@ class _$GReviewWithDateData_createReviewSerializer
   final String wireName = 'GReviewWithDateData_createReview';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GReviewWithDateData_createReview object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
@@ -98,22 +100,26 @@ class _$GReviewWithDateData_createReviewSerializer
           specifiedType: const FullType(
               BuiltList, const [const FullType(_i3.CustomField)])),
     ];
-    if (object.episode != null) {
+    Object? value;
+    value = object.episode;
+    if (value != null) {
       result
         ..add('episode')
-        ..add(serializers.serialize(object.episode,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(_i2.GEpisode)));
     }
-    if (object.commentary != null) {
+    value = object.commentary;
+    if (value != null) {
       result
         ..add('commentary')
-        ..add(serializers.serialize(object.commentary,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
-    if (object.createdAt != null) {
+    value = object.createdAt;
+    if (value != null) {
       result
         ..add('createdAt')
-        ..add(serializers.serialize(object.createdAt,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(DateTime)));
     }
     return result;
@@ -121,7 +127,7 @@ class _$GReviewWithDateData_createReviewSerializer
 
   @override
   GReviewWithDateData_createReview deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GReviewWithDateData_createReviewBuilder();
 
@@ -129,7 +135,7 @@ class _$GReviewWithDateData_createReviewSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -154,13 +160,13 @@ class _$GReviewWithDateData_createReviewSerializer
         case 'seenOn':
           result.seenOn.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      BuiltList, const [const FullType(DateTime)]))
+                      BuiltList, const [const FullType(DateTime)]))!
               as BuiltList<Object>);
           break;
         case 'custom':
           result.custom.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
-                      BuiltList, const [const FullType(_i3.CustomField)]))
+                      BuiltList, const [const FullType(_i3.CustomField)]))!
               as BuiltList<Object>);
           break;
       }
@@ -174,16 +180,16 @@ class _$GReviewWithDateData extends GReviewWithDateData {
   @override
   final String G__typename;
   @override
-  final GReviewWithDateData_createReview createReview;
+  final GReviewWithDateData_createReview? createReview;
 
   factory _$GReviewWithDateData(
-          [void Function(GReviewWithDateDataBuilder) updates]) =>
+          [void Function(GReviewWithDateDataBuilder)? updates]) =>
       (new GReviewWithDateDataBuilder()..update(updates)).build();
 
-  _$GReviewWithDateData._({this.G__typename, this.createReview}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GReviewWithDateData', 'G__typename');
-    }
+  _$GReviewWithDateData._({required this.G__typename, this.createReview})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GReviewWithDateData', 'G__typename');
   }
 
   @override
@@ -219,16 +225,16 @@ class _$GReviewWithDateData extends GReviewWithDateData {
 
 class GReviewWithDateDataBuilder
     implements Builder<GReviewWithDateData, GReviewWithDateDataBuilder> {
-  _$GReviewWithDateData _$v;
+  _$GReviewWithDateData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GReviewWithDateData_createReviewBuilder _createReview;
+  GReviewWithDateData_createReviewBuilder? _createReview;
   GReviewWithDateData_createReviewBuilder get createReview =>
       _$this._createReview ??= new GReviewWithDateData_createReviewBuilder();
-  set createReview(GReviewWithDateData_createReviewBuilder createReview) =>
+  set createReview(GReviewWithDateData_createReviewBuilder? createReview) =>
       _$this._createReview = createReview;
 
   GReviewWithDateDataBuilder() {
@@ -236,9 +242,10 @@ class GReviewWithDateDataBuilder
   }
 
   GReviewWithDateDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _createReview = _$v.createReview?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _createReview = $v.createReview?.toBuilder();
       _$v = null;
     }
     return this;
@@ -246,14 +253,12 @@ class GReviewWithDateDataBuilder
 
   @override
   void replace(GReviewWithDateData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GReviewWithDateData;
   }
 
   @override
-  void update(void Function(GReviewWithDateDataBuilder) updates) {
+  void update(void Function(GReviewWithDateDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -263,9 +268,11 @@ class GReviewWithDateDataBuilder
     try {
       _$result = _$v ??
           new _$GReviewWithDateData._(
-              G__typename: G__typename, createReview: _createReview?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GReviewWithDateData', 'G__typename'),
+              createReview: _createReview?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'createReview';
         _createReview?.build();
@@ -285,47 +292,39 @@ class _$GReviewWithDateData_createReview
   @override
   final String G__typename;
   @override
-  final _i2.GEpisode episode;
+  final _i2.GEpisode? episode;
   @override
   final int stars;
   @override
-  final String commentary;
+  final String? commentary;
   @override
-  final DateTime createdAt;
+  final DateTime? createdAt;
   @override
   final BuiltList<DateTime> seenOn;
   @override
   final BuiltList<_i3.CustomField> custom;
 
   factory _$GReviewWithDateData_createReview(
-          [void Function(GReviewWithDateData_createReviewBuilder) updates]) =>
+          [void Function(GReviewWithDateData_createReviewBuilder)? updates]) =>
       (new GReviewWithDateData_createReviewBuilder()..update(updates)).build();
 
   _$GReviewWithDateData_createReview._(
-      {this.G__typename,
+      {required this.G__typename,
       this.episode,
-      this.stars,
+      required this.stars,
       this.commentary,
       this.createdAt,
-      this.seenOn,
-      this.custom})
+      required this.seenOn,
+      required this.custom})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GReviewWithDateData_createReview', 'G__typename');
-    }
-    if (stars == null) {
-      throw new BuiltValueNullFieldError(
-          'GReviewWithDateData_createReview', 'stars');
-    }
-    if (seenOn == null) {
-      throw new BuiltValueNullFieldError(
-          'GReviewWithDateData_createReview', 'seenOn');
-    }
-    if (custom == null) {
-      throw new BuiltValueNullFieldError(
-          'GReviewWithDateData_createReview', 'custom');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GReviewWithDateData_createReview', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        stars, 'GReviewWithDateData_createReview', 'stars');
+    BuiltValueNullFieldError.checkNotNull(
+        seenOn, 'GReviewWithDateData_createReview', 'seenOn');
+    BuiltValueNullFieldError.checkNotNull(
+        custom, 'GReviewWithDateData_createReview', 'custom');
   }
 
   @override
@@ -382,51 +381,52 @@ class GReviewWithDateData_createReviewBuilder
     implements
         Builder<GReviewWithDateData_createReview,
             GReviewWithDateData_createReviewBuilder> {
-  _$GReviewWithDateData_createReview _$v;
+  _$GReviewWithDateData_createReview? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  _i2.GEpisode _episode;
-  _i2.GEpisode get episode => _$this._episode;
-  set episode(_i2.GEpisode episode) => _$this._episode = episode;
+  _i2.GEpisode? _episode;
+  _i2.GEpisode? get episode => _$this._episode;
+  set episode(_i2.GEpisode? episode) => _$this._episode = episode;
 
-  int _stars;
-  int get stars => _$this._stars;
-  set stars(int stars) => _$this._stars = stars;
+  int? _stars;
+  int? get stars => _$this._stars;
+  set stars(int? stars) => _$this._stars = stars;
 
-  String _commentary;
-  String get commentary => _$this._commentary;
-  set commentary(String commentary) => _$this._commentary = commentary;
+  String? _commentary;
+  String? get commentary => _$this._commentary;
+  set commentary(String? commentary) => _$this._commentary = commentary;
 
-  DateTime _createdAt;
-  DateTime get createdAt => _$this._createdAt;
-  set createdAt(DateTime createdAt) => _$this._createdAt = createdAt;
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
 
-  ListBuilder<DateTime> _seenOn;
+  ListBuilder<DateTime>? _seenOn;
   ListBuilder<DateTime> get seenOn =>
       _$this._seenOn ??= new ListBuilder<DateTime>();
-  set seenOn(ListBuilder<DateTime> seenOn) => _$this._seenOn = seenOn;
+  set seenOn(ListBuilder<DateTime>? seenOn) => _$this._seenOn = seenOn;
 
-  ListBuilder<_i3.CustomField> _custom;
+  ListBuilder<_i3.CustomField>? _custom;
   ListBuilder<_i3.CustomField> get custom =>
       _$this._custom ??= new ListBuilder<_i3.CustomField>();
-  set custom(ListBuilder<_i3.CustomField> custom) => _$this._custom = custom;
+  set custom(ListBuilder<_i3.CustomField>? custom) => _$this._custom = custom;
 
   GReviewWithDateData_createReviewBuilder() {
     GReviewWithDateData_createReview._initializeBuilder(this);
   }
 
   GReviewWithDateData_createReviewBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _episode = _$v.episode;
-      _stars = _$v.stars;
-      _commentary = _$v.commentary;
-      _createdAt = _$v.createdAt;
-      _seenOn = _$v.seenOn?.toBuilder();
-      _custom = _$v.custom?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _episode = $v.episode;
+      _stars = $v.stars;
+      _commentary = $v.commentary;
+      _createdAt = $v.createdAt;
+      _seenOn = $v.seenOn.toBuilder();
+      _custom = $v.custom.toBuilder();
       _$v = null;
     }
     return this;
@@ -434,14 +434,12 @@ class GReviewWithDateData_createReviewBuilder
 
   @override
   void replace(GReviewWithDateData_createReview other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GReviewWithDateData_createReview;
   }
 
   @override
-  void update(void Function(GReviewWithDateData_createReviewBuilder) updates) {
+  void update(void Function(GReviewWithDateData_createReviewBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -451,15 +449,17 @@ class GReviewWithDateData_createReviewBuilder
     try {
       _$result = _$v ??
           new _$GReviewWithDateData_createReview._(
-              G__typename: G__typename,
+              G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                  'GReviewWithDateData_createReview', 'G__typename'),
               episode: episode,
-              stars: stars,
+              stars: BuiltValueNullFieldError.checkNotNull(
+                  stars, 'GReviewWithDateData_createReview', 'stars'),
               commentary: commentary,
               createdAt: createdAt,
               seenOn: seenOn.build(),
               custom: custom.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'seenOn';
         seenOn.build();

--- a/codegen/end_to_end_test/lib/scalars/review_with_date.req.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/review_with_date.req.gql.dart
@@ -24,7 +24,8 @@ abstract class GReviewWithDate
   static Serializer<GReviewWithDate> get serializer =>
       _$gReviewWithDateSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GReviewWithDate.serializer, this);
-  static GReviewWithDate fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GReviewWithDate.serializer, this)
+          as Map<String, dynamic>);
+  static GReviewWithDate? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GReviewWithDate.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/scalars/review_with_date.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/scalars/review_with_date.req.gql.g.dart
@@ -17,9 +17,9 @@ class _$GReviewWithDateSerializer
   final String wireName = 'GReviewWithDate';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GReviewWithDate object,
+  Iterable<Object?> serialize(Serializers serializers, GReviewWithDate object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GReviewWithDateVars)),
@@ -33,7 +33,7 @@ class _$GReviewWithDateSerializer
 
   @override
   GReviewWithDate deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GReviewWithDateBuilder();
 
@@ -41,11 +41,11 @@ class _$GReviewWithDateSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GReviewWithDateVars))
+                  specifiedType: const FullType(_i3.GReviewWithDateVars))!
               as _i3.GReviewWithDateVars);
           break;
         case 'operation':
@@ -65,16 +65,14 @@ class _$GReviewWithDate extends GReviewWithDate {
   @override
   final _i1.Operation operation;
 
-  factory _$GReviewWithDate([void Function(GReviewWithDateBuilder) updates]) =>
+  factory _$GReviewWithDate([void Function(GReviewWithDateBuilder)? updates]) =>
       (new GReviewWithDateBuilder()..update(updates)).build();
 
-  _$GReviewWithDate._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GReviewWithDate', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GReviewWithDate', 'operation');
-    }
+  _$GReviewWithDate._({required this.vars, required this.operation})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GReviewWithDate', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GReviewWithDate', 'operation');
   }
 
   @override
@@ -109,25 +107,26 @@ class _$GReviewWithDate extends GReviewWithDate {
 
 class GReviewWithDateBuilder
     implements Builder<GReviewWithDate, GReviewWithDateBuilder> {
-  _$GReviewWithDate _$v;
+  _$GReviewWithDate? _$v;
 
-  _i3.GReviewWithDateVarsBuilder _vars;
+  _i3.GReviewWithDateVarsBuilder? _vars;
   _i3.GReviewWithDateVarsBuilder get vars =>
       _$this._vars ??= new _i3.GReviewWithDateVarsBuilder();
-  set vars(_i3.GReviewWithDateVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GReviewWithDateVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GReviewWithDateBuilder() {
     GReviewWithDate._initializeBuilder(this);
   }
 
   GReviewWithDateBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -135,14 +134,12 @@ class GReviewWithDateBuilder
 
   @override
   void replace(GReviewWithDate other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GReviewWithDate;
   }
 
   @override
-  void update(void Function(GReviewWithDateBuilder) updates) {
+  void update(void Function(GReviewWithDateBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -151,9 +148,12 @@ class GReviewWithDateBuilder
     _$GReviewWithDate _$result;
     try {
       _$result = _$v ??
-          new _$GReviewWithDate._(vars: vars.build(), operation: operation);
+          new _$GReviewWithDate._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GReviewWithDate', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/scalars/review_with_date.var.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/review_with_date.var.gql.dart
@@ -14,15 +14,14 @@ abstract class GReviewWithDateVars
   factory GReviewWithDateVars(
       [Function(GReviewWithDateVarsBuilder b) updates]) = _$GReviewWithDateVars;
 
-  @nullable
-  _i1.GEpisode get episode;
+  _i1.GEpisode? get episode;
   _i1.GReviewInput get review;
-  @nullable
-  DateTime get createdAt;
+  DateTime? get createdAt;
   static Serializer<GReviewWithDateVars> get serializer =>
       _$gReviewWithDateVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i2.serializers.serializeWith(GReviewWithDateVars.serializer, this);
-  static GReviewWithDateVars fromJson(Map<String, dynamic> json) =>
+      (_i2.serializers.serializeWith(GReviewWithDateVars.serializer, this)
+          as Map<String, dynamic>);
+  static GReviewWithDateVars? fromJson(Map<String, dynamic> json) =>
       _i2.serializers.deserializeWith(GReviewWithDateVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/scalars/review_with_date.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/scalars/review_with_date.var.gql.g.dart
@@ -20,24 +20,27 @@ class _$GReviewWithDateVarsSerializer
   final String wireName = 'GReviewWithDateVars';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GReviewWithDateVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'review',
       serializers.serialize(object.review,
           specifiedType: const FullType(_i1.GReviewInput)),
     ];
-    if (object.episode != null) {
+    Object? value;
+    value = object.episode;
+    if (value != null) {
       result
         ..add('episode')
-        ..add(serializers.serialize(object.episode,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(_i1.GEpisode)));
     }
-    if (object.createdAt != null) {
+    value = object.createdAt;
+    if (value != null) {
       result
         ..add('createdAt')
-        ..add(serializers.serialize(object.createdAt,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(DateTime)));
     }
     return result;
@@ -45,7 +48,7 @@ class _$GReviewWithDateVarsSerializer
 
   @override
   GReviewWithDateVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GReviewWithDateVarsBuilder();
 
@@ -53,7 +56,7 @@ class _$GReviewWithDateVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'episode':
           result.episode = serializers.deserialize(value,
@@ -61,7 +64,7 @@ class _$GReviewWithDateVarsSerializer
           break;
         case 'review':
           result.review.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i1.GReviewInput))
+                  specifiedType: const FullType(_i1.GReviewInput))!
               as _i1.GReviewInput);
           break;
         case 'createdAt':
@@ -77,21 +80,20 @@ class _$GReviewWithDateVarsSerializer
 
 class _$GReviewWithDateVars extends GReviewWithDateVars {
   @override
-  final _i1.GEpisode episode;
+  final _i1.GEpisode? episode;
   @override
   final _i1.GReviewInput review;
   @override
-  final DateTime createdAt;
+  final DateTime? createdAt;
 
   factory _$GReviewWithDateVars(
-          [void Function(GReviewWithDateVarsBuilder) updates]) =>
+          [void Function(GReviewWithDateVarsBuilder)? updates]) =>
       (new GReviewWithDateVarsBuilder()..update(updates)).build();
 
-  _$GReviewWithDateVars._({this.episode, this.review, this.createdAt})
+  _$GReviewWithDateVars._({this.episode, required this.review, this.createdAt})
       : super._() {
-    if (review == null) {
-      throw new BuiltValueNullFieldError('GReviewWithDateVars', 'review');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        review, 'GReviewWithDateVars', 'review');
   }
 
   @override
@@ -130,28 +132,29 @@ class _$GReviewWithDateVars extends GReviewWithDateVars {
 
 class GReviewWithDateVarsBuilder
     implements Builder<GReviewWithDateVars, GReviewWithDateVarsBuilder> {
-  _$GReviewWithDateVars _$v;
+  _$GReviewWithDateVars? _$v;
 
-  _i1.GEpisode _episode;
-  _i1.GEpisode get episode => _$this._episode;
-  set episode(_i1.GEpisode episode) => _$this._episode = episode;
+  _i1.GEpisode? _episode;
+  _i1.GEpisode? get episode => _$this._episode;
+  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
 
-  _i1.GReviewInputBuilder _review;
+  _i1.GReviewInputBuilder? _review;
   _i1.GReviewInputBuilder get review =>
       _$this._review ??= new _i1.GReviewInputBuilder();
-  set review(_i1.GReviewInputBuilder review) => _$this._review = review;
+  set review(_i1.GReviewInputBuilder? review) => _$this._review = review;
 
-  DateTime _createdAt;
-  DateTime get createdAt => _$this._createdAt;
-  set createdAt(DateTime createdAt) => _$this._createdAt = createdAt;
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
 
   GReviewWithDateVarsBuilder();
 
   GReviewWithDateVarsBuilder get _$this {
-    if (_$v != null) {
-      _episode = _$v.episode;
-      _review = _$v.review?.toBuilder();
-      _createdAt = _$v.createdAt;
+    final $v = _$v;
+    if ($v != null) {
+      _episode = $v.episode;
+      _review = $v.review.toBuilder();
+      _createdAt = $v.createdAt;
       _$v = null;
     }
     return this;
@@ -159,14 +162,12 @@ class GReviewWithDateVarsBuilder
 
   @override
   void replace(GReviewWithDateVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GReviewWithDateVars;
   }
 
   @override
-  void update(void Function(GReviewWithDateVarsBuilder) updates) {
+  void update(void Function(GReviewWithDateVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -178,7 +179,7 @@ class GReviewWithDateVarsBuilder
           new _$GReviewWithDateVars._(
               episode: episode, review: review.build(), createdAt: createdAt);
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'review';
         review.build();

--- a/codegen/end_to_end_test/lib/variables/create_review.data.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/create_review.data.gql.dart
@@ -18,13 +18,13 @@ abstract class GCreateReviewData
       b..G__typename = 'Mutation';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GCreateReviewData_createReview get createReview;
+  GCreateReviewData_createReview? get createReview;
   static Serializer<GCreateReviewData> get serializer =>
       _$gCreateReviewDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GCreateReviewData.serializer, this);
-  static GCreateReviewData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GCreateReviewData.serializer, this)
+          as Map<String, dynamic>);
+  static GCreateReviewData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GCreateReviewData.serializer, json);
 }
 
@@ -42,16 +42,14 @@ abstract class GCreateReviewData_createReview
       b..G__typename = 'Review';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  _i2.GEpisode get episode;
+  _i2.GEpisode? get episode;
   int get stars;
-  @nullable
-  String get commentary;
+  String? get commentary;
   static Serializer<GCreateReviewData_createReview> get serializer =>
       _$gCreateReviewDataCreateReviewSerializer;
-  Map<String, dynamic> toJson() => _i1.serializers
-      .serializeWith(GCreateReviewData_createReview.serializer, this);
-  static GCreateReviewData_createReview fromJson(Map<String, dynamic> json) =>
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+      GCreateReviewData_createReview.serializer, this) as Map<String, dynamic>);
+  static GCreateReviewData_createReview? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GCreateReviewData_createReview.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/variables/create_review.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/create_review.data.gql.g.dart
@@ -20,17 +20,19 @@ class _$GCreateReviewDataSerializer
   final String wireName = 'GCreateReviewData';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GCreateReviewData object,
+  Iterable<Object?> serialize(Serializers serializers, GCreateReviewData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.createReview != null) {
+    Object? value;
+    value = object.createReview;
+    if (value != null) {
       result
         ..add('createReview')
-        ..add(serializers.serialize(object.createReview,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GCreateReviewData_createReview)));
     }
     return result;
@@ -38,7 +40,7 @@ class _$GCreateReviewDataSerializer
 
   @override
   GCreateReviewData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GCreateReviewDataBuilder();
 
@@ -46,7 +48,7 @@ class _$GCreateReviewDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -54,7 +56,8 @@ class _$GCreateReviewDataSerializer
           break;
         case 'createReview':
           result.createReview.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(GCreateReviewData_createReview))
+                  specifiedType:
+                      const FullType(GCreateReviewData_createReview))!
               as GCreateReviewData_createReview);
           break;
       }
@@ -75,26 +78,29 @@ class _$GCreateReviewData_createReviewSerializer
   final String wireName = 'GCreateReviewData_createReview';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GCreateReviewData_createReview object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
       'stars',
       serializers.serialize(object.stars, specifiedType: const FullType(int)),
     ];
-    if (object.episode != null) {
+    Object? value;
+    value = object.episode;
+    if (value != null) {
       result
         ..add('episode')
-        ..add(serializers.serialize(object.episode,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(_i2.GEpisode)));
     }
-    if (object.commentary != null) {
+    value = object.commentary;
+    if (value != null) {
       result
         ..add('commentary')
-        ..add(serializers.serialize(object.commentary,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
     return result;
@@ -102,7 +108,7 @@ class _$GCreateReviewData_createReviewSerializer
 
   @override
   GCreateReviewData_createReview deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GCreateReviewData_createReviewBuilder();
 
@@ -110,7 +116,7 @@ class _$GCreateReviewData_createReviewSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -139,16 +145,16 @@ class _$GCreateReviewData extends GCreateReviewData {
   @override
   final String G__typename;
   @override
-  final GCreateReviewData_createReview createReview;
+  final GCreateReviewData_createReview? createReview;
 
   factory _$GCreateReviewData(
-          [void Function(GCreateReviewDataBuilder) updates]) =>
+          [void Function(GCreateReviewDataBuilder)? updates]) =>
       (new GCreateReviewDataBuilder()..update(updates)).build();
 
-  _$GCreateReviewData._({this.G__typename, this.createReview}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GCreateReviewData', 'G__typename');
-    }
+  _$GCreateReviewData._({required this.G__typename, this.createReview})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GCreateReviewData', 'G__typename');
   }
 
   @override
@@ -183,16 +189,16 @@ class _$GCreateReviewData extends GCreateReviewData {
 
 class GCreateReviewDataBuilder
     implements Builder<GCreateReviewData, GCreateReviewDataBuilder> {
-  _$GCreateReviewData _$v;
+  _$GCreateReviewData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GCreateReviewData_createReviewBuilder _createReview;
+  GCreateReviewData_createReviewBuilder? _createReview;
   GCreateReviewData_createReviewBuilder get createReview =>
       _$this._createReview ??= new GCreateReviewData_createReviewBuilder();
-  set createReview(GCreateReviewData_createReviewBuilder createReview) =>
+  set createReview(GCreateReviewData_createReviewBuilder? createReview) =>
       _$this._createReview = createReview;
 
   GCreateReviewDataBuilder() {
@@ -200,9 +206,10 @@ class GCreateReviewDataBuilder
   }
 
   GCreateReviewDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _createReview = _$v.createReview?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _createReview = $v.createReview?.toBuilder();
       _$v = null;
     }
     return this;
@@ -210,14 +217,12 @@ class GCreateReviewDataBuilder
 
   @override
   void replace(GCreateReviewData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GCreateReviewData;
   }
 
   @override
-  void update(void Function(GCreateReviewDataBuilder) updates) {
+  void update(void Function(GCreateReviewDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -227,9 +232,11 @@ class GCreateReviewDataBuilder
     try {
       _$result = _$v ??
           new _$GCreateReviewData._(
-              G__typename: G__typename, createReview: _createReview?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GCreateReviewData', 'G__typename'),
+              createReview: _createReview?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'createReview';
         _createReview?.build();
@@ -248,27 +255,26 @@ class _$GCreateReviewData_createReview extends GCreateReviewData_createReview {
   @override
   final String G__typename;
   @override
-  final _i2.GEpisode episode;
+  final _i2.GEpisode? episode;
   @override
   final int stars;
   @override
-  final String commentary;
+  final String? commentary;
 
   factory _$GCreateReviewData_createReview(
-          [void Function(GCreateReviewData_createReviewBuilder) updates]) =>
+          [void Function(GCreateReviewData_createReviewBuilder)? updates]) =>
       (new GCreateReviewData_createReviewBuilder()..update(updates)).build();
 
   _$GCreateReviewData_createReview._(
-      {this.G__typename, this.episode, this.stars, this.commentary})
+      {required this.G__typename,
+      this.episode,
+      required this.stars,
+      this.commentary})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GCreateReviewData_createReview', 'G__typename');
-    }
-    if (stars == null) {
-      throw new BuiltValueNullFieldError(
-          'GCreateReviewData_createReview', 'stars');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GCreateReviewData_createReview', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        stars, 'GCreateReviewData_createReview', 'stars');
   }
 
   @override
@@ -313,34 +319,35 @@ class GCreateReviewData_createReviewBuilder
     implements
         Builder<GCreateReviewData_createReview,
             GCreateReviewData_createReviewBuilder> {
-  _$GCreateReviewData_createReview _$v;
+  _$GCreateReviewData_createReview? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  _i2.GEpisode _episode;
-  _i2.GEpisode get episode => _$this._episode;
-  set episode(_i2.GEpisode episode) => _$this._episode = episode;
+  _i2.GEpisode? _episode;
+  _i2.GEpisode? get episode => _$this._episode;
+  set episode(_i2.GEpisode? episode) => _$this._episode = episode;
 
-  int _stars;
-  int get stars => _$this._stars;
-  set stars(int stars) => _$this._stars = stars;
+  int? _stars;
+  int? get stars => _$this._stars;
+  set stars(int? stars) => _$this._stars = stars;
 
-  String _commentary;
-  String get commentary => _$this._commentary;
-  set commentary(String commentary) => _$this._commentary = commentary;
+  String? _commentary;
+  String? get commentary => _$this._commentary;
+  set commentary(String? commentary) => _$this._commentary = commentary;
 
   GCreateReviewData_createReviewBuilder() {
     GCreateReviewData_createReview._initializeBuilder(this);
   }
 
   GCreateReviewData_createReviewBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _episode = _$v.episode;
-      _stars = _$v.stars;
-      _commentary = _$v.commentary;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _episode = $v.episode;
+      _stars = $v.stars;
+      _commentary = $v.commentary;
       _$v = null;
     }
     return this;
@@ -348,14 +355,12 @@ class GCreateReviewData_createReviewBuilder
 
   @override
   void replace(GCreateReviewData_createReview other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GCreateReviewData_createReview;
   }
 
   @override
-  void update(void Function(GCreateReviewData_createReviewBuilder) updates) {
+  void update(void Function(GCreateReviewData_createReviewBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -363,9 +368,11 @@ class GCreateReviewData_createReviewBuilder
   _$GCreateReviewData_createReview build() {
     final _$result = _$v ??
         new _$GCreateReviewData_createReview._(
-            G__typename: G__typename,
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, 'GCreateReviewData_createReview', 'G__typename'),
             episode: episode,
-            stars: stars,
+            stars: BuiltValueNullFieldError.checkNotNull(
+                stars, 'GCreateReviewData_createReview', 'stars'),
             commentary: commentary);
     replace(_$result);
     return _$result;

--- a/codegen/end_to_end_test/lib/variables/create_review.req.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/create_review.req.gql.dart
@@ -23,7 +23,8 @@ abstract class GCreateReview
   _i1.Operation get operation;
   static Serializer<GCreateReview> get serializer => _$gCreateReviewSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GCreateReview.serializer, this);
-  static GCreateReview fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GCreateReview.serializer, this)
+          as Map<String, dynamic>);
+  static GCreateReview? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GCreateReview.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/variables/create_review.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/create_review.req.gql.g.dart
@@ -16,9 +16,9 @@ class _$GCreateReviewSerializer implements StructuredSerializer<GCreateReview> {
   final String wireName = 'GCreateReview';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GCreateReview object,
+  Iterable<Object?> serialize(Serializers serializers, GCreateReview object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GCreateReviewVars)),
@@ -32,7 +32,7 @@ class _$GCreateReviewSerializer implements StructuredSerializer<GCreateReview> {
 
   @override
   GCreateReview deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GCreateReviewBuilder();
 
@@ -40,11 +40,11 @@ class _$GCreateReviewSerializer implements StructuredSerializer<GCreateReview> {
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GCreateReviewVars))
+                  specifiedType: const FullType(_i3.GCreateReviewVars))!
               as _i3.GCreateReviewVars);
           break;
         case 'operation':
@@ -64,16 +64,13 @@ class _$GCreateReview extends GCreateReview {
   @override
   final _i1.Operation operation;
 
-  factory _$GCreateReview([void Function(GCreateReviewBuilder) updates]) =>
+  factory _$GCreateReview([void Function(GCreateReviewBuilder)? updates]) =>
       (new GCreateReviewBuilder()..update(updates)).build();
 
-  _$GCreateReview._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GCreateReview', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GCreateReview', 'operation');
-    }
+  _$GCreateReview._({required this.vars, required this.operation}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GCreateReview', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GCreateReview', 'operation');
   }
 
   @override
@@ -107,25 +104,26 @@ class _$GCreateReview extends GCreateReview {
 
 class GCreateReviewBuilder
     implements Builder<GCreateReview, GCreateReviewBuilder> {
-  _$GCreateReview _$v;
+  _$GCreateReview? _$v;
 
-  _i3.GCreateReviewVarsBuilder _vars;
+  _i3.GCreateReviewVarsBuilder? _vars;
   _i3.GCreateReviewVarsBuilder get vars =>
       _$this._vars ??= new _i3.GCreateReviewVarsBuilder();
-  set vars(_i3.GCreateReviewVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GCreateReviewVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GCreateReviewBuilder() {
     GCreateReview._initializeBuilder(this);
   }
 
   GCreateReviewBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -133,14 +131,12 @@ class GCreateReviewBuilder
 
   @override
   void replace(GCreateReview other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GCreateReview;
   }
 
   @override
-  void update(void Function(GCreateReviewBuilder) updates) {
+  void update(void Function(GCreateReviewBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -149,9 +145,12 @@ class GCreateReviewBuilder
     _$GCreateReview _$result;
     try {
       _$result = _$v ??
-          new _$GCreateReview._(vars: vars.build(), operation: operation);
+          new _$GCreateReview._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GCreateReview', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/variables/create_review.var.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/create_review.var.gql.dart
@@ -14,13 +14,13 @@ abstract class GCreateReviewVars
   factory GCreateReviewVars([Function(GCreateReviewVarsBuilder b) updates]) =
       _$GCreateReviewVars;
 
-  @nullable
-  _i1.GEpisode get episode;
+  _i1.GEpisode? get episode;
   _i1.GReviewInput get review;
   static Serializer<GCreateReviewVars> get serializer =>
       _$gCreateReviewVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i2.serializers.serializeWith(GCreateReviewVars.serializer, this);
-  static GCreateReviewVars fromJson(Map<String, dynamic> json) =>
+      (_i2.serializers.serializeWith(GCreateReviewVars.serializer, this)
+          as Map<String, dynamic>);
+  static GCreateReviewVars? fromJson(Map<String, dynamic> json) =>
       _i2.serializers.deserializeWith(GCreateReviewVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/variables/create_review.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/create_review.var.gql.g.dart
@@ -17,17 +17,19 @@ class _$GCreateReviewVarsSerializer
   final String wireName = 'GCreateReviewVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GCreateReviewVars object,
+  Iterable<Object?> serialize(Serializers serializers, GCreateReviewVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'review',
       serializers.serialize(object.review,
           specifiedType: const FullType(_i1.GReviewInput)),
     ];
-    if (object.episode != null) {
+    Object? value;
+    value = object.episode;
+    if (value != null) {
       result
         ..add('episode')
-        ..add(serializers.serialize(object.episode,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(_i1.GEpisode)));
     }
     return result;
@@ -35,7 +37,7 @@ class _$GCreateReviewVarsSerializer
 
   @override
   GCreateReviewVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GCreateReviewVarsBuilder();
 
@@ -43,7 +45,7 @@ class _$GCreateReviewVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'episode':
           result.episode = serializers.deserialize(value,
@@ -51,7 +53,7 @@ class _$GCreateReviewVarsSerializer
           break;
         case 'review':
           result.review.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i1.GReviewInput))
+                  specifiedType: const FullType(_i1.GReviewInput))!
               as _i1.GReviewInput);
           break;
       }
@@ -63,18 +65,17 @@ class _$GCreateReviewVarsSerializer
 
 class _$GCreateReviewVars extends GCreateReviewVars {
   @override
-  final _i1.GEpisode episode;
+  final _i1.GEpisode? episode;
   @override
   final _i1.GReviewInput review;
 
   factory _$GCreateReviewVars(
-          [void Function(GCreateReviewVarsBuilder) updates]) =>
+          [void Function(GCreateReviewVarsBuilder)? updates]) =>
       (new GCreateReviewVarsBuilder()..update(updates)).build();
 
-  _$GCreateReviewVars._({this.episode, this.review}) : super._() {
-    if (review == null) {
-      throw new BuiltValueNullFieldError('GCreateReviewVars', 'review');
-    }
+  _$GCreateReviewVars._({this.episode, required this.review}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        review, 'GCreateReviewVars', 'review');
   }
 
   @override
@@ -109,23 +110,24 @@ class _$GCreateReviewVars extends GCreateReviewVars {
 
 class GCreateReviewVarsBuilder
     implements Builder<GCreateReviewVars, GCreateReviewVarsBuilder> {
-  _$GCreateReviewVars _$v;
+  _$GCreateReviewVars? _$v;
 
-  _i1.GEpisode _episode;
-  _i1.GEpisode get episode => _$this._episode;
-  set episode(_i1.GEpisode episode) => _$this._episode = episode;
+  _i1.GEpisode? _episode;
+  _i1.GEpisode? get episode => _$this._episode;
+  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
 
-  _i1.GReviewInputBuilder _review;
+  _i1.GReviewInputBuilder? _review;
   _i1.GReviewInputBuilder get review =>
       _$this._review ??= new _i1.GReviewInputBuilder();
-  set review(_i1.GReviewInputBuilder review) => _$this._review = review;
+  set review(_i1.GReviewInputBuilder? review) => _$this._review = review;
 
   GCreateReviewVarsBuilder();
 
   GCreateReviewVarsBuilder get _$this {
-    if (_$v != null) {
-      _episode = _$v.episode;
-      _review = _$v.review?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _episode = $v.episode;
+      _review = $v.review.toBuilder();
       _$v = null;
     }
     return this;
@@ -133,14 +135,12 @@ class GCreateReviewVarsBuilder
 
   @override
   void replace(GCreateReviewVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GCreateReviewVars;
   }
 
   @override
-  void update(void Function(GCreateReviewVarsBuilder) updates) {
+  void update(void Function(GCreateReviewVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -151,7 +151,7 @@ class GCreateReviewVarsBuilder
       _$result = _$v ??
           new _$GCreateReviewVars._(episode: episode, review: review.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'review';
         review.build();

--- a/codegen/end_to_end_test/lib/variables/human_with_args.data.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/human_with_args.data.gql.dart
@@ -17,13 +17,13 @@ abstract class GHumanWithArgsData
       b..G__typename = 'Query';
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @nullable
-  GHumanWithArgsData_human get human;
+  GHumanWithArgsData_human? get human;
   static Serializer<GHumanWithArgsData> get serializer =>
       _$gHumanWithArgsDataSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHumanWithArgsData.serializer, this);
-  static GHumanWithArgsData fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHumanWithArgsData.serializer, this)
+          as Map<String, dynamic>);
+  static GHumanWithArgsData? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHumanWithArgsData.serializer, json);
 }
 
@@ -41,13 +41,13 @@ abstract class GHumanWithArgsData_human
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
   String get name;
-  @nullable
-  double get height;
+  double? get height;
   static Serializer<GHumanWithArgsData_human> get serializer =>
       _$gHumanWithArgsDataHumanSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHumanWithArgsData_human.serializer, this);
-  static GHumanWithArgsData_human fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHumanWithArgsData_human.serializer, this)
+          as Map<String, dynamic>);
+  static GHumanWithArgsData_human? fromJson(Map<String, dynamic> json) =>
       _i1.serializers
           .deserializeWith(GHumanWithArgsData_human.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/variables/human_with_args.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/human_with_args.data.gql.g.dart
@@ -19,17 +19,20 @@ class _$GHumanWithArgsDataSerializer
   final String wireName = 'GHumanWithArgsData';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHumanWithArgsData object,
+  Iterable<Object?> serialize(
+      Serializers serializers, GHumanWithArgsData object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
     ];
-    if (object.human != null) {
+    Object? value;
+    value = object.human;
+    if (value != null) {
       result
         ..add('human')
-        ..add(serializers.serialize(object.human,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(GHumanWithArgsData_human)));
     }
     return result;
@@ -37,7 +40,7 @@ class _$GHumanWithArgsDataSerializer
 
   @override
   GHumanWithArgsData deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHumanWithArgsDataBuilder();
 
@@ -45,7 +48,7 @@ class _$GHumanWithArgsDataSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -53,7 +56,7 @@ class _$GHumanWithArgsDataSerializer
           break;
         case 'human':
           result.human.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(GHumanWithArgsData_human))
+                  specifiedType: const FullType(GHumanWithArgsData_human))!
               as GHumanWithArgsData_human);
           break;
       }
@@ -74,20 +77,22 @@ class _$GHumanWithArgsData_humanSerializer
   final String wireName = 'GHumanWithArgsData_human';
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
       Serializers serializers, GHumanWithArgsData_human object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       '__typename',
       serializers.serialize(object.G__typename,
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
     ];
-    if (object.height != null) {
+    Object? value;
+    value = object.height;
+    if (value != null) {
       result
         ..add('height')
-        ..add(serializers.serialize(object.height,
+        ..add(serializers.serialize(value,
             specifiedType: const FullType(double)));
     }
     return result;
@@ -95,7 +100,7 @@ class _$GHumanWithArgsData_humanSerializer
 
   @override
   GHumanWithArgsData_human deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHumanWithArgsData_humanBuilder();
 
@@ -103,7 +108,7 @@ class _$GHumanWithArgsData_humanSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case '__typename':
           result.G__typename = serializers.deserialize(value,
@@ -128,16 +133,15 @@ class _$GHumanWithArgsData extends GHumanWithArgsData {
   @override
   final String G__typename;
   @override
-  final GHumanWithArgsData_human human;
+  final GHumanWithArgsData_human? human;
 
   factory _$GHumanWithArgsData(
-          [void Function(GHumanWithArgsDataBuilder) updates]) =>
+          [void Function(GHumanWithArgsDataBuilder)? updates]) =>
       (new GHumanWithArgsDataBuilder()..update(updates)).build();
 
-  _$GHumanWithArgsData._({this.G__typename, this.human}) : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError('GHumanWithArgsData', 'G__typename');
-    }
+  _$GHumanWithArgsData._({required this.G__typename, this.human}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHumanWithArgsData', 'G__typename');
   }
 
   @override
@@ -173,25 +177,26 @@ class _$GHumanWithArgsData extends GHumanWithArgsData {
 
 class GHumanWithArgsDataBuilder
     implements Builder<GHumanWithArgsData, GHumanWithArgsDataBuilder> {
-  _$GHumanWithArgsData _$v;
+  _$GHumanWithArgsData? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  GHumanWithArgsData_humanBuilder _human;
+  GHumanWithArgsData_humanBuilder? _human;
   GHumanWithArgsData_humanBuilder get human =>
       _$this._human ??= new GHumanWithArgsData_humanBuilder();
-  set human(GHumanWithArgsData_humanBuilder human) => _$this._human = human;
+  set human(GHumanWithArgsData_humanBuilder? human) => _$this._human = human;
 
   GHumanWithArgsDataBuilder() {
     GHumanWithArgsData._initializeBuilder(this);
   }
 
   GHumanWithArgsDataBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _human = _$v.human?.toBuilder();
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _human = $v.human?.toBuilder();
       _$v = null;
     }
     return this;
@@ -199,14 +204,12 @@ class GHumanWithArgsDataBuilder
 
   @override
   void replace(GHumanWithArgsData other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHumanWithArgsData;
   }
 
   @override
-  void update(void Function(GHumanWithArgsDataBuilder) updates) {
+  void update(void Function(GHumanWithArgsDataBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -216,9 +219,11 @@ class GHumanWithArgsDataBuilder
     try {
       _$result = _$v ??
           new _$GHumanWithArgsData._(
-              G__typename: G__typename, human: _human?.build());
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, 'GHumanWithArgsData', 'G__typename'),
+              human: _human?.build());
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'human';
         _human?.build();
@@ -239,21 +244,19 @@ class _$GHumanWithArgsData_human extends GHumanWithArgsData_human {
   @override
   final String name;
   @override
-  final double height;
+  final double? height;
 
   factory _$GHumanWithArgsData_human(
-          [void Function(GHumanWithArgsData_humanBuilder) updates]) =>
+          [void Function(GHumanWithArgsData_humanBuilder)? updates]) =>
       (new GHumanWithArgsData_humanBuilder()..update(updates)).build();
 
-  _$GHumanWithArgsData_human._({this.G__typename, this.name, this.height})
+  _$GHumanWithArgsData_human._(
+      {required this.G__typename, required this.name, this.height})
       : super._() {
-    if (G__typename == null) {
-      throw new BuiltValueNullFieldError(
-          'GHumanWithArgsData_human', 'G__typename');
-    }
-    if (name == null) {
-      throw new BuiltValueNullFieldError('GHumanWithArgsData_human', 'name');
-    }
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, 'GHumanWithArgsData_human', 'G__typename');
+    BuiltValueNullFieldError.checkNotNull(
+        name, 'GHumanWithArgsData_human', 'name');
   }
 
   @override
@@ -293,29 +296,30 @@ class _$GHumanWithArgsData_human extends GHumanWithArgsData_human {
 class GHumanWithArgsData_humanBuilder
     implements
         Builder<GHumanWithArgsData_human, GHumanWithArgsData_humanBuilder> {
-  _$GHumanWithArgsData_human _$v;
+  _$GHumanWithArgsData_human? _$v;
 
-  String _G__typename;
-  String get G__typename => _$this._G__typename;
-  set G__typename(String G__typename) => _$this._G__typename = G__typename;
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
 
-  String _name;
-  String get name => _$this._name;
-  set name(String name) => _$this._name = name;
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
-  double _height;
-  double get height => _$this._height;
-  set height(double height) => _$this._height = height;
+  double? _height;
+  double? get height => _$this._height;
+  set height(double? height) => _$this._height = height;
 
   GHumanWithArgsData_humanBuilder() {
     GHumanWithArgsData_human._initializeBuilder(this);
   }
 
   GHumanWithArgsData_humanBuilder get _$this {
-    if (_$v != null) {
-      _G__typename = _$v.G__typename;
-      _name = _$v.name;
-      _height = _$v.height;
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
+      _height = $v.height;
       _$v = null;
     }
     return this;
@@ -323,14 +327,12 @@ class GHumanWithArgsData_humanBuilder
 
   @override
   void replace(GHumanWithArgsData_human other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHumanWithArgsData_human;
   }
 
   @override
-  void update(void Function(GHumanWithArgsData_humanBuilder) updates) {
+  void update(void Function(GHumanWithArgsData_humanBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -338,7 +340,11 @@ class GHumanWithArgsData_humanBuilder
   _$GHumanWithArgsData_human build() {
     final _$result = _$v ??
         new _$GHumanWithArgsData_human._(
-            G__typename: G__typename, name: name, height: height);
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, 'GHumanWithArgsData_human', 'G__typename'),
+            name: BuiltValueNullFieldError.checkNotNull(
+                name, 'GHumanWithArgsData_human', 'name'),
+            height: height);
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/variables/human_with_args.req.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/human_with_args.req.gql.dart
@@ -24,7 +24,8 @@ abstract class GHumanWithArgs
   static Serializer<GHumanWithArgs> get serializer =>
       _$gHumanWithArgsSerializer;
   Map<String, dynamic> toJson() =>
-      _i4.serializers.serializeWith(GHumanWithArgs.serializer, this);
-  static GHumanWithArgs fromJson(Map<String, dynamic> json) =>
+      (_i4.serializers.serializeWith(GHumanWithArgs.serializer, this)
+          as Map<String, dynamic>);
+  static GHumanWithArgs? fromJson(Map<String, dynamic> json) =>
       _i4.serializers.deserializeWith(GHumanWithArgs.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/variables/human_with_args.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/human_with_args.req.gql.g.dart
@@ -17,9 +17,9 @@ class _$GHumanWithArgsSerializer
   final String wireName = 'GHumanWithArgs';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHumanWithArgs object,
+  Iterable<Object?> serialize(Serializers serializers, GHumanWithArgs object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'vars',
       serializers.serialize(object.vars,
           specifiedType: const FullType(_i3.GHumanWithArgsVars)),
@@ -33,7 +33,7 @@ class _$GHumanWithArgsSerializer
 
   @override
   GHumanWithArgs deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHumanWithArgsBuilder();
 
@@ -41,11 +41,11 @@ class _$GHumanWithArgsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'vars':
           result.vars.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i3.GHumanWithArgsVars))
+                  specifiedType: const FullType(_i3.GHumanWithArgsVars))!
               as _i3.GHumanWithArgsVars);
           break;
         case 'operation':
@@ -65,16 +65,14 @@ class _$GHumanWithArgs extends GHumanWithArgs {
   @override
   final _i1.Operation operation;
 
-  factory _$GHumanWithArgs([void Function(GHumanWithArgsBuilder) updates]) =>
+  factory _$GHumanWithArgs([void Function(GHumanWithArgsBuilder)? updates]) =>
       (new GHumanWithArgsBuilder()..update(updates)).build();
 
-  _$GHumanWithArgs._({this.vars, this.operation}) : super._() {
-    if (vars == null) {
-      throw new BuiltValueNullFieldError('GHumanWithArgs', 'vars');
-    }
-    if (operation == null) {
-      throw new BuiltValueNullFieldError('GHumanWithArgs', 'operation');
-    }
+  _$GHumanWithArgs._({required this.vars, required this.operation})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(vars, 'GHumanWithArgs', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, 'GHumanWithArgs', 'operation');
   }
 
   @override
@@ -109,25 +107,26 @@ class _$GHumanWithArgs extends GHumanWithArgs {
 
 class GHumanWithArgsBuilder
     implements Builder<GHumanWithArgs, GHumanWithArgsBuilder> {
-  _$GHumanWithArgs _$v;
+  _$GHumanWithArgs? _$v;
 
-  _i3.GHumanWithArgsVarsBuilder _vars;
+  _i3.GHumanWithArgsVarsBuilder? _vars;
   _i3.GHumanWithArgsVarsBuilder get vars =>
       _$this._vars ??= new _i3.GHumanWithArgsVarsBuilder();
-  set vars(_i3.GHumanWithArgsVarsBuilder vars) => _$this._vars = vars;
+  set vars(_i3.GHumanWithArgsVarsBuilder? vars) => _$this._vars = vars;
 
-  _i1.Operation _operation;
-  _i1.Operation get operation => _$this._operation;
-  set operation(_i1.Operation operation) => _$this._operation = operation;
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
 
   GHumanWithArgsBuilder() {
     GHumanWithArgs._initializeBuilder(this);
   }
 
   GHumanWithArgsBuilder get _$this {
-    if (_$v != null) {
-      _vars = _$v.vars?.toBuilder();
-      _operation = _$v.operation;
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
       _$v = null;
     }
     return this;
@@ -135,14 +134,12 @@ class GHumanWithArgsBuilder
 
   @override
   void replace(GHumanWithArgs other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHumanWithArgs;
   }
 
   @override
-  void update(void Function(GHumanWithArgsBuilder) updates) {
+  void update(void Function(GHumanWithArgsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
@@ -151,9 +148,12 @@ class GHumanWithArgsBuilder
     _$GHumanWithArgs _$result;
     try {
       _$result = _$v ??
-          new _$GHumanWithArgs._(vars: vars.build(), operation: operation);
+          new _$GHumanWithArgs._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, 'GHumanWithArgs', 'operation'));
     } catch (_) {
-      String _$failedField;
+      late String _$failedField;
       try {
         _$failedField = 'vars';
         vars.build();

--- a/codegen/end_to_end_test/lib/variables/human_with_args.var.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/human_with_args.var.gql.dart
@@ -17,7 +17,8 @@ abstract class GHumanWithArgsVars
   static Serializer<GHumanWithArgsVars> get serializer =>
       _$gHumanWithArgsVarsSerializer;
   Map<String, dynamic> toJson() =>
-      _i1.serializers.serializeWith(GHumanWithArgsVars.serializer, this);
-  static GHumanWithArgsVars fromJson(Map<String, dynamic> json) =>
+      (_i1.serializers.serializeWith(GHumanWithArgsVars.serializer, this)
+          as Map<String, dynamic>);
+  static GHumanWithArgsVars? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(GHumanWithArgsVars.serializer, json);
 }

--- a/codegen/end_to_end_test/lib/variables/human_with_args.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/human_with_args.var.gql.g.dart
@@ -17,9 +17,10 @@ class _$GHumanWithArgsVarsSerializer
   final String wireName = 'GHumanWithArgsVars';
 
   @override
-  Iterable<Object> serialize(Serializers serializers, GHumanWithArgsVars object,
+  Iterable<Object?> serialize(
+      Serializers serializers, GHumanWithArgsVars object,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object>[
+    final result = <Object?>[
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
     ];
@@ -29,7 +30,7 @@ class _$GHumanWithArgsVarsSerializer
 
   @override
   GHumanWithArgsVars deserialize(
-      Serializers serializers, Iterable<Object> serialized,
+      Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = new GHumanWithArgsVarsBuilder();
 
@@ -37,7 +38,7 @@ class _$GHumanWithArgsVarsSerializer
     while (iterator.moveNext()) {
       final key = iterator.current as String;
       iterator.moveNext();
-      final dynamic value = iterator.current;
+      final Object? value = iterator.current;
       switch (key) {
         case 'id':
           result.id = serializers.deserialize(value,
@@ -55,13 +56,11 @@ class _$GHumanWithArgsVars extends GHumanWithArgsVars {
   final String id;
 
   factory _$GHumanWithArgsVars(
-          [void Function(GHumanWithArgsVarsBuilder) updates]) =>
+          [void Function(GHumanWithArgsVarsBuilder)? updates]) =>
       (new GHumanWithArgsVarsBuilder()..update(updates)).build();
 
-  _$GHumanWithArgsVars._({this.id}) : super._() {
-    if (id == null) {
-      throw new BuiltValueNullFieldError('GHumanWithArgsVars', 'id');
-    }
+  _$GHumanWithArgsVars._({required this.id}) : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, 'GHumanWithArgsVars', 'id');
   }
 
   @override
@@ -93,17 +92,18 @@ class _$GHumanWithArgsVars extends GHumanWithArgsVars {
 
 class GHumanWithArgsVarsBuilder
     implements Builder<GHumanWithArgsVars, GHumanWithArgsVarsBuilder> {
-  _$GHumanWithArgsVars _$v;
+  _$GHumanWithArgsVars? _$v;
 
-  String _id;
-  String get id => _$this._id;
-  set id(String id) => _$this._id = id;
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
 
   GHumanWithArgsVarsBuilder();
 
   GHumanWithArgsVarsBuilder get _$this {
-    if (_$v != null) {
-      _id = _$v.id;
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
       _$v = null;
     }
     return this;
@@ -111,20 +111,21 @@ class GHumanWithArgsVarsBuilder
 
   @override
   void replace(GHumanWithArgsVars other) {
-    if (other == null) {
-      throw new ArgumentError.notNull('other');
-    }
+    ArgumentError.checkNotNull(other, 'other');
     _$v = other as _$GHumanWithArgsVars;
   }
 
   @override
-  void update(void Function(GHumanWithArgsVarsBuilder) updates) {
+  void update(void Function(GHumanWithArgsVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
   _$GHumanWithArgsVars build() {
-    final _$result = _$v ?? new _$GHumanWithArgsVars._(id: id);
+    final _$result = _$v ??
+        new _$GHumanWithArgsVars._(
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, 'GHumanWithArgsVars', 'id'));
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/pubspec.yaml
+++ b/codegen/end_to_end_test/pubspec.yaml
@@ -3,15 +3,15 @@ version: 0.0.1
 publish_to: none
 description: Tests, not for publishing.\n
 repository: https://github.com/gql-dart/gql
-environment:
+environment: 
   sdk: '>=2.12.0 <3.0.0'
-dependencies:
+dependencies: 
   built_collection: ^5.0.0
   built_value: ^8.0.4
   gql_exec: ^0.3.0-nullsafety.2
   gql_build: ^0.2.0-nullsafety.0
   gql_code_builder: ^0.2.0-nullsafety.0
-dev_dependencies:
+dev_dependencies: 
   build: ^2.0.0
   build_runner: ^1.12.2
   test: ^1.16.8

--- a/codegen/end_to_end_test/pubspec.yaml
+++ b/codegen/end_to_end_test/pubspec.yaml
@@ -3,16 +3,15 @@ version: 0.0.1
 publish_to: none
 description: Tests, not for publishing.\n
 repository: https://github.com/gql-dart/gql
-environment: 
-  sdk: '>=2.0.0-dev <3.0.0'
-dependencies: 
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+dependencies:
   built_collection: ^5.0.0
-  built_value: ^8.0.0
-  gql_exec: ^0.2.5
-  gql_build: ^0.1.3
-  gql_code_builder: ^0.1.3
-dev_dependencies: 
-  collection: ^1.14.13
-  build: ^1.0.0
-  build_runner: ^1.11.1
-  test: ^1.0.0
+  built_value: ^8.0.4
+  gql_exec: ^0.3.0-nullsafety.2
+  gql_build: ^0.2.0
+  gql_code_builder: ^0.2.0
+dev_dependencies:
+  build: ^2.0.0
+  build_runner: ^1.12.2
+  test: ^1.16.8

--- a/codegen/end_to_end_test/pubspec.yaml
+++ b/codegen/end_to_end_test/pubspec.yaml
@@ -9,8 +9,8 @@ dependencies:
   built_collection: ^5.0.0
   built_value: ^8.0.4
   gql_exec: ^0.3.0-nullsafety.2
-  gql_build: ^0.2.0
-  gql_code_builder: ^0.2.0
+  gql_build: ^0.2.0-nullsafety.0
+  gql_code_builder: ^0.2.0-nullsafety.0
 dev_dependencies:
   build: ^2.0.0
   build_runner: ^1.12.2

--- a/codegen/end_to_end_test/test/custom_serializers/operation_serializer_test.dart
+++ b/codegen/end_to_end_test/test/custom_serializers/operation_serializer_test.dart
@@ -14,7 +14,7 @@ void main() {
       );
       final json = serializers.serialize(operation);
       final Operation deserialized =
-          serializers.deserializeWith(OperationSerializer(), json);
+          serializers.deserializeWith(OperationSerializer(), json)!;
       expect(deserialized, equals(operation));
     });
 
@@ -22,7 +22,7 @@ void main() {
       final operation = Operation(document: document);
       final json = serializers.serialize(operation);
       final Operation deserialized =
-          serializers.deserializeWith(OperationSerializer(), json);
+          serializers.deserializeWith(OperationSerializer(), json)!;
       expect(deserialized, equals(operation));
     });
   });

--- a/codegen/end_to_end_test/test/schema/scalars_test.dart
+++ b/codegen/end_to_end_test/test/schema/scalars_test.dart
@@ -34,9 +34,9 @@ void main() {
       ..createReview.stars = 1);
 
     test('can use in GraphQL operation data', () {
-      expect(data.createReview.custom.first, equals(customField));
+      expect(data.createReview!.custom.first, equals(customField));
       expect(
-        data.createReview.toJson()['custom'].first,
+        data.createReview!.toJson()['custom'].first,
         equals(customField.toJson()),
       );
     });
@@ -61,7 +61,7 @@ void main() {
         ..seenOn.add(DateTime.fromMillisecondsSinceEpoch(1591892597000)),
     );
     test('correctly overrides scalars in input types', () {
-      expect(input.seenOn.first, TypeMatcher<DateTime>());
+      expect(input.seenOn!.first, TypeMatcher<DateTime>());
     });
 
     test('can be serialized and deserialized with custom serializer', () {
@@ -109,8 +109,8 @@ void main() {
     );
 
     test('correctly overrides scalars in data types', () {
-      expect(data.createReview.seenOn.first, TypeMatcher<DateTime>());
-      expect(data.createReview.createdAt, TypeMatcher<DateTime>());
+      expect(data.createReview!.seenOn.first, TypeMatcher<DateTime>());
+      expect(data.createReview!.createdAt, TypeMatcher<DateTime>());
     });
 
     test('can be serialized and deserialized with custom serializer', () {

--- a/codegen/gql_build/CHANGELOG.md
+++ b/codegen/gql_build/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-nullsafety.0
+
+- add initial null-safety support
+
 ## 0.1.4+2
 
 - bump `gql` version

--- a/codegen/gql_build/lib/gql_build.dart
+++ b/codegen/gql_build/lib/gql_build.dart
@@ -22,7 +22,7 @@ Builder dataBuilder(
         options.config["schema"] as String,
       ),
       (options.config["add_typenames"] ?? true) as bool,
-      typeOverrideMap(options?.config["type_overrides"]),
+      typeOverrideMap(options.config["type_overrides"]),
     );
 
 /// Builds GraphQL type-safe request builder
@@ -43,7 +43,7 @@ Builder varBuilder(
       AssetId.parse(
         options.config["schema"] as String,
       ),
-      typeOverrideMap(options?.config["type_overrides"]),
+      typeOverrideMap(options.config["type_overrides"]),
     );
 
 /// Builds GraphQL schema types
@@ -51,8 +51,8 @@ Builder schemaBuilder(
   BuilderOptions options,
 ) =>
     SchemaBuilder(
-      typeOverrideMap(options?.config["type_overrides"]),
-      enumFallbackConfig(options?.config),
+      typeOverrideMap(options.config["type_overrides"]),
+      enumFallbackConfig(options.config),
     );
 
 /// Builds an aggregate Serlializers object for [built_value]s
@@ -65,6 +65,6 @@ Builder serializerBuilder(
       AssetId.parse(
         options.config["schema"] as String,
       ),
-      customSerializers(options?.config["custom_serializers"]),
-      typeOverrideMap(options?.config["type_overrides"]),
+      customSerializers(options.config["custom_serializers"]),
+      typeOverrideMap(options.config["type_overrides"]),
     );

--- a/codegen/gql_build/lib/src/allocators/gql_allocator.dart
+++ b/codegen/gql_build/lib/src/allocators/gql_allocator.dart
@@ -16,9 +16,9 @@ class GqlAllocator implements Allocator {
 
   final String sourceUrl;
   final String currentUrl;
-  final String schemaUrl;
+  final String? schemaUrl;
 
-  final _imports = <String, int>{};
+  final _imports = <String, int?>{};
   var _keys = 1;
 
   GqlAllocator(
@@ -63,9 +63,9 @@ class GqlAllocator implements Allocator {
     if (uri.path.isEmpty && uri.fragment.isNotEmpty) {
       String replacedUrl;
       if (uri.fragment == "schema") {
-        replacedUrl = schemaUrl;
+        replacedUrl = schemaUrl!;
       } else if (uri.fragment == "serializer") {
-        replacedUrl = "${p.dirname(schemaUrl)}/serializers.gql.dart";
+        replacedUrl = "${p.dirname(schemaUrl!)}/serializers.gql.dart";
       } else {
         replacedUrl = sourceUrl.replaceAll(
           RegExp(r".graphql$"),

--- a/codegen/gql_build/lib/src/allocators/pick_allocator.dart
+++ b/codegen/gql_build/lib/src/allocators/pick_allocator.dart
@@ -5,9 +5,12 @@ class PickAllocator implements Allocator {
   final List<String> doNotPick;
   final List<String> include;
 
-  final Map<String, List<String>> _imports = {};
+  final Map<String, List<String>?> _imports = {};
 
-  PickAllocator({this.doNotPick, this.include}) {
+  PickAllocator({
+    this.doNotPick = const [],
+    this.include = const [],
+  }) {
     for (final url in include) {
       _imports[url] = null;
     }
@@ -29,7 +32,7 @@ class PickAllocator implements Allocator {
       return symbol;
     }
 
-    _imports.update(reference.url, (symbols) => symbols..add(reference.symbol),
+    _imports.update(reference.url, (symbols) => symbols?..add(reference.symbol),
         ifAbsent: () => [reference.symbol]);
 
     return symbol;

--- a/codegen/gql_build/lib/src/serializer_builder.dart
+++ b/codegen/gql_build/lib/src/serializer_builder.dart
@@ -53,8 +53,8 @@ class SerializerBuilder implements Builder {
     final hasSerializer = (ClassElement c) => c.fields.any((field) =>
         field.isStatic &&
         field.name == "serializer" &&
-        field.type.element.name == "Serializer" &&
-        field.type.element.source.uri.toString() ==
+        field.type.element?.name == "Serializer" &&
+        field.type.element?.source?.uri.toString() ==
             "package:built_value/serializer.dart");
 
     final isBuiltValue = (ClassElement c) => c.allSupertypes.any((interface) =>
@@ -108,6 +108,7 @@ class SerializerBuilder implements Builder {
               .where((url) => url != null)
         ],
       ),
+      true,
       true,
     );
 

--- a/codegen/gql_build/lib/src/utils/add_introspection.dart
+++ b/codegen/gql_build/lib/src/utils/add_introspection.dart
@@ -53,7 +53,7 @@ class AddTypenameField extends TransformingVisitor {
       return node;
     }
 
-    final hasTypename = node.selectionSet.selections
+    final hasTypename = node.selectionSet!.selections
         .whereType<FieldNode>()
         .any((node) => node.name.value == "__typename");
 
@@ -69,7 +69,7 @@ class AddTypenameField extends TransformingVisitor {
           FieldNode(
             name: NameNode(value: "__typename"),
           ),
-          ...node.selectionSet.selections,
+          ...node.selectionSet!.selections,
         ],
       ),
     );

--- a/codegen/gql_build/lib/src/utils/reader.dart
+++ b/codegen/gql_build/lib/src/utils/reader.dart
@@ -9,9 +9,9 @@ import "package:gql_build/src/config.dart";
 
 Set<AssetId> _getImports(
   String source, {
-  AssetId from,
+  AssetId? from,
 }) {
-  final imports = <String>{};
+  final imports = <Uri>{};
 
   final patterns = [
     RegExp(r'^#\s*import\s+"([^"]+)"', multiLine: true),
@@ -19,12 +19,14 @@ Set<AssetId> _getImports(
   ];
 
   for (final pattern in patterns) {
-    pattern.allMatches(source)?.forEach(
+    pattern.allMatches(source).forEach(
       (match) {
-        final path = match?.group(1);
+        final path = match.group(1);
         if (path != null) {
           imports.add(
-            path.endsWith(sourceExtension) ? path : "$path$sourceExtension",
+            Uri.parse(
+              path.endsWith(sourceExtension) ? path : "$path$sourceExtension",
+            ),
           );
         }
       },
@@ -73,7 +75,7 @@ Future<SourceNode> _assetToSourceNode(
 
 Future<SourceNode> readDocument(
   BuildStep buildStep, [
-  AssetId rootId,
+  AssetId? rootId,
 ]) =>
     _assetToSourceNode(
       buildStep,

--- a/codegen/gql_build/lib/src/utils/writer.dart
+++ b/codegen/gql_build/lib/src/utils/writer.dart
@@ -12,9 +12,9 @@ Future<void> writeDocument(
   Library library,
   BuildStep buildStep,
   String extension, [
-  String schemaUrl,
+  String? schemaUrl,
 ]) {
-  if (library.body.isEmpty) return null;
+  if (library.body.isEmpty) return Future.value(null);
 
   final generatedAsset = buildStep.inputId.changeExtension(extension);
 
@@ -25,6 +25,7 @@ Future<void> writeDocument(
         generatedAsset.uri.toString(),
         schemaUrl,
       ),
+      true,
       true,
     ),
   )}");

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -2,9 +2,9 @@ name: gql_build
 version: 0.2.0-nullsafety.0
 description: Useful builders for your GraphQL SDL and documents. Based on package:gql_code_builder and package:build
 repository: https://github.com/gql-dart/gql
-environment:
+environment: 
   sdk: '>=2.12.0 <3.0.0'
-dependencies:
+dependencies: 
   analyzer: ^1.2.0
   build: ^2.0.0
   built_collection: ^5.0.0
@@ -17,6 +17,6 @@ dependencies:
   gql_code_builder: ^0.2.0-nullsafety.0
   path: ^1.8.0
   yaml: ^3.1.0
-dev_dependencies:
+dev_dependencies: 
   build_test: ^2.0.0
   gql_pedantic: ^1.0.2

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_build
-version: 0.2.0
+version: 0.2.0-nullsafety.0
 description: Useful builders for your GraphQL SDL and documents. Based on package:gql_code_builder and package:build
 repository: https://github.com/gql-dart/gql
 environment:
@@ -14,13 +14,9 @@ dependencies:
   dart_style: ^2.0.0
   glob: ^2.0.0
   gql: ^0.13.0-nullsafety.2
-  gql_code_builder: ^0.1.4
+  gql_code_builder: ^0.2.0-nullsafety.0
   path: ^1.8.0
   yaml: ^3.1.0
 dev_dependencies:
   build_test: ^2.0.0
   gql_pedantic: ^1.0.2
-
-dependency_overrides:
-  gql_code_builder:
-    path: ../gql_code_builder

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -1,22 +1,26 @@
 name: gql_build
-version: 0.1.4+2
+version: 0.2.0
 description: Useful builders for your GraphQL SDL and documents. Based on package:gql_code_builder and package:build
 repository: https://github.com/gql-dart/gql
-environment: 
-  sdk: '>=2.7.2 <3.0.0'
-dependencies: 
-  analyzer: ^0.40.1
-  gql: ^0.12.4
-  path: ^1.6.4
-  glob: ^1.2.0
-  build: ^1.0.0
-  gql_code_builder: ^0.1.4
-  code_builder: ^3.3.0
-  dart_style: ^1.2.9
-  built_value: ^8.0.0
-  built_value_generator: ^8.0.0
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+dependencies:
+  analyzer: ^1.2.0
+  build: ^2.0.0
   built_collection: ^5.0.0
-  yaml: ^2.2.1
-dev_dependencies: 
-  build_test: ^0.10.7
+  built_value: ^8.0.4
+  built_value_generator: ^8.0.4
+  code_builder: ^3.7.0
+  dart_style: ^2.0.0
+  glob: ^2.0.0
+  gql: ^0.13.0-nullsafety.2
+  gql_code_builder: ^0.1.4
+  path: ^1.8.0
+  yaml: ^3.1.0
+dev_dependencies:
+  build_test: ^2.0.0
   gql_pedantic: ^1.0.2
+
+dependency_overrides:
+  gql_code_builder:
+    path: ../gql_code_builder

--- a/codegen/gql_code_builder/CHANGELOG.md
+++ b/codegen/gql_code_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-nullsafety.0
+
+- add initial null-safety support
+
 ## 0.1.4+1
 
 - bump `gql` version

--- a/codegen/gql_code_builder/lib/ast.dart
+++ b/codegen/gql_code_builder/lib/ast.dart
@@ -43,15 +43,18 @@ Library buildAstLibrary(
 }
 
 String _getName(DefinitionNode def) {
-  if (def.name != null && def.name.value != null) return def.name.value;
+  if (def is DirectiveDefinitionNode) return def.name.value;
+  if (def is TypeDefinitionNode) return def.name.value;
+  if (def is FragmentDefinitionNode) return def.name.value;
+  if (def is TypeExtensionNode) return def.name.value;
 
   if (def is SchemaDefinitionNode) return "schema";
 
   if (def is OperationDefinitionNode) {
+    if (def.name != null) return def.name!.value;
     if (def.type == OperationType.query) return "query";
     if (def.type == OperationType.mutation) return "mutation";
     if (def.type == OperationType.subscription) return "subscription";
   }
-
-  return null;
+  throw Exception("Unknown DefinitionNode type");
 }

--- a/codegen/gql_code_builder/lib/schema.dart
+++ b/codegen/gql_code_builder/lib/schema.dart
@@ -1,7 +1,6 @@
 import "package:code_builder/code_builder.dart";
 import "package:gql_code_builder/src/schema.dart";
 import "package:gql_code_builder/source.dart";
-import "package:meta/meta.dart";
 
 Library buildSchemaLibrary(
     SourceNode schemaSource,
@@ -24,15 +23,13 @@ Library buildSchemaLibrary(
 
 class EnumFallbackConfig {
   final bool generateFallbackValuesGlobally;
-  final String globalEnumFallbackName;
+  final String? globalEnumFallbackName;
   final Map<String, String> fallbackValueMap;
 
   const EnumFallbackConfig({
-    @required this.generateFallbackValuesGlobally,
+    required this.generateFallbackValuesGlobally,
     this.globalEnumFallbackName,
-    @required this.fallbackValueMap,
-  })  : assert(fallbackValueMap != null),
-        assert(generateFallbackValuesGlobally != null),
-        assert(
+    required this.fallbackValueMap,
+  }) : assert(
             !generateFallbackValuesGlobally || globalEnumFallbackName != null);
 }

--- a/codegen/gql_code_builder/lib/source.dart
+++ b/codegen/gql_code_builder/lib/source.dart
@@ -8,8 +8,8 @@ class SourceNode {
   final Set<SourceNode> imports;
 
   const SourceNode({
-    this.url,
-    this.document,
+    required this.url,
+    required this.document,
     this.imports = const {},
   });
 
@@ -38,15 +38,18 @@ class SourceNode {
 }
 
 String _getName(DefinitionNode def) {
-  if (def.name != null && def.name.value != null) return def.name.value;
+  if (def is DirectiveDefinitionNode) return def.name.value;
+  if (def is TypeDefinitionNode) return def.name.value;
+  if (def is FragmentDefinitionNode) return def.name.value;
+  if (def is TypeExtensionNode) return def.name.value;
 
   if (def is SchemaDefinitionNode) return "schema";
 
   if (def is OperationDefinitionNode) {
+    if (def.name != null) return def.name!.value;
     if (def.type == OperationType.query) return "query";
     if (def.type == OperationType.mutation) return "mutation";
     if (def.type == OperationType.subscription) return "subscription";
   }
-
-  return null;
+  throw Exception("Unknown DefinitionNode type");
 }

--- a/codegen/gql_code_builder/lib/src/ast.dart
+++ b/codegen/gql_code_builder/lib/src/ast.dart
@@ -30,7 +30,7 @@ Expression _node(
 
 class _PrintVisitor extends Visitor<Expression> {
   Expression _acceptOne(
-    Node node,
+    Node? node,
   ) =>
       node != null ? node.accept(this) : literalNull;
 
@@ -613,9 +613,6 @@ Expression _opType(OperationType t) {
     case OperationType.subscription:
       return _ref("OperationType.subscription");
   }
-
-  // dead code to satisfy lint
-  return null;
 }
 
 Expression _directiveLocation(DirectiveLocation location) {
@@ -657,7 +654,4 @@ Expression _directiveLocation(DirectiveLocation location) {
     case DirectiveLocation.inputFieldDefinition:
       return _ref("DirectiveLocation.inputFieldDefinition");
   }
-
-  // dead code to satisfy lint
-  return null;
 }

--- a/codegen/gql_code_builder/lib/src/built_class.dart
+++ b/codegen/gql_code_builder/lib/src/built_class.dart
@@ -1,15 +1,14 @@
 import "package:built_collection/built_collection.dart";
 import "package:code_builder/code_builder.dart";
-import "package:meta/meta.dart";
 import "package:recase/recase.dart";
 
 import "./common.dart";
 
 /// Generates a class that implements [Built], along with its serializers
 Class builtClass({
-  @required String name,
-  Iterable<Method> getters,
-  Map<String, Expression> initializers,
+  required String name,
+  Iterable<Method>? getters,
+  Map<String, Expression>? initializers,
 }) {
   final className = builtClassName(name);
   return Class(
@@ -66,7 +65,7 @@ Class builtClass({
                 initializers,
               ).code,
           ),
-        ...getters,
+        if (getters != null) ...getters,
         // Serlialization methods
         buildSerializerGetter(className).rebuild(
           (b) => b..body = Code("_\$${className.camelCase}Serializer"),

--- a/codegen/gql_code_builder/lib/src/common.dart
+++ b/codegen/gql_code_builder/lib/src/common.dart
@@ -1,7 +1,7 @@
 import "package:built_collection/built_collection.dart";
 import "package:code_builder/code_builder.dart";
 import "package:gql/ast.dart";
-import "package:meta/meta.dart";
+import "package:collection/collection.dart";
 
 import "../source.dart";
 
@@ -50,12 +50,12 @@ const _reserved = <String>[
 ];
 
 class SourceSelections {
-  final String url;
+  final String? url;
   final List<SelectionNode> selections;
 
   const SourceSelections({
     this.url,
-    this.selections,
+    required this.selections,
   });
 }
 
@@ -84,17 +84,23 @@ Reference _typeRef(
   Map<String, Reference> typeMap,
 ) {
   if (type is NamedTypeNode) {
-    return typeMap[type.name.value] ?? Reference(type.name.value);
+    final ref = typeMap[type.name.value] ?? Reference(type.name.value);
+    return TypeReference(
+      (b) => b
+        ..url = ref.url
+        ..symbol = ref.symbol
+        ..isNullable = !type.isNonNull,
+    );
   } else if (type is ListTypeNode) {
     return TypeReference(
       (b) => b
         ..url = "package:built_collection/built_collection.dart"
         ..symbol = "BuiltList"
+        ..isNullable = !type.isNonNull
         ..types.add(_typeRef(type.type, typeMap)),
     );
   }
-
-  return null;
+  throw Exception("Unrecognized TypeNode type");
 }
 
 const defaultRootTypes = {
@@ -106,37 +112,30 @@ const defaultRootTypes = {
 NamedTypeNode unwrapTypeNode(
   TypeNode node,
 ) {
-  if (node is NamedTypeNode) {
-    return node;
-  }
-
   if (node is ListTypeNode) {
     return unwrapTypeNode(node.type);
   }
-
-  return null;
+  return node as NamedTypeNode;
 }
 
-TypeDefinitionNode getTypeDefinitionNode(
+TypeDefinitionNode? getTypeDefinitionNode(
   DocumentNode schema,
   String name,
 ) =>
-    schema.definitions.whereType<TypeDefinitionNode>().firstWhere(
-          (node) => node.name.value == name,
-          orElse: () => null,
-        );
+    schema.definitions
+        .whereType<TypeDefinitionNode>()
+        .firstWhereOrNull((node) => node.name.value == name);
 
 Method buildGetter({
-  @required NameNode nameNode,
-  @required TypeNode typeNode,
-  @required SourceNode schemaSource,
+  required NameNode nameNode,
+  required TypeNode typeNode,
+  required SourceNode schemaSource,
   Map<String, Reference> typeOverrides = const {},
-  String typeRefPrefix,
+  String? typeRefPrefix,
   bool built = true,
 }) {
   final unwrappedTypeNode = unwrapTypeNode(typeNode);
   final typeName = unwrappedTypeNode.name.value;
-  final nullable = !unwrappedTypeNode.isNonNull;
   final typeDef = getTypeDefinitionNode(
     schemaSource.document,
     typeName,
@@ -162,8 +161,6 @@ Method buildGetter({
   return Method(
     (b) => b
       ..annotations = ListBuilder(<Expression>[
-        if (built && nullable)
-          refer("nullable", "package:built_value/built_value.dart"),
         if (built && identifier(nameNode.value) != nameNode.value)
           refer("BuiltValueField", "package:built_value/built_value.dart")
               .call([], {"wireName": literalString(nameNode.value)}),
@@ -203,16 +200,22 @@ Method buildToJsonGetter(
             ? refer("serializers", "#serializer")
                 .property("serializeWith")
                 .call([
-                refer(className).property("serializer"),
-                refer("this"),
-              ]).code
+                  refer(className).property("serializer"),
+                  refer("this"),
+                ])
+                .asA(refer("Map<String, dynamic>"))
+                .code
             : null,
     );
 
 Method buildFromJsonGetter(String className) => Method(
       (b) => b
         ..static = true
-        ..returns = refer(className)
+        ..returns = TypeReference(
+          (b) => b
+            ..symbol = className
+            ..isNullable = true,
+        )
         ..name = "fromJson"
         ..requiredParameters.add(Parameter((b) => b
           ..type = refer("Map<String, dynamic>")

--- a/codegen/gql_code_builder/lib/src/common.dart
+++ b/codegen/gql_code_builder/lib/src/common.dart
@@ -81,15 +81,22 @@ const defaultTypeMap = <String, Reference>{
 
 Reference _typeRef(
   TypeNode type,
-  Map<String, Reference> typeMap,
-) {
+  Map<String, Reference> typeMap, [
+
+  /// TODO: remove
+  /// https://github.com/google/built_value.dart/issues/1011#issuecomment-804843573
+  bool inList = false,
+]) {
   if (type is NamedTypeNode) {
     final ref = typeMap[type.name.value] ?? Reference(type.name.value);
     return TypeReference(
       (b) => b
         ..url = ref.url
         ..symbol = ref.symbol
-        ..isNullable = !type.isNonNull,
+
+        /// TODO: remove `inList` check
+        /// https://github.com/google/built_value.dart/issues/1011#issuecomment-804843573
+        ..isNullable = !inList && !type.isNonNull,
     );
   } else if (type is ListTypeNode) {
     return TypeReference(
@@ -97,7 +104,7 @@ Reference _typeRef(
         ..url = "package:built_collection/built_collection.dart"
         ..symbol = "BuiltList"
         ..isNullable = !type.isNonNull
-        ..types.add(_typeRef(type.type, typeMap)),
+        ..types.add(_typeRef(type.type, typeMap, true)),
     );
   }
   throw Exception("Unrecognized TypeNode type");

--- a/codegen/gql_code_builder/lib/src/frag_vars.dart
+++ b/codegen/gql_code_builder/lib/src/frag_vars.dart
@@ -1,26 +1,25 @@
 import "package:gql/ast.dart";
-import "package:meta/meta.dart";
 
 import "./common.dart";
 
 /// Recursively traverses a fragment and returns a map of variable types from the schema
 Map<NameNode, TypeNode> fragmentVarTypes({
-  @required FragmentDefinitionNode fragment,
-  @required Map<String, FragmentDefinitionNode> fragmentMap,
-  @required DocumentNode schema,
+  required FragmentDefinitionNode fragment,
+  required Map<String, FragmentDefinitionNode> fragmentMap,
+  required DocumentNode schema,
 }) =>
     _varTypesForSelections(
       fragmentMap: fragmentMap,
-      selections: fragment.selectionSet?.selections ?? [],
+      selections: fragment.selectionSet.selections,
       parentType: fragment.typeCondition.on,
       schema: schema,
     );
 
 Map<NameNode, TypeNode> _varTypesForSelections({
-  @required List<SelectionNode> selections,
-  @required Map<String, FragmentDefinitionNode> fragmentMap,
-  @required NamedTypeNode parentType,
-  @required DocumentNode schema,
+  required List<SelectionNode> selections,
+  required Map<String, FragmentDefinitionNode> fragmentMap,
+  required NamedTypeNode parentType,
+  required DocumentNode schema,
 }) =>
     selections.fold({}, (argMap, selection) {
       if (selection is FieldNode) {
@@ -33,7 +32,7 @@ Map<NameNode, TypeNode> _varTypesForSelections({
           ),
           if (selection.selectionSet != null)
             ..._varTypesForSelections(
-              selections: selection.selectionSet.selections,
+              selections: selection.selectionSet!.selections,
               fragmentMap: fragmentMap,
               parentType: unwrapTypeNode(
                 _fieldDefinition(
@@ -51,12 +50,16 @@ Map<NameNode, TypeNode> _varTypesForSelections({
           ..._varTypesForSelections(
             selections: selection.selectionSet.selections,
             fragmentMap: fragmentMap,
-            parentType: selection.typeCondition.on,
+            parentType: selection.typeCondition?.on ?? parentType,
             schema: schema,
           ),
         };
       } else if (selection is FragmentSpreadNode) {
         final fragment = fragmentMap[selection.name.value];
+        if (fragment == null) {
+          throw Exception(
+              "Missing fragment definition for ${selection.name.value}");
+        }
         return {
           ...argMap,
           ..._varTypesForSelections(
@@ -67,13 +70,14 @@ Map<NameNode, TypeNode> _varTypesForSelections({
           ),
         };
       }
+      throw Exception("Unrecognized SelectionNode Type");
     });
 
 /// Returns a map of a field's argument variables to their respective types from the schema
 Map<NameNode, TypeNode> _varTypesForField({
-  @required FieldNode field,
-  @required NamedTypeNode parentType,
-  @required DocumentNode schema,
+  required FieldNode field,
+  required NamedTypeNode parentType,
+  required DocumentNode schema,
 }) {
   if (field.arguments.isEmpty) {
     return {};
@@ -94,9 +98,9 @@ Map<NameNode, TypeNode> _varTypesForField({
 
 /// Given a field from a query, fetches the field's definition from the schema
 FieldDefinitionNode _fieldDefinition({
-  @required FieldNode field,
-  @required NamedTypeNode parentType,
-  @required DocumentNode schema,
+  required FieldNode field,
+  required NamedTypeNode parentType,
+  required DocumentNode schema,
 }) {
   final parentTypeDef = getTypeDefinitionNode(schema, parentType.name.value);
 

--- a/codegen/gql_code_builder/lib/src/operation/req.dart
+++ b/codegen/gql_code_builder/lib/src/operation/req.dart
@@ -17,12 +17,12 @@ Class _buildOperationReqClass(
   OperationDefinitionNode node,
 ) =>
     builtClass(
-      name: node.name.value,
+      name: node.name!.value,
       getters: [
         Method(
           (b) => b
             ..returns = refer(
-              "${builtClassName(node.name.value)}Vars",
+              "${builtClassName(node.name!.value)}Vars",
               "#var",
             )
             ..type = MethodType.getter
@@ -43,7 +43,7 @@ Class _buildOperationReqClass(
           [],
           {
             "document": refer("document", "#ast"),
-            "operationName": literalString(node.name.value),
+            "operationName": literalString(node.name!.value),
           },
         ),
       },

--- a/codegen/gql_code_builder/lib/src/schema.dart
+++ b/codegen/gql_code_builder/lib/src/schema.dart
@@ -7,7 +7,7 @@ import "package:gql_code_builder/src/schema/scalar.dart";
 import "package:gql_code_builder/source.dart";
 
 /// Build input types, enums and scalars from schema
-Spec buildSchema(
+Spec? buildSchema(
   SourceNode schemaSource,
   Map<String, Reference> typeOverrides,
   EnumFallbackConfig enumFallbackConfig,
@@ -20,7 +20,7 @@ Spec buildSchema(
       ),
     );
 
-class _SchemaBuilderVisitor extends SimpleVisitor<Spec> {
+class _SchemaBuilderVisitor extends SimpleVisitor<Spec?> {
   final SourceNode schemaSource;
   final Map<String, Reference> typeOverrides;
   final EnumFallbackConfig enumFallbackConfig;
@@ -31,12 +31,12 @@ class _SchemaBuilderVisitor extends SimpleVisitor<Spec> {
     this.enumFallbackConfig,
   );
 
-  Spec _acceptOne(
-    Node node,
+  Spec? _acceptOne(
+    Node? node,
   ) =>
       node != null ? node.accept(this) : literalNull;
 
-  List<Spec> _acceptMany(
+  List<Spec?> _acceptMany(
     List<Node> nodes,
   ) =>
       nodes.map(_acceptOne).toList(
@@ -64,7 +64,7 @@ class _SchemaBuilderVisitor extends SimpleVisitor<Spec> {
       );
 
   @override
-  Spec visitScalarTypeDefinitionNode(
+  Spec? visitScalarTypeDefinitionNode(
     ScalarTypeDefinitionNode node,
   ) =>
       typeOverrides.containsKey(node.name.value)

--- a/codegen/gql_code_builder/lib/src/schema/enum.dart
+++ b/codegen/gql_code_builder/lib/src/schema/enum.dart
@@ -34,8 +34,11 @@ Class buildEnumClass(
                     .containsKey(node.name.value))
               EnumValueDefinitionNode(
                   name: NameNode(
-                      value: _ensureNoNameClashes(
-                          enumFallbackConfig.globalEnumFallbackName, node)),
+                    value: _ensureNoNameClashes(
+                      enumFallbackConfig.globalEnumFallbackName!,
+                      node,
+                    ),
+                  ),
                   fallback: true)
           ],
           builtClassName(node.name.value),

--- a/codegen/gql_code_builder/lib/src/schema/scalar.dart
+++ b/codegen/gql_code_builder/lib/src/schema/scalar.dart
@@ -40,7 +40,11 @@ ListBuilder<Constructor> _buildConstructors(
               Parameter(
                 (b) => b
                   ..name = "value"
-                  ..type = refer("String"),
+                  ..type = TypeReference(
+                    (b) => b
+                      ..symbol = "String"
+                      ..isNullable = true,
+                  ),
               ),
             )
             ..body = refer("_\$${scalarName}").call([
@@ -105,7 +109,15 @@ ListBuilder<Method> _buildMethods(
                     ),
                   )
                   ..lambda = true
-                  ..body = refer(scalarName).call([refer("serialized")]).code,
+                  ..body = refer(scalarName).call([
+                    refer("serialized").asA(
+                      TypeReference(
+                        (b) => b
+                          ..symbol = "String"
+                          ..isNullable = true,
+                      ),
+                    )
+                  ]).code,
               ).closure
             ]).code,
         ),

--- a/codegen/gql_code_builder/lib/src/serializers/default_scalar_serializer.dart
+++ b/codegen/gql_code_builder/lib/src/serializers/default_scalar_serializer.dart
@@ -13,7 +13,7 @@ class DefaultScalarSerializer<T> implements PrimitiveSerializer<T> {
   @override
   Object serialize(Serializers serializers, T scalar,
           {FullType specifiedType = FullType.unspecified}) =>
-      (scalar as dynamic).value;
+      (scalar as dynamic).value as Object;
 
   @override
   T deserialize(Serializers serializers, Object serialized,

--- a/codegen/gql_code_builder/lib/src/serializers/inline_fragment_serializer.dart
+++ b/codegen/gql_code_builder/lib/src/serializers/inline_fragment_serializer.dart
@@ -32,7 +32,7 @@ class InlineFragmentSerializer<T> implements StructuredSerializer<T> {
       // Get JSON representation of object
       final json = StandardJsonPlugin()
           .afterSerialize(serialized, specifiedType) as Map<String, dynamic>;
-      final typeName = json["__typename"] as String ?? "";
+      final typeName = (json["__typename"] ?? "") as String;
       final type = _typeForTypename(typeName);
       final serializer =
           serializers.serializerForType(type) as StructuredSerializer;
@@ -44,7 +44,7 @@ class InlineFragmentSerializer<T> implements StructuredSerializer<T> {
   }
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
     Serializers serializers,
     T object, {
     FullType specifiedType = FullType.unspecified,

--- a/codegen/gql_code_builder/lib/src/serializers/json_serializer.dart
+++ b/codegen/gql_code_builder/lib/src/serializers/json_serializer.dart
@@ -21,7 +21,7 @@ abstract class JsonSerializer<T> implements StructuredSerializer<T> {
   }
 
   @override
-  Iterable<Object> serialize(
+  Iterable<Object?> serialize(
     Serializers serializers,
     T object, {
     FullType specifiedType = FullType.unspecified,

--- a/codegen/gql_code_builder/lib/src/serializers/operation_serializer.dart
+++ b/codegen/gql_code_builder/lib/src/serializers/operation_serializer.dart
@@ -8,7 +8,7 @@ class OperationSerializer extends JsonSerializer<Operation> {
   @override
   Operation fromJson(Map<String, dynamic> json) => Operation(
         document: parseString(json["document"] as String),
-        operationName: json["operationName"] as String,
+        operationName: json["operationName"] as String?,
       );
 
   @override

--- a/codegen/gql_code_builder/lib/var.dart
+++ b/codegen/gql_code_builder/lib/var.dart
@@ -16,7 +16,7 @@ Library buildVarLibrary(
       .whereType<OperationDefinitionNode>()
       .map(
         (op) => builtClass(
-          name: "${op.name.value}Vars",
+          name: "${op.name!.value}Vars",
           getters: op.variableDefinitions.map<Method>(
             (node) => buildGetter(
               nameNode: node.variable.name,

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_code_builder
-version: 0.2.0
+version: 0.2.0-nullsafety.0
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
 environment:

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -2,9 +2,9 @@ name: gql_code_builder
 version: 0.2.0-nullsafety.0
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
-environment:
+environment: 
   sdk: '>=2.12.0 <3.0.0'
-dependencies:
+dependencies: 
   analyzer: ^1.2.0
   built_collection: ^5.0.0
   built_value: ^8.0.4
@@ -13,7 +13,7 @@ dependencies:
   gql_exec: ^0.3.0-nullsafety.2
   path: ^1.8.0
   recase: ^4.0.0-nullsafety.0
-dev_dependencies:
+dev_dependencies: 
   build_runner: ^1.12.2
   gql_pedantic: ^1.0.2
   test: ^1.16.8

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -2,9 +2,9 @@ name: gql_code_builder
 version: 0.2.0-nullsafety.0
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
-environment:
+environment: 
   sdk: '>=2.12.0 <3.0.0'
-dependencies:
+dependencies: 
   analyzer: ^1.2.0
   built_collection: ^5.0.0
   built_value: ^8.0.4
@@ -14,7 +14,7 @@ dependencies:
   gql_exec: ^0.3.0-nullsafety.2
   path: ^1.8.0
   recase: ^4.0.0-nullsafety.0
-dev_dependencies:
+dev_dependencies: 
   build_runner: ^1.12.2
   gql_pedantic: ^1.0.2
   test: ^1.16.8

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -1,20 +1,19 @@
 name: gql_code_builder
-version: 0.1.4+1
+version: 0.2.0
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
-environment: 
-  sdk: '>=2.7.2 <3.0.0'
-dependencies: 
-  analyzer: ^0.40.1
-  gql: ^0.12.4
-  code_builder: ^3.3.0
-  meta: ^1.1.7
+environment:
+  sdk: '>=2.12.0 <3.0.0'
+dependencies:
+  analyzer: ^1.2.0
   built_collection: ^5.0.0
-  built_value: ^8.0.0
-  path: ^1.6.4
-  recase: ^3.0.0
-  gql_exec: ^0.2.5
-dev_dependencies: 
+  built_value: ^8.0.4
+  code_builder: ^3.7.0
+  gql: ^0.13.0-nullsafety.2
+  gql_exec: ^0.3.0-nullsafety.2
+  path: ^1.8.0
+  recase: ^4.0.0-nullsafety.0
+dev_dependencies:
+  build_runner: ^1.12.2
   gql_pedantic: ^1.0.2
-  build_runner: ^1.11.1
-  test: ^1.0.0
+  test: ^1.16.8

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -2,18 +2,19 @@ name: gql_code_builder
 version: 0.2.0-nullsafety.0
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
-environment: 
+environment:
   sdk: '>=2.12.0 <3.0.0'
-dependencies: 
+dependencies:
   analyzer: ^1.2.0
   built_collection: ^5.0.0
   built_value: ^8.0.4
   code_builder: ^3.7.0
+  collection: ^1.15.0
   gql: ^0.13.0-nullsafety.2
   gql_exec: ^0.3.0-nullsafety.2
   path: ^1.8.0
   recase: ^4.0.0-nullsafety.0
-dev_dependencies: 
+dev_dependencies:
   build_runner: ^1.12.2
   gql_pedantic: ^1.0.2
   test: ^1.16.8

--- a/codegen/gql_code_builder/test/enum/enum_fallback_test.dart
+++ b/codegen/gql_code_builder/test/enum/enum_fallback_test.dart
@@ -163,7 +163,7 @@ void main() {
 
 InvokeExpression getBuiltValueEnumConstAnnotation(Field field) =>
     field.annotations.whereType<InvokeExpression>().singleWhere(
-        (annotation) =>
-            (annotation.target is Reference) &&
-            (annotation.target as Reference).symbol == "BuiltValueEnumConst",
-        orElse: () => null);
+          (annotation) =>
+              (annotation.target is Reference) &&
+              (annotation.target as Reference).symbol == "BuiltValueEnumConst",
+        );

--- a/gql/pubspec.yaml
+++ b/gql/pubspec.yaml
@@ -8,8 +8,8 @@ dependencies:
   collection: ^1.15.0
   meta: ^1.3.0
   source_span: ^1.8.0
-dev_dependencies:
-  cats:
-    path: ../cats
+dev_dependencies: 
   gql_pedantic: ^1.0.2
   test: ^1.16.2
+  cats: 
+    path: ../cats

--- a/gql/pubspec.yaml
+++ b/gql/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.13.0-nullsafety.2
 description: GraphQL tools for parsing, transforming and printing GraphQL documents.
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   collection: ^1.15.0
   meta: ^1.3.0

--- a/links/gql_dedupe_link/pubspec.yaml
+++ b/links/gql_dedupe_link/pubspec.yaml
@@ -3,7 +3,7 @@ version: 2.0.0-nullsafety.1
 description: GQL Link to deduplicate identical in-flight execution requests
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   meta: ^1.3.0
   gql_exec: ^0.3.0-nullsafety.1

--- a/links/gql_error_link/pubspec.yaml
+++ b/links/gql_error_link/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.2.0-nullsafety.1
 description: GQL Link to handle execution errors and exceptions
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   async: ^2.5.0
   gql_exec: ^0.3.0-nullsafety.1

--- a/links/gql_exec/pubspec.yaml
+++ b/links/gql_exec/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.3.0-nullsafety.2
 description: Basis for GraphQL execution layer to support Link and Client.
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   collection: ^1.15.0
   meta: ^1.3.0

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.4.0-nullsafety.1
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   meta: ^1.3.0
   gql: ^0.13.0-nullsafety.1

--- a/links/gql_link/CHANGELOG.md
+++ b/links/gql_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0-nullsafety.3
+
+- fix generated mockito testing
+
 ## 0.4.0-nullsafety.2
 
 Null Safety Pre-release
@@ -22,12 +26,12 @@ Null Safety Pre-release
 
 ## 0.2.1
 
--  use `package:gql_exec`
+- use `package:gql_exec`
 
 ## 0.2.0
 
 - rename `Exception` classes and extend from a new `LinkException`
-- add various `Link` utils: `Link.function`, `Link.concat`, `Link.route` and `Link.split` 
+- add various `Link` utils: `Link.function`, `Link.concat`, `Link.route` and `Link.split`
 
 ## 0.1.0
 

--- a/links/gql_link/lib/src/link.dart
+++ b/links/gql_link/lib/src/link.dart
@@ -1,4 +1,5 @@
 import "package:gql_exec/gql_exec.dart";
+import 'package:meta/meta.dart';
 
 /// Type of the `forward` function
 typedef NextLink = Stream<Response> Function(
@@ -56,7 +57,7 @@ abstract class Link {
   factory Link.split(
     bool Function(Request request) test,
     Link left, [
-    Link right = const _PassthroughLink(),
+    Link right = const PassthroughLink(),
   ]) =>
       _RouterLink((Request request) => test(request) ? left : right);
 
@@ -76,7 +77,7 @@ abstract class Link {
   Link split(
     bool Function(Request request) test,
     Link left, [
-    Link right = const _PassthroughLink(),
+    Link right = const PassthroughLink(),
   ]) =>
       concat(
         _RouterLink(
@@ -126,8 +127,9 @@ class _LinkChain extends Link {
       )!(request);
 }
 
-class _PassthroughLink extends Link {
-  const _PassthroughLink();
+@visibleForTesting
+class PassthroughLink extends Link {
+  const PassthroughLink();
 
   @override
   Stream<Response> request(

--- a/links/gql_link/lib/src/link.dart
+++ b/links/gql_link/lib/src/link.dart
@@ -1,5 +1,5 @@
 import "package:gql_exec/gql_exec.dart";
-import 'package:meta/meta.dart';
+import "package:meta/meta.dart";
 
 /// Type of the `forward` function
 typedef NextLink = Stream<Response> Function(

--- a/links/gql_link/pubspec.yaml
+++ b/links/gql_link/pubspec.yaml
@@ -1,14 +1,14 @@
 name: gql_link
-version: 0.4.0-nullsafety.2
+version: 0.4.0-nullsafety.3
 description: A simple and modular AST-based GraphQL request execution interface.
 repository: https://github.com/gql-dart/gql
-environment: 
+environment:
   sdk: '>=2.12.0-259.9.beta <3.0.0'
-dependencies: 
+dependencies:
   meta: ^1.1.7
   gql: ^0.13.0-nullsafety.1
   gql_exec: ^0.3.0-nullsafety.1
-dev_dependencies: 
+dev_dependencies:
   test: ^1.0.0
   mockito: ^4.1.1
   gql_pedantic: ^1.0.2

--- a/links/gql_link/pubspec.yaml
+++ b/links/gql_link/pubspec.yaml
@@ -2,13 +2,13 @@ name: gql_link
 version: 0.4.0-nullsafety.3
 description: A simple and modular AST-based GraphQL request execution interface.
 repository: https://github.com/gql-dart/gql
-environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
-dependencies:
+environment: 
+  sdk: '>=2.12.0 <3.0.0'
+dependencies: 
   meta: ^1.1.7
   gql: ^0.13.0-nullsafety.1
   gql_exec: ^0.3.0-nullsafety.1
-dev_dependencies:
+dev_dependencies: 
   test: ^1.0.0
   mockito: ^4.1.1
   gql_pedantic: ^1.0.2

--- a/links/gql_transform_link/pubspec.yaml
+++ b/links/gql_transform_link/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.2.0-nullsafety.1
 description: GQL Link to transform Requests and Responses. May be used to update context, document, variables, data, errors, etc.
 repository: https://github.com/gql-dart/gql
 environment: 
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   gql_exec: ^0.3.0-nullsafety.1
   gql_link: ^0.4.0-nullsafety.1


### PR DESCRIPTION
- [x] update codegen libs to null safety
- [x] make codegen libs generate null-safe code

A few notes:

## `code_builder`

`code_builder` (upon which `gql_build` and `gql_code_builder` depend) has [not yet been migrated](https://github.com/dart-lang/code_builder/issues/303), and it's not clear when it will be, so I've migrated our codegen packages anyway. This means that the builders may have some unsound code paths for the time being, but this shouldn't really be an issue for users of the code gen.

## nulls in lists

The migration to null safety exposed a bug with nullable GraphQL types in lists. `BuiltList` doesn't support nulls (https://github.com/google/built_collection.dart/issues/232, https://github.com/google/built_value.dart/issues/1011), so nulls in lists will cause deserialization to fail. For example, let's take a look at the following schema:

```graphql
type User {
  name: String
  aliases: [String]
}
```
In this case, the `aliases` field will be a nullable list with nullable strings, which should be deserialized into the dart type `BuiltList<String?>?`. Since `BuiltList` cannot currently accept nulls, this fails.

I've implemented a [workaround](https://github.com/gql-dart/gql/blob/d34762ceb28654d58272a22b503157b3ab5ee18a/codegen/gql_code_builder/lib/src/common.dart#L99) to essentially ignore the nullability of values in lists such that the above example would be deserialized as a `BuiltList<String>?`. However, **if your graphql server actually returns a list with null values, it could cause a runtime exception.**

Since this issue already exists in the current non null-safe version, I'm simply highlighting it here. Once https://github.com/google/built_value.dart/issues/1011 is resolved, we will remove the workaround.