### PR TITLE
Add support for Schema description

### DIFF
--- a/gql/lib/src/ast/ast.dart
+++ b/gql/lib/src/ast/ast.dart
@@ -656,10 +656,12 @@ abstract class TypeExtensionNode extends TypeSystemExtensionNode {
 }
 
 class SchemaDefinitionNode extends TypeSystemDefinitionNode {
+  final StringValueNode? description;
   final List<DirectiveNode> directives;
   final List<OperationTypeDefinitionNode> operationTypes;
 
   const SchemaDefinitionNode({
+    this.description,
     this.directives = const [],
     this.operationTypes = const [],
     FileSpan? span,
@@ -669,7 +671,8 @@ class SchemaDefinitionNode extends TypeSystemDefinitionNode {
   R accept<R>(Visitor<R> v) => v.visitSchemaDefinitionNode(this);
 
   @override
-  List<Object> get _children => <Object>[
+  List<Object?> get _children => <Object?>[
+        description,
         directives,
         operationTypes,
       ];

--- a/gql/lib/src/ast/transformer.dart
+++ b/gql/lib/src/ast/transformer.dart
@@ -864,6 +864,7 @@ class _Transformer extends Visitor<Node> {
     SchemaDefinitionNode node,
   ) {
     final updatedNode = SchemaDefinitionNode(
+      description: _visitOne(node.description),
       directives: _visitAll(node.directives),
       operationTypes: _visitAll(node.operationTypes),
     );

--- a/gql/lib/src/language/parser.dart
+++ b/gql/lib/src/language/parser.dart
@@ -609,9 +609,11 @@ class _Parser {
   }
 
   SchemaDefinitionNode _parseSchemaDefinition() {
+    final description = _parseDescription();
     _expectKeyword("schema");
 
     return SchemaDefinitionNode(
+      description: description,
       directives: _parseDirectives(
         isConst: true,
       ),

--- a/gql/lib/src/language/printer.dart
+++ b/gql/lib/src/language/printer.dart
@@ -288,6 +288,10 @@ class _PrintVisitor extends Visitor<String> {
 
   @override
   String visitSchemaDefinitionNode(SchemaDefinitionNode node) => [
+        if (node.description != null) ...[
+          node.description!.accept(this),
+          "\n",
+        ],
         "schema",
         " ",
         visitDirectiveSetNode(node.directives),


### PR DESCRIPTION
Fixes https://github.com/gql-dart/gql/issues/283

Hi!

This adds support for descriptions in schemas. I am not sure if I did everything thats necessary, please let me know if there is anything else I can help you with. Added a test for parsing and printing multiple descriptions. I opened a PR which modifies similar files in https://github.com/gql-dart/gql/pull/279.

Thanks