### PR TITLE
Ignore gql cats directory

### DIFF
--- a/gql/.pubignore
+++ b/gql/.pubignore
@@ -1,0 +1,1 @@
+lib/cats/


### PR DESCRIPTION
This is a fix for the issue discussed in #268.