### PR TITLE
feat: add canonical dispose method on gql_link

### DIFF
--- a/links/gql_http_link/lib/src/link.dart
+++ b/links/gql_http_link/lib/src/link.dart
@@ -243,7 +243,8 @@ class HttpLink extends Link {
       };
 
   /// Closes the underlining [http.Client]
-  void dispose() {
+  @override
+  Future<void> dispose() async {
     _httpClient?.close();
   }
 }

--- a/links/gql_http_link/test/gql_http_link_test.dart
+++ b/links/gql_http_link/test/gql_http_link_test.dart
@@ -606,8 +606,8 @@ void main() {
       );
     });
 
-    test("closes the underlining http client", () {
-      link.dispose();
+    test("closes the underlining http client", () async {
+      await link.dispose();
 
       verify(
         client.close(),

--- a/links/gql_link/lib/src/link.dart
+++ b/links/gql_link/lib/src/link.dart
@@ -96,6 +96,9 @@ abstract class Link {
     /// Terminating [Link]s do not call this function.
     NextLink? forward,
   ]);
+
+  /// Can be called to clean up resources
+  Future<void> dispose() async => null;
 }
 
 class _FunctionLink extends Link {
@@ -125,6 +128,9 @@ class _LinkChain extends Link {
         forward,
         (fw, link) => (op) => link.request(op, fw),
       )!(request);
+
+  @override
+  Future<void> dispose() => Future.wait(links.map((link) => link.dispose()));
 }
 
 @visibleForTesting

--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -336,6 +336,7 @@ class WebSocketLink extends Link {
   /// Only use this, if you want to disconnect from the current server
   /// in favour of another one. If that's the case,
   /// create a new [WebSocketLink] instance.
+  @override
   Future<void> dispose() async {
     await _close();
     _channel = null;


### PR DESCRIPTION
This PR adds a canonical `dispose()` method to the `Link` class.

This includes a minor breaking change - `HttpLink`'s dispose method now returns a `Future<void>` instead of a `void`.