### PR TITLE
[gql_websocket_link] Parse errors and extension in error message type use websocket_status.normalClosure

### DIFF
--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -232,10 +232,6 @@ class WebSocketLink extends Link {
           _reConnectRequests.clear();
         }
       }, onDone: () {
-        assert(
-          !isDisabled || _connectionStateController.value == closed,
-          "_connectionStateController should be disposed with a closed state",
-        );
         if (isDisabled) {
           // already disposed
           return;
@@ -276,7 +272,7 @@ class WebSocketLink extends Link {
             .map<ConnectionKeepAlive>(
                 (message) => message as ConnectionKeepAlive)
             .timeout(inactivityTimeout!, onTimeout: (_) {
-          _channel!.sink.close(websocket_status.goingAway);
+          _channel!.sink.close(websocket_status.normalClosure);
         }).listen(null);
       }
     } catch (e) {
@@ -378,12 +374,12 @@ class WebSocketLink extends Link {
       return _disposedCompleter!.future;
     }
     _disposedCompleter = Completer();
+    _reconnectTimer?.cancel();
     await _keepAliveSubscription?.cancel();
-    await _channel?.sink.close(websocket_status.goingAway);
+    await _channel?.sink.close(websocket_status.normalClosure);
     _connectionStateController.add(closed);
     await _connectionStateController.close();
     await _messagesController.close();
-    _reconnectTimer?.cancel();
     _disposedCompleter!.complete();
   }
 

--- a/links/gql_websocket_link/lib/src/link.dart
+++ b/links/gql_websocket_link/lib/src/link.dart
@@ -336,7 +336,35 @@ class WebSocketLink extends Link {
         final dynamic extensions = payload["extensions"];
         return SubscriptionData(id, data, errors, extensions);
       case MessageTypes.error:
-        return SubscriptionError(id, payload);
+        List<Map<String, Object?>>? _tryCastErrors(List<Object?> list) {
+          final allAreErrors = list.every(
+            (map) =>
+                map is Map<String, Object?> &&
+                map["message"] is String &&
+                (map["path"] is List?) &&
+                (map["locations"] is List?) &&
+                (map["extensions"] is Map<String, Object?>?),
+          );
+          return allAreErrors ? list.cast() : null;
+        }
+        Object? extensions;
+        List<Map<String, Object?>>? errors;
+        if (payload is List) {
+          errors = _tryCastErrors(payload);
+        } else if (payload is Map) {
+          if (payload["errors"] is List) {
+            extensions = payload["extensions"];
+            errors = _tryCastErrors(payload["errors"] as List);
+          } else {
+            errors = _tryCastErrors([payload]);
+            // only pass root level extensions if they weren't passed as
+            // extensions in the error
+            if (errors == null) {
+              extensions = payload["extensions"];
+            }
+          }
+        }
+        return SubscriptionError(id, payload, errors, extensions);
       case MessageTypes.complete:
         return SubscriptionComplete(id);
       default:

--- a/links/gql_websocket_link/lib/src/messages.dart
+++ b/links/gql_websocket_link/lib/src/messages.dart
@@ -172,16 +172,25 @@ class SubscriptionData extends GraphQLSocketMessage {
 /// Errors sent from the server to the client if the subscription operation was
 /// not successful, usually due to GraphQL validation errors.
 class SubscriptionError extends GraphQLSocketMessage {
-  SubscriptionError(this.id, this.payload) : super(MessageTypes.error);
+  SubscriptionError(
+    this.id,
+    this.payload,
+    this.errors,
+    this.extensions,
+  ) : super(MessageTypes.error);
 
   final String id;
   final dynamic payload;
+  final List<Map<String, Object?>>? errors;
+  final dynamic extensions;
 
   @override
   Map<String, dynamic> toJson() => <String, dynamic>{
         "type": type,
         "id": id,
         "payload": payload,
+        if (errors != null) "errors": errors,
+        if (extensions != null) "extensions": extensions,
       };
 }
 

--- a/links/gql_websocket_link/test/gql_websocket_link_test.dart
+++ b/links/gql_websocket_link/test/gql_websocket_link_test.dart
@@ -1172,7 +1172,7 @@ void main() {
                 ),
                 onDone: expectAsync0(
                   () {
-                    expect(channel.closeCode, websocket_status.goingAway);
+                    expect(channel.closeCode, websocket_status.normalClosure);
                   },
                   count: 1,
                 ),

--- a/links/gql_websocket_link/test/gql_websocket_link_test.dart
+++ b/links/gql_websocket_link/test/gql_websocket_link_test.dart
@@ -1216,6 +1216,182 @@ void main() {
           await Future.wait([firstFut, secondFut]);
         },
       );
+
+      test(
+        "error message type parsing",
+        () async {
+          HttpServer server;
+          WebSocket webSocket;
+          IOWebSocketChannel channel;
+          WebSocketLink link;
+          Request request;
+
+          final errorsList = [
+            // Map with errors (similar to data messages)
+            {
+              "errors": [
+                {
+                  "message": "error message 0",
+                  "path": ["p1", 2]
+                },
+              ],
+            },
+            // Map with errors and response extensions
+            {
+              "errors": [
+                {"message": "error message 1"}
+              ],
+              "extensions": {
+                "otherFields": 1,
+              }
+            },
+            // List of errors
+            [
+              {
+                "message": "error message 2.1",
+                "locations": [
+                  {"column": 1, "line": 2}
+                ]
+              },
+              {
+                "message": "error message 2.2",
+              }
+            ],
+            // Single error
+            {
+              "message": "error message 3",
+              "extensions": {
+                "otherFields": 3,
+              }
+            },
+          ];
+
+          request = Request(
+            operation: Operation(
+              operationName: "pokemonsSubscription",
+              document: parseString(
+                  r"subscription MySubscription { pokemons(first: $first) { name } }"),
+            ),
+            variables: const <String, dynamic>{
+              "first": 3,
+            },
+          );
+
+          server = await HttpServer.bind("localhost", 0);
+          server.transform(WebSocketTransformer()).listen(
+            (webSocket) async {
+              final channel = IOWebSocketChannel(webSocket);
+              channel.stream.listen(
+                expectAsync1<void, dynamic>(
+                  (dynamic message) async {
+                    final map =
+                        json.decode(message as String) as Map<String, dynamic>;
+                    if (map["type"] == "connection_init") {
+                      channel.sink.add(json.encode(ConnectionAck()));
+                    } else if (map["type"] == "start") {
+                      for (final err in errorsList) {
+                        channel.sink.add(
+                          json.encode(
+                            <String, dynamic>{
+                              "type": "error",
+                              "id": map["id"],
+                              "payload": err,
+                            },
+                          ),
+                        );
+                      }
+                    }
+                  },
+                  count: 2,
+                ),
+              );
+            },
+          );
+
+          webSocket = await WebSocket.connect("ws://localhost:${server.port}");
+          channel = IOWebSocketChannel(webSocket);
+
+          link = WebSocketLink(null, channelGenerator: () => channel);
+          int messageIndex = 0;
+          link.request(request).listen(
+                expectAsync1(
+                  (Response response) {
+                    switch (messageIndex) {
+                      case 0:
+                        expect(response.errors!.length, 1);
+                        expect(
+                          response.errors!.first.message,
+                          "error message 0",
+                        );
+                        expect(
+                          response.errors!.first.path,
+                          ["p1", 2],
+                        );
+
+                        break;
+                      case 1:
+                        expect(response.errors!.length, 1);
+                        expect(
+                          response.errors!.first.message,
+                          "error message 1",
+                        );
+                        expect(
+                          response.context
+                              .entry<ResponseExtensions>()!
+                              .extensions,
+                          {
+                            "otherFields": 1,
+                          },
+                        );
+                        break;
+                      case 2:
+                        final errors = response.errors!;
+                        expect(errors.length, 2);
+                        expect(
+                          errors.first.message,
+                          "error message 2.1",
+                        );
+                        expect(
+                          errors.first.locations!
+                              .map((e) => {"column": e.column, "line": e.line}),
+                          [
+                            {"column": 1, "line": 2}
+                          ],
+                        );
+                        expect(
+                          errors.last.message,
+                          "error message 2.2",
+                        );
+                        break;
+                      case 3:
+                        expect(response.errors!.length, 1);
+                        expect(
+                          response.errors!.first.message,
+                          "error message 3",
+                        );
+                        expect(
+                          response.errors!.first.extensions,
+                          {
+                            "otherFields": 3,
+                          },
+                        );
+                        expect(
+                          response.context
+                              .entry<ResponseExtensions>()!
+                              .extensions,
+                          null,
+                        );
+                        break;
+                      default:
+                        throw Error();
+                    }
+                    messageIndex += 1;
+                  },
+                  count: errorsList.length,
+                ),
+              );
+        },
+      );
     },
   );
 }


### PR DESCRIPTION
Fixes [237](https://github.com/gql-dart/gql/issues/237) and [260](https://github.com/gql-dart/gql/issues/260). 
Improves on [278](https://github.com/gql-dart/gql/pull/278) to fix [260](https://github.com/gql-dart/gql/issues/260) by using `websocket_status.normalClosure` instead of `websocket_status.goingAway`to support web (replicated the issue and tested on a browser).

Hi, from the conversation in [237](https://github.com/gql-dart/gql/issues/237) I added `errors` and `extensions` field in `SubscriptionError`, the parsing checks if the error objects are of the right format for `ResponseParser.parseError`. The root (response) extensions are only passed if the payload could not be parsed as an error, since otherwise they would be duplicated in the `errors[0].extension` and `response.entry<ResponseExtensions>()!.extensions`. I left the complete payload in the `SubscriptionError.toJson` in case anyone was using that, however, I can remove it if you think that's better.

Adds a test with different payload formats. A map with "errors" field, a map with "errors" field and response "extensions", a list of errors and a single error.

Please, tell me if there is something that I could change to improve the PR or anything else you want to discuss.

Thank you!


