### PR TITLE
gql_websocket_link:  better (correct) assertion

### DIFF
--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -120,7 +120,8 @@ class WebSocketLink extends Link {
     this.graphQLSocketMessageDecoder = _defaultGraphQLSocketMessageDecoder,
     this.initialPayload,
     this.inactivityTimeout,
-  }) : assert(uri == null || (channelGenerator == null)) {
+  }) : assert((uri == null && channelGenerator != null) ||
+            (uri != null && channelGenerator == null)) {
     _channelGenerator =
         channelGenerator ?? () => WebSocketChannel.connect(Uri.parse(uri!));
   }


### PR DESCRIPTION

The assertion now checks if either one of the two values is null while the other is not which aligns with the given documentation. The previous assertion only checked if one of them is null. 

Took me quite some time to find the bug which was caused by a null URI in an isolate.  