### PR TITLE
gql_dio_link: Forward original exception on dio errors

### DIFF
--- a/links/gql_dio_link/CHANGELOG.md
+++ b/links/gql_dio_link/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [0.0.1] - TODO: Add release date.
+## 0.0.5
 
-* TODO: Describe initial release.
+- Pass original exception inside `DioLinkServerException` also if http request fails with error status and improve `DioLinkServerException.toString` to print part of plain response (even if it was not valid graphQL json). These should be helpful for debugging.

--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -164,7 +164,10 @@ class DioLink extends Link {
                 ? parser.parseResponse(res.data as Map<String, dynamic>)
                 : null;
             throw DioLinkServerException(
-                response: res, parsedResponse: parsedResponse);
+              response: res, 
+              parsedResponse: parsedResponse,
+              originalException: e
+            );
           }
         case dio.DioErrorType.DEFAULT:
         default:

--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -164,10 +164,9 @@ class DioLink extends Link {
                 ? parser.parseResponse(res.data as Map<String, dynamic>)
                 : null;
             throw DioLinkServerException(
-              response: res, 
-              parsedResponse: parsedResponse,
-              originalException: e
-            );
+                response: res,
+                parsedResponse: parsedResponse,
+                originalException: e);
           }
         case dio.DioErrorType.DEFAULT:
         default:

--- a/links/gql_dio_link/lib/src/exceptions.dart
+++ b/links/gql_dio_link/lib/src/exceptions.dart
@@ -24,21 +24,21 @@ class DioLinkServerException extends ServerException {
   /// Response which caused the exception
   final dio.Response response;
 
-  const DioLinkServerException({
-    @required this.response,
-    @required Response parsedResponse,
-    dynamic originalException
-  }) : super(
-    parsedResponse: parsedResponse,
-    originalException: originalException
-  );
+  const DioLinkServerException(
+      {@required this.response,
+      @required Response parsedResponse,
+      dynamic originalException})
+      : super(
+            parsedResponse: parsedResponse,
+            originalException: originalException);
 
   @override
   String toString() {
     final dynamic data = response.data;
     String plainResponse = "...";
     if (data is String) {
-      plainResponse = data.length > 80 ? data.replaceRange(80, data.length, "...") : data;
+      plainResponse =
+          data.length > 80 ? data.replaceRange(80, data.length, "...") : data;
     }
     return "DioLinkServerException(originalException: $originalException, status: ${response.statusCode}, response: ${parsedResponse ?? plainResponse}";
   }

--- a/links/gql_dio_link/lib/src/exceptions.dart
+++ b/links/gql_dio_link/lib/src/exceptions.dart
@@ -24,21 +24,21 @@ class DioLinkServerException extends ServerException {
   /// Response which caused the exception
   final dio.Response response;
 
-  const DioLinkServerException(
-      {@required this.response,
-      @required Response parsedResponse,
-      dynamic originalException})
-      : super(
-            parsedResponse: parsedResponse,
-            originalException: originalException);
+  const DioLinkServerException({
+    @required this.response,
+    @required Response parsedResponse,
+    dynamic originalException
+  }) : super(
+    parsedResponse: parsedResponse,
+    originalException: originalException
+  );
 
   @override
   String toString() {
     final dynamic data = response.data;
     String plainResponse = "...";
     if (data is String) {
-      plainResponse =
-          data.length > 80 ? data.replaceRange(80, data.length, "...") : data;
+      plainResponse = data.length > 80 ? data.replaceRange(80, data.length, "...") : data;
     }
     return "DioLinkServerException(originalException: $originalException, status: ${response.statusCode}, response: ${parsedResponse ?? plainResponse}";
   }

--- a/links/gql_dio_link/lib/src/exceptions.dart
+++ b/links/gql_dio_link/lib/src/exceptions.dart
@@ -24,12 +24,24 @@ class DioLinkServerException extends ServerException {
   /// Response which caused the exception
   final dio.Response response;
 
-  const DioLinkServerException({
-    @required this.response,
-    @required Response parsedResponse,
-  }) : super(
-          parsedResponse: parsedResponse,
-        );
+  const DioLinkServerException(
+      {@required this.response,
+      @required Response parsedResponse,
+      dynamic originalException})
+      : super(
+            parsedResponse: parsedResponse,
+            originalException: originalException);
+
+  @override
+  String toString() {
+    final dynamic data = response.data;
+    String plainResponse = "...";
+    if (data is String) {
+      plainResponse =
+          data.length > 80 ? data.replaceRange(80, data.length, "...") : data;
+    }
+    return "DioLinkServerException(originalException: $originalException, status: ${response.statusCode}, response: ${parsedResponse ?? plainResponse}";
+  }
 }
 
 @immutable

--- a/links/gql_dio_link/pubspec.yaml
+++ b/links/gql_dio_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_dio_link
-version: 0.0.4
+version: 0.0.5
 description: Similar to gql_http_link, gql_dio_link is a GQL Terminating Link to execute requests via Dio using JSON
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_dio_link/test/gql_dio_link_test.dart
+++ b/links/gql_dio_link/test/gql_dio_link_test.dart
@@ -483,6 +483,62 @@ void main() {
           ),
         ),
       );
+
+      // Dio returned the failed response instead of throwing, so there is no exception
+      expect(exception.originalException, null);
+    });
+
+    test("throws DioLinkServerException for dio error response", () async {
+      final error = dio.DioError(
+          response:
+              dio.Response<String>(data: "Not authenticated", statusCode: 401),
+          type: dio.DioErrorType.RESPONSE);
+
+      when(
+        client.post<dynamic>(
+          any,
+          data: anyNamed("data"),
+          options: anyNamed("options"),
+        ),
+      ).thenThrow(
+        error,
+      );
+
+      DioLinkServerException exception;
+
+      try {
+        await execute().first;
+      } catch (e) {
+        exception = e as DioLinkServerException;
+      }
+
+      expect(
+        exception,
+        TypeMatcher<DioLinkServerException>(),
+      );
+      expect(
+        exception.response.data,
+        error.response.data,
+      );
+      expect(
+        exception.response.statusCode,
+        error.response.statusCode,
+      );
+      // Failed to parse non-grahpql formatted body, so therefore null
+      expect(
+        exception.parsedResponse,
+        null,
+      );
+
+      expect(exception.originalException != null, true);
+
+      final dioException = exception.originalException as dio.DioError;
+      expect(dioException.response.data, "Not authenticated");
+      expect(dioException.response.statusCode, 401);
+      expect(dioException.type, dio.DioErrorType.RESPONSE);
+
+      expect(exception.toString(),
+          "DioLinkServerException(originalException: DioError [DioErrorType.RESPONSE]: , status: 401, response: Not authenticated");
     });
 
     test("throws HttpLinkServerException when no data and errors", () async {


### PR DESCRIPTION
Pass original exception also if http request fails with error status. Dio throws DioError if response status is in error range so this makes it possible to have that as original error and makes debugging easier.