### PR TITLE
Use Uri.file(file.path) fixes breaking changes in yaml 3

### DIFF
--- a/cats/lib/src/cat_builder.dart
+++ b/cats/lib/src/cat_builder.dart
@@ -31,7 +31,7 @@ class CatBuilder {
   Scenario buildScenario(File file, Directory folder) {
     var doc = loadYaml(
       file.readAsStringSync(),
-      sourceUrl: file.path,
+      sourceUrl: Uri.file(file.path),
     );
 
     var schema;


### PR DESCRIPTION
`yaml 3` has breaking change which require `sourceUrl` to be of type `Uri`

This PR fix it.