### PR TITLE
Add a method to stop subscriptions.

### DIFF
--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -209,9 +209,9 @@ class WebSocketLink extends Link {
   /// ```
   Future<void> stop(String requestId) async {
     final messagesSubscription = _messageSubscriptions[requestId];
-    messagesSubscription?.cancel();
+    await messagesSubscription?.cancel();
     _messageSubscriptions.remove(requestId);
-    _write(StopOperation(requestId));
+    await _write(StopOperation(requestId));
     _requests.removeWhere((e) => e.context.entry<RequestId>().id == requestId);
   }
 

--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -11,9 +11,11 @@ import "package:web_socket_channel/web_socket_channel.dart";
 import "package:web_socket_channel/status.dart" as websocket_status;
 
 typedef ChannelGenerator = FutureOr<WebSocketChannel> Function();
-typedef GraphQLSocketMessageDecoder = FutureOr<Map<String, dynamic>> Function(dynamic message);
+typedef GraphQLSocketMessageDecoder = FutureOr<Map<String, dynamic>> Function(
+    dynamic message);
 
-typedef GraphQLSocketMessageEncoder = FutureOr<String> Function(Map<String, dynamic> message);
+typedef GraphQLSocketMessageEncoder = FutureOr<String> Function(
+    Map<String, dynamic> message);
 
 @immutable
 class RequestId extends ContextEntry {
@@ -39,7 +41,8 @@ class WebSocketLink extends Link {
   final _requests = <Request>[];
 
   // Current active subscriptions listening for messages from the active requests.
-  final _messageSubscriptions = <String, StreamSubscription<GraphQLSocketMessage>>{};
+  final _messageSubscriptions =
+      <String, StreamSubscription<GraphQLSocketMessage>>{};
 
   // subscriptions that need to be re-initialized after channel reconnect
   final _reConnectRequests = <Request>[];
@@ -57,7 +60,9 @@ class WebSocketLink extends Link {
   /// A function that encodes the request message to json string before sending it over the network.
   final GraphQLSocketMessageEncoder graphQLSocketMessageEncoder;
 
-  static String _defaultGraphQLSocketMessageEncoder(Map<String, dynamic> message) => json.encode(message);
+  static String _defaultGraphQLSocketMessageEncoder(
+          Map<String, dynamic> message) =>
+      json.encode(message);
 
   /// A function that decodes the incoming http response to `Map<String, dynamic>`,
   /// the decoded map will be then passes to the `RequestSerializer`.
@@ -67,7 +72,8 @@ class WebSocketLink extends Link {
   /// ```
   final GraphQLSocketMessageDecoder graphQLSocketMessageDecoder;
 
-  static Map<String, dynamic> _defaultGraphQLSocketMessageDecoder(dynamic message) =>
+  static Map<String, dynamic> _defaultGraphQLSocketMessageDecoder(
+          dynamic message) =>
       json.decode(message as String) as Map<String, dynamic>;
 
   /// Automatically recreate the channel when connection is lost,
@@ -93,9 +99,11 @@ class WebSocketLink extends Link {
   static const int closed = 0;
   static const int connecting = 1;
   static const int open = 2;
-  final BehaviorSubject<int> _connectionStateController = BehaviorSubject<int>.seeded(closed);
+  final BehaviorSubject<int> _connectionStateController =
+      BehaviorSubject<int>.seeded(closed);
 
-  final StreamController<GraphQLSocketMessage> _messagesController = StreamController<GraphQLSocketMessage>.broadcast();
+  final StreamController<GraphQLSocketMessage> _messagesController =
+      StreamController<GraphQLSocketMessage>.broadcast();
   StreamSubscription<ConnectionKeepAlive> _keepAliveSubscription;
 
   /// Initialize the [WebSocketLink] with a [uri].
@@ -119,7 +127,8 @@ class WebSocketLink extends Link {
     if (uri != null) {
       _uri = uri;
     } else {
-      _channelGenerator = channelGenerator ?? () => WebSocketChannel.connect(Uri.parse(_uri));
+      _channelGenerator =
+          channelGenerator ?? () => WebSocketChannel.connect(Uri.parse(_uri));
     }
   }
 
@@ -138,7 +147,8 @@ class WebSocketLink extends Link {
     StreamSubscription<GraphQLSocketMessage> messagesSubscription;
 
     response.onListen = () {
-      final Stream<int> waitForConnectedState = _connectionStateController.where((state) => state == open).take(1);
+      final Stream<int> waitForConnectedState =
+          _connectionStateController.where((state) => state == open).take(1);
 
       waitForConnectedState.listen((_) {
         // listen for response messages
@@ -152,7 +162,8 @@ class WebSocketLink extends Link {
           (message) {
             if (message is SubscriptionData || message is SubscriptionError) {
               try {
-                final parsed = _parseMessage(message).withContextEntry(RequestId(id));
+                final parsed =
+                    _parseMessage(message).withContextEntry(RequestId(id));
                 if (parsed.data == null && parsed.errors == null) {
                   throw WebSocketLinkServerException(
                     originalException: null,
@@ -250,9 +261,11 @@ class WebSocketLink extends Link {
 
       if (initialPayload is Function) {
         final dynamic payload = await initialPayload();
-        await _write(InitOperation(payload)).catchError(_messagesController.addError);
+        await _write(InitOperation(payload))
+            .catchError(_messagesController.addError);
       } else {
-        await _write(InitOperation(initialPayload)).catchError(_messagesController.addError);
+        await _write(InitOperation(initialPayload))
+            .catchError(_messagesController.addError);
       }
 
       // inactivityTimeout
@@ -261,7 +274,8 @@ class WebSocketLink extends Link {
             .where(
               (GraphQLSocketMessage message) => message is ConnectionKeepAlive,
             )
-            .map<ConnectionKeepAlive>((message) => message as ConnectionKeepAlive)
+            .map<ConnectionKeepAlive>(
+                (message) => message as ConnectionKeepAlive)
             .timeout(inactivityTimeout, onTimeout: (_) {
           _channel.sink.close(websocket_status.goingAway);
         }).listen(null);

--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -11,11 +11,9 @@ import "package:web_socket_channel/web_socket_channel.dart";
 import "package:web_socket_channel/status.dart" as websocket_status;
 
 typedef ChannelGenerator = FutureOr<WebSocketChannel> Function();
-typedef GraphQLSocketMessageDecoder = FutureOr<Map<String, dynamic>> Function(
-    dynamic message);
+typedef GraphQLSocketMessageDecoder = FutureOr<Map<String, dynamic>> Function(dynamic message);
 
-typedef GraphQLSocketMessageEncoder = FutureOr<String> Function(
-    Map<String, dynamic> message);
+typedef GraphQLSocketMessageEncoder = FutureOr<String> Function(Map<String, dynamic> message);
 
 @immutable
 class RequestId extends ContextEntry {
@@ -40,6 +38,9 @@ class WebSocketLink extends Link {
   // Current active subscriptions
   final _requests = <Request>[];
 
+  // Current active subscriptions listening for messages from the active requests.
+  final _messageSubscriptions = <String, StreamSubscription<GraphQLSocketMessage>>{};
+
   // subscriptions that need to be re-initialized after channel reconnect
   final _reConnectRequests = <Request>[];
 
@@ -56,9 +57,7 @@ class WebSocketLink extends Link {
   /// A function that encodes the request message to json string before sending it over the network.
   final GraphQLSocketMessageEncoder graphQLSocketMessageEncoder;
 
-  static String _defaultGraphQLSocketMessageEncoder(
-          Map<String, dynamic> message) =>
-      json.encode(message);
+  static String _defaultGraphQLSocketMessageEncoder(Map<String, dynamic> message) => json.encode(message);
 
   /// A function that decodes the incoming http response to `Map<String, dynamic>`,
   /// the decoded map will be then passes to the `RequestSerializer`.
@@ -68,8 +67,7 @@ class WebSocketLink extends Link {
   /// ```
   final GraphQLSocketMessageDecoder graphQLSocketMessageDecoder;
 
-  static Map<String, dynamic> _defaultGraphQLSocketMessageDecoder(
-          dynamic message) =>
+  static Map<String, dynamic> _defaultGraphQLSocketMessageDecoder(dynamic message) =>
       json.decode(message as String) as Map<String, dynamic>;
 
   /// Automatically recreate the channel when connection is lost,
@@ -95,11 +93,9 @@ class WebSocketLink extends Link {
   static const int closed = 0;
   static const int connecting = 1;
   static const int open = 2;
-  final BehaviorSubject<int> _connectionStateController =
-      BehaviorSubject<int>.seeded(closed);
+  final BehaviorSubject<int> _connectionStateController = BehaviorSubject<int>.seeded(closed);
 
-  final StreamController<GraphQLSocketMessage> _messagesController =
-      StreamController<GraphQLSocketMessage>.broadcast();
+  final StreamController<GraphQLSocketMessage> _messagesController = StreamController<GraphQLSocketMessage>.broadcast();
   StreamSubscription<ConnectionKeepAlive> _keepAliveSubscription;
 
   /// Initialize the [WebSocketLink] with a [uri].
@@ -123,8 +119,7 @@ class WebSocketLink extends Link {
     if (uri != null) {
       _uri = uri;
     } else {
-      _channelGenerator =
-          channelGenerator ?? () => WebSocketChannel.connect(Uri.parse(_uri));
+      _channelGenerator = channelGenerator ?? () => WebSocketChannel.connect(Uri.parse(_uri));
     }
   }
 
@@ -143,8 +138,7 @@ class WebSocketLink extends Link {
     StreamSubscription<GraphQLSocketMessage> messagesSubscription;
 
     response.onListen = () {
-      final Stream<int> waitForConnectedState =
-          _connectionStateController.where((state) => state == open).take(1);
+      final Stream<int> waitForConnectedState = _connectionStateController.where((state) => state == open).take(1);
 
       waitForConnectedState.listen((_) {
         // listen for response messages
@@ -158,7 +152,7 @@ class WebSocketLink extends Link {
           (message) {
             if (message is SubscriptionData || message is SubscriptionError) {
               try {
-                final parsed = _parseMessage(message);
+                final parsed = _parseMessage(message).withContextEntry(RequestId(id));
                 if (parsed.data == null && parsed.errors == null) {
                   throw WebSocketLinkServerException(
                     originalException: null,
@@ -176,6 +170,7 @@ class WebSocketLink extends Link {
           },
           onError: response.addError,
         );
+        _messageSubscriptions[id] = messagesSubscription;
         // Send the request.
         _write(
           StartOperation(
@@ -188,11 +183,25 @@ class WebSocketLink extends Link {
 
     response.onCancel = () {
       messagesSubscription?.cancel();
+      _messageSubscriptions.remove(id);
       _write(StopOperation(id)).catchError(response.addError);
       _requests.removeWhere((e) => e.context.entry<RequestId>().id == id);
     };
 
     yield* response.stream;
+  }
+
+  /// Stops the subscription to the request with the given id.
+  /// The requestId can be found in the context of any response.
+  /// ```
+  /// String requestId = response.context.entry<RequestId>().id;
+  /// ```
+  Future<void> stop(String requestId) async {
+    final messagesSubscription = _messageSubscriptions[requestId];
+    messagesSubscription?.cancel();
+    _messageSubscriptions.remove(requestId);
+    _write(StopOperation(requestId));
+    _requests.removeWhere((e) => e.context.entry<RequestId>().id == requestId);
   }
 
   /// Connects to the server.
@@ -241,11 +250,9 @@ class WebSocketLink extends Link {
 
       if (initialPayload is Function) {
         final dynamic payload = await initialPayload();
-        await _write(InitOperation(payload))
-            .catchError(_messagesController.addError);
+        await _write(InitOperation(payload)).catchError(_messagesController.addError);
       } else {
-        await _write(InitOperation(initialPayload))
-            .catchError(_messagesController.addError);
+        await _write(InitOperation(initialPayload)).catchError(_messagesController.addError);
       }
 
       // inactivityTimeout
@@ -254,8 +261,7 @@ class WebSocketLink extends Link {
             .where(
               (GraphQLSocketMessage message) => message is ConnectionKeepAlive,
             )
-            .map<ConnectionKeepAlive>(
-                (message) => message as ConnectionKeepAlive)
+            .map<ConnectionKeepAlive>((message) => message as ConnectionKeepAlive)
             .timeout(inactivityTimeout, onTimeout: (_) {
           _channel.sink.close(websocket_status.goingAway);
         }).listen(null);

--- a/links/gql_websocket_link/test/gql_websocket_link_test.dart
+++ b/links/gql_websocket_link/test/gql_websocket_link_test.dart
@@ -43,7 +43,8 @@ void main() {
               channel.stream.take(1).listen(
                 expectAsync1<void, dynamic>(
                   (dynamic message) {
-                    final map = json.decode(message as String) as Map<String, dynamic>;
+                    final map =
+                        json.decode(message as String) as Map<String, dynamic>;
                     expect(map["type"], MessageTypes.connectionInit);
                   },
                 ),
@@ -84,7 +85,8 @@ void main() {
               channel.stream.take(1).listen(
                 expectAsync1<void, dynamic>(
                   (dynamic message) {
-                    final map = json.decode(message as String) as Map<String, dynamic>;
+                    final map =
+                        json.decode(message as String) as Map<String, dynamic>;
                     expect(map["type"], MessageTypes.connectionInit);
                     expect(map["payload"], initialPayload);
                   },
@@ -133,7 +135,8 @@ void main() {
               channel.stream.take(1).listen(
                 expectAsync1<void, dynamic>(
                   (dynamic message) {
-                    final map = json.decode(message as String) as Map<String, dynamic>;
+                    final map =
+                        json.decode(message as String) as Map<String, dynamic>;
                     expect(map["type"], MessageTypes.connectionInit);
                     expect(map["payload"], baseInitialPayload);
                   },
@@ -175,7 +178,8 @@ void main() {
           final Request request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(
+                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -186,7 +190,9 @@ void main() {
           server.transform(WebSocketTransformer()).listen(
             (webSocket) async {
               final channel = IOWebSocketChannel(webSocket);
-              channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
+              channel.stream
+                  .map<dynamic>((dynamic s) => json.decode(s as String))
+                  .listen(
                 (dynamic message) {
                   if (message["type"] == "connection_init") {
                     channel.sink.add(
@@ -258,7 +264,8 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(
+                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -271,7 +278,8 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) async {
-                  final map = json.decode(message as String) as Map<String, dynamic>;
+                  final map =
+                      json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -317,7 +325,10 @@ void main() {
           // We expect responseData1, then responseData2 in order.
           int callCounter = 0;
           const maxCall = 2;
-          link.request(request).map((Response response) => response.data).listen(
+          link
+              .request(request)
+              .map((Response response) => response.data)
+              .listen(
                 expectAsync1(
                   (data) {
                     callCounter += 1;
@@ -359,7 +370,8 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(
+                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -372,7 +384,8 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) {
-                  final map = json.decode(message as String) as Map<String, dynamic>;
+                  final map =
+                      json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -412,12 +425,15 @@ void main() {
                     message: responseError["message"] as String,
                     locations: [
                       ErrorLocation(
-                        line: (responseError["locations"] as List)[0]["line"] as int,
-                        column: (responseError["locations"] as List)[0]["column"] as int,
+                        line: (responseError["locations"] as List)[0]["line"]
+                            as int,
+                        column: (responseError["locations"] as List)[0]
+                            ["column"] as int,
                       ),
                     ],
                     path: responseError["path"] as List<String>,
-                    extensions: responseError["extensions"] as Map<String, dynamic>,
+                    extensions:
+                        responseError["extensions"] as Map<String, dynamic>,
                   ),
                 );
               },
@@ -465,7 +481,8 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(
+                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -478,7 +495,8 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) async {
-                  final map = json.decode(message as String) as Map<String, dynamic>;
+                  final map =
+                      json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -538,7 +556,10 @@ void main() {
           // We expect responseData1, then responseData3 in order.
           int callCounter = 0;
           const maxCall = 2;
-          link.request(request).map((Response response) => response.data).listen(
+          link
+              .request(request)
+              .map((Response response) => response.data)
+              .listen(
                 expectAsync1(
                   (data) {
                     callCounter += 1;
@@ -599,7 +620,8 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(
+                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -612,7 +634,8 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) async {
-                  final map = json.decode(message as String) as Map<String, dynamic>;
+                  final map =
+                      json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -688,7 +711,8 @@ void main() {
         },
       );
 
-      test("throw WebSocketLinkParserException when unable to parse response", () async {
+      test("throw WebSocketLinkParserException when unable to parse response",
+          () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -706,7 +730,9 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
+            channel.stream
+                .map<dynamic>((dynamic s) => json.decode(s as String))
+                .listen(
               (dynamic message) {
                 if (message["type"] == "connection_init") {
                   channel.sink.add(
@@ -742,7 +768,9 @@ void main() {
         );
       });
 
-      test("throw WebSocketLinkServerException when response is missing both `data` and `errors`", () async {
+      test(
+          "throw WebSocketLinkServerException when response is missing both `data` and `errors`",
+          () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -760,7 +788,9 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
+            channel.stream
+                .map<dynamic>((dynamic s) => json.decode(s as String))
+                .listen(
               (dynamic message) {
                 if (message["type"] == "connection_init") {
                   channel.sink.add(
@@ -845,7 +875,8 @@ void main() {
             channel.stream.listen(
               expectAsyncUntil1<void, dynamic>(
                 (dynamic message) {
-                  final map = json.decode(message as String) as Map<String, dynamic>;
+                  final map =
+                      json.decode(message as String) as Map<String, dynamic>;
                   if (messageCount == 0) {
                     expect(map["type"], MessageTypes.connectionInit);
                     channel.sink.add(
@@ -881,7 +912,9 @@ void main() {
         responseSub = link.request(request).listen(print);
       });
 
-      test("close the socket when no keep alive received from server withe inactivityTimeout", () async {
+      test(
+          "close the socket when no keep alive received from server withe inactivityTimeout",
+          () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -890,7 +923,8 @@ void main() {
         final Request request = Request(
           operation: Operation(
             operationName: "pokemonsSubscription",
-            document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+            document: parseString(
+                r"subscription MySubscription { pokemons(first: $first) { name } }"),
           ),
           variables: const <String, dynamic>{
             "first": 3,
@@ -901,7 +935,9 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
+            channel.stream
+                .map<dynamic>((dynamic s) => json.decode(s as String))
+                .listen(
               (dynamic message) {
                 // Do not send anything, let it timeout.
               },
@@ -928,7 +964,9 @@ void main() {
         );
       });
 
-      test("never close the socket as long as keep alive is send from the server", () async {
+      test(
+          "never close the socket as long as keep alive is send from the server",
+          () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -937,7 +975,8 @@ void main() {
         final Request request = Request(
           operation: Operation(
             operationName: "pokemonsSubscription",
-            document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+            document: parseString(
+                r"subscription MySubscription { pokemons(first: $first) { name } }"),
           ),
           variables: const <String, dynamic>{
             "first": 3,
@@ -948,7 +987,9 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
+            channel.stream
+                .map<dynamic>((dynamic s) => json.decode(s as String))
+                .listen(
               (dynamic message) {
                 Timer.periodic(Duration(seconds: 1), (_) {
                   channel.sink.add(
@@ -1003,9 +1044,11 @@ void main() {
                     channel.stream.take(1).listen(
                           expectAsync1<void, dynamic>(
                             (dynamic message) {
-                              final map = json.decode(message as String) as Map<String, dynamic>;
+                              final map = json.decode(message as String)
+                                  as Map<String, dynamic>;
                               if (messageCount == 0) {
-                                expect(map["type"], MessageTypes.connectionInit);
+                                expect(
+                                    map["type"], MessageTypes.connectionInit);
                                 channel.sink.add(
                                   json.encode(
                                     ConnectionAck(),
@@ -1028,7 +1071,8 @@ void main() {
           link = WebSocketLink(
             null,
             channelGenerator: () async {
-              final webSocket = await WebSocket.connect("ws://localhost:${server.port}");
+              final webSocket =
+                  await WebSocket.connect("ws://localhost:${server.port}");
               return IOWebSocketChannel(webSocket);
             },
             reconnectInterval: Duration(milliseconds: 500),
@@ -1064,7 +1108,8 @@ void main() {
                   channel.stream.listen(
                     expectAsync1<void, dynamic>(
                       (dynamic message) {
-                        final map = json.decode(message as String) as Map<String, dynamic>;
+                        final map = json.decode(message as String)
+                            as Map<String, dynamic>;
                         if (messageCount == 0) {
                           expect(map["type"], MessageTypes.connectionInit);
                           channel.sink.add(
@@ -1098,7 +1143,8 @@ void main() {
                   channel.stream.listen(
                     expectAsync1<void, dynamic>(
                       (dynamic message) {
-                        final map = json.decode(message as String) as Map<String, dynamic>;
+                        final map = json.decode(message as String)
+                            as Map<String, dynamic>;
                         if (messageCount == 0) {
                           expect(map["type"], MessageTypes.connectionInit);
                           channel.sink.add(
@@ -1128,10 +1174,12 @@ void main() {
           channelGenerator: () async {
             if (connectToServer == 1) {
               connectToServer++;
-              final webSocket = await WebSocket.connect("ws://localhost:${server1.port}");
+              final webSocket =
+                  await WebSocket.connect("ws://localhost:${server1.port}");
               return IOWebSocketChannel(webSocket);
             } else {
-              final webSocket = await WebSocket.connect("ws://localhost:${server2.port}");
+              final webSocket =
+                  await WebSocket.connect("ws://localhost:${server2.port}");
               return IOWebSocketChannel(webSocket);
             }
           },

--- a/links/gql_websocket_link/test/gql_websocket_link_test.dart
+++ b/links/gql_websocket_link/test/gql_websocket_link_test.dart
@@ -43,8 +43,7 @@ void main() {
               channel.stream.take(1).listen(
                 expectAsync1<void, dynamic>(
                   (dynamic message) {
-                    final map =
-                        json.decode(message as String) as Map<String, dynamic>;
+                    final map = json.decode(message as String) as Map<String, dynamic>;
                     expect(map["type"], MessageTypes.connectionInit);
                   },
                 ),
@@ -85,8 +84,7 @@ void main() {
               channel.stream.take(1).listen(
                 expectAsync1<void, dynamic>(
                   (dynamic message) {
-                    final map =
-                        json.decode(message as String) as Map<String, dynamic>;
+                    final map = json.decode(message as String) as Map<String, dynamic>;
                     expect(map["type"], MessageTypes.connectionInit);
                     expect(map["payload"], initialPayload);
                   },
@@ -135,8 +133,7 @@ void main() {
               channel.stream.take(1).listen(
                 expectAsync1<void, dynamic>(
                   (dynamic message) {
-                    final map =
-                        json.decode(message as String) as Map<String, dynamic>;
+                    final map = json.decode(message as String) as Map<String, dynamic>;
                     expect(map["type"], MessageTypes.connectionInit);
                     expect(map["payload"], baseInitialPayload);
                   },
@@ -178,8 +175,7 @@ void main() {
           final Request request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(
-                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -190,9 +186,7 @@ void main() {
           server.transform(WebSocketTransformer()).listen(
             (webSocket) async {
               final channel = IOWebSocketChannel(webSocket);
-              channel.stream
-                  .map<dynamic>((dynamic s) => json.decode(s as String))
-                  .listen(
+              channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
                 (dynamic message) {
                   if (message["type"] == "connection_init") {
                     channel.sink.add(
@@ -264,8 +258,7 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(
-                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -278,8 +271,7 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) async {
-                  final map =
-                      json.decode(message as String) as Map<String, dynamic>;
+                  final map = json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -325,10 +317,7 @@ void main() {
           // We expect responseData1, then responseData2 in order.
           int callCounter = 0;
           const maxCall = 2;
-          link
-              .request(request)
-              .map((Response response) => response.data)
-              .listen(
+          link.request(request).map((Response response) => response.data).listen(
                 expectAsync1(
                   (data) {
                     callCounter += 1;
@@ -370,8 +359,7 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(
-                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -384,8 +372,7 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) {
-                  final map =
-                      json.decode(message as String) as Map<String, dynamic>;
+                  final map = json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -425,15 +412,12 @@ void main() {
                     message: responseError["message"] as String,
                     locations: [
                       ErrorLocation(
-                        line: (responseError["locations"] as List)[0]["line"]
-                            as int,
-                        column: (responseError["locations"] as List)[0]
-                            ["column"] as int,
+                        line: (responseError["locations"] as List)[0]["line"] as int,
+                        column: (responseError["locations"] as List)[0]["column"] as int,
                       ),
                     ],
                     path: responseError["path"] as List<String>,
-                    extensions:
-                        responseError["extensions"] as Map<String, dynamic>,
+                    extensions: responseError["extensions"] as Map<String, dynamic>,
                   ),
                 );
               },
@@ -481,8 +465,7 @@ void main() {
           request = Request(
             operation: Operation(
               operationName: "pokemonsSubscription",
-              document: parseString(
-                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
+              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
             ),
             variables: const <String, dynamic>{
               "first": 3,
@@ -495,8 +478,7 @@ void main() {
               final channel = IOWebSocketChannel(webSocket);
               channel.stream.listen(
                 (dynamic message) async {
-                  final map =
-                      json.decode(message as String) as Map<String, dynamic>;
+                  final map = json.decode(message as String) as Map<String, dynamic>;
                   if (map["type"] == "connection_init") {
                     channel.sink.add(
                       json.encode(
@@ -556,10 +538,7 @@ void main() {
           // We expect responseData1, then responseData3 in order.
           int callCounter = 0;
           const maxCall = 2;
-          link
-              .request(request)
-              .map((Response response) => response.data)
-              .listen(
+          link.request(request).map((Response response) => response.data).listen(
                 expectAsync1(
                   (data) {
                     callCounter += 1;
@@ -581,8 +560,135 @@ void main() {
         },
       );
 
-      test("throw WebSocketLinkParserException when unable to parse response",
-          () async {
+      test(
+        "stop subscription",
+        () async {
+          HttpServer server;
+          WebSocket webSocket;
+          IOWebSocketChannel channel;
+          WebSocketLink link;
+          Request request;
+          final responseData1 = {
+            "data": {
+              "pokemons": [
+                {"name": "Bulbasaur"},
+                {"name": "Ivysaur"},
+                {"name": "Venusaur"}
+              ]
+            }
+          };
+          final responseData2 = {
+            "data": {
+              "pokemons": [
+                {"name": "Charmander"},
+                {"name": "Charmeleon"},
+                {"name": "Charizard"}
+              ]
+            }
+          };
+          final responseData3 = {
+            "data": {
+              "pokemons": [
+                {"name": "Bagon"},
+                {"name": "Cacnea"},
+                {"name": "Elgyem"}
+              ]
+            }
+          };
+
+          request = Request(
+            operation: Operation(
+              operationName: "pokemonsSubscription",
+              document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
+            ),
+            variables: const <String, dynamic>{
+              "first": 3,
+            },
+          );
+
+          server = await HttpServer.bind("localhost", 0);
+          server.transform(WebSocketTransformer()).listen(
+            (webSocket) async {
+              final channel = IOWebSocketChannel(webSocket);
+              channel.stream.listen(
+                (dynamic message) async {
+                  final map = json.decode(message as String) as Map<String, dynamic>;
+                  if (map["type"] == "connection_init") {
+                    channel.sink.add(
+                      json.encode(
+                        ConnectionAck(),
+                      ),
+                    );
+                  } else if (map["type"] == "start") {
+                    channel.sink.add(
+                      json.encode(
+                        <String, dynamic>{
+                          "type": "data",
+                          "id": map["id"],
+                          "payload": {
+                            "data": responseData1,
+                            "errors": null,
+                          },
+                        },
+                      ),
+                    );
+                    await Future<void>.delayed(Duration(seconds: 1));
+                    channel.sink.add(
+                      json.encode(
+                        <String, dynamic>{
+                          "type": "data",
+                          "id": map["id"],
+                          "payload": {
+                            "data": responseData2,
+                            "errors": null,
+                          },
+                        },
+                      ),
+                    );
+                    await Future<void>.delayed(Duration(seconds: 1));
+                    channel.sink.add(
+                      json.encode(
+                        <String, dynamic>{
+                          "type": "data",
+                          "id": map["id"],
+                          "payload": {
+                            "data": responseData3,
+                            "errors": null,
+                          },
+                        },
+                      ),
+                    );
+                  }
+                },
+              );
+            },
+          );
+
+          webSocket = await WebSocket.connect("ws://localhost:${server.port}");
+          channel = IOWebSocketChannel(webSocket);
+
+          link = WebSocketLink(null, channelGenerator: () => channel);
+          // We expect responseData1, then stop the subscription, so no more responses are expected.
+          String subId;
+          link.request(request).map((Response response) {
+            subId = response.context.entry<RequestId>().id;
+            expect(subId, isNotNull);
+            return response.data;
+          }).listen(
+            expectAsync1(
+              (data) {
+                expect(
+                  data,
+                  responseData1,
+                );
+                link.stop(subId);
+              },
+            ),
+          );
+        },
+      );
+
+      test("throw WebSocketLinkParserException when unable to parse response", () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -600,9 +706,7 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream
-                .map<dynamic>((dynamic s) => json.decode(s as String))
-                .listen(
+            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
               (dynamic message) {
                 if (message["type"] == "connection_init") {
                   channel.sink.add(
@@ -638,9 +742,7 @@ void main() {
         );
       });
 
-      test(
-          "throw WebSocketLinkServerException when response is missing both `data` and `errors`",
-          () async {
+      test("throw WebSocketLinkServerException when response is missing both `data` and `errors`", () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -658,9 +760,7 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream
-                .map<dynamic>((dynamic s) => json.decode(s as String))
-                .listen(
+            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
               (dynamic message) {
                 if (message["type"] == "connection_init") {
                   channel.sink.add(
@@ -745,8 +845,7 @@ void main() {
             channel.stream.listen(
               expectAsyncUntil1<void, dynamic>(
                 (dynamic message) {
-                  final map =
-                      json.decode(message as String) as Map<String, dynamic>;
+                  final map = json.decode(message as String) as Map<String, dynamic>;
                   if (messageCount == 0) {
                     expect(map["type"], MessageTypes.connectionInit);
                     channel.sink.add(
@@ -782,9 +881,7 @@ void main() {
         responseSub = link.request(request).listen(print);
       });
 
-      test(
-          "close the socket when no keep alive received from server withe inactivityTimeout",
-          () async {
+      test("close the socket when no keep alive received from server withe inactivityTimeout", () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -793,8 +890,7 @@ void main() {
         final Request request = Request(
           operation: Operation(
             operationName: "pokemonsSubscription",
-            document: parseString(
-                r"subscription MySubscription { pokemons(first: $first) { name } }"),
+            document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
           ),
           variables: const <String, dynamic>{
             "first": 3,
@@ -805,9 +901,7 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream
-                .map<dynamic>((dynamic s) => json.decode(s as String))
-                .listen(
+            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
               (dynamic message) {
                 // Do not send anything, let it timeout.
               },
@@ -834,9 +928,7 @@ void main() {
         );
       });
 
-      test(
-          "never close the socket as long as keep alive is send from the server",
-          () async {
+      test("never close the socket as long as keep alive is send from the server", () async {
         HttpServer server;
         WebSocket webSocket;
         IOWebSocketChannel channel;
@@ -845,8 +937,7 @@ void main() {
         final Request request = Request(
           operation: Operation(
             operationName: "pokemonsSubscription",
-            document: parseString(
-                r"subscription MySubscription { pokemons(first: $first) { name } }"),
+            document: parseString(r"subscription MySubscription { pokemons(first: $first) { name } }"),
           ),
           variables: const <String, dynamic>{
             "first": 3,
@@ -857,9 +948,7 @@ void main() {
         server.transform(WebSocketTransformer()).listen(
           (webSocket) async {
             final channel = IOWebSocketChannel(webSocket);
-            channel.stream
-                .map<dynamic>((dynamic s) => json.decode(s as String))
-                .listen(
+            channel.stream.map<dynamic>((dynamic s) => json.decode(s as String)).listen(
               (dynamic message) {
                 Timer.periodic(Duration(seconds: 1), (_) {
                   channel.sink.add(
@@ -914,11 +1003,9 @@ void main() {
                     channel.stream.take(1).listen(
                           expectAsync1<void, dynamic>(
                             (dynamic message) {
-                              final map = json.decode(message as String)
-                                  as Map<String, dynamic>;
+                              final map = json.decode(message as String) as Map<String, dynamic>;
                               if (messageCount == 0) {
-                                expect(
-                                    map["type"], MessageTypes.connectionInit);
+                                expect(map["type"], MessageTypes.connectionInit);
                                 channel.sink.add(
                                   json.encode(
                                     ConnectionAck(),
@@ -941,8 +1028,7 @@ void main() {
           link = WebSocketLink(
             null,
             channelGenerator: () async {
-              final webSocket =
-                  await WebSocket.connect("ws://localhost:${server.port}");
+              final webSocket = await WebSocket.connect("ws://localhost:${server.port}");
               return IOWebSocketChannel(webSocket);
             },
             reconnectInterval: Duration(milliseconds: 500),
@@ -978,8 +1064,7 @@ void main() {
                   channel.stream.listen(
                     expectAsync1<void, dynamic>(
                       (dynamic message) {
-                        final map = json.decode(message as String)
-                            as Map<String, dynamic>;
+                        final map = json.decode(message as String) as Map<String, dynamic>;
                         if (messageCount == 0) {
                           expect(map["type"], MessageTypes.connectionInit);
                           channel.sink.add(
@@ -1013,8 +1098,7 @@ void main() {
                   channel.stream.listen(
                     expectAsync1<void, dynamic>(
                       (dynamic message) {
-                        final map = json.decode(message as String)
-                            as Map<String, dynamic>;
+                        final map = json.decode(message as String) as Map<String, dynamic>;
                         if (messageCount == 0) {
                           expect(map["type"], MessageTypes.connectionInit);
                           channel.sink.add(
@@ -1044,12 +1128,10 @@ void main() {
           channelGenerator: () async {
             if (connectToServer == 1) {
               connectToServer++;
-              final webSocket =
-                  await WebSocket.connect("ws://localhost:${server1.port}");
+              final webSocket = await WebSocket.connect("ws://localhost:${server1.port}");
               return IOWebSocketChannel(webSocket);
             } else {
-              final webSocket =
-                  await WebSocket.connect("ws://localhost:${server2.port}");
+              final webSocket = await WebSocket.connect("ws://localhost:${server2.port}");
               return IOWebSocketChannel(webSocket);
             }
           },


### PR DESCRIPTION
Currently there isn't any way to stop a subscription without closing the link altogether, this is problematic if you have multiple subscriptions and you want to be able to start and stop them without opening multiple sockets.

This PR adds an API to do this by exposing a 'stop' function on WebSocketLink, which takes the requestId.
The requestId was also not publicly available, so I'm also adding the RequestId context entry to the Response, it is up to the consumer to get the id from the response and use it to stop a subscription.

I added a unit test for this and I also tested it in my app which is under development.