### PR TITLE
add "missing fragment definition" validation rule

### DIFF
--- a/gql/lib/src/validation/rules/missing_fragment_definitions.dart
+++ b/gql/lib/src/validation/rules/missing_fragment_definitions.dart
@@ -1,0 +1,66 @@
+import "package:gql/ast.dart";
+import "package:gql/document.dart";
+import "package:gql/src/validation/validating_visitor.dart";
+
+class MissingFragmentDefinitionError implements ValidationError {
+  const MissingFragmentDefinitionError({
+    required this.node,
+  });
+
+  @override
+  final FragmentSpreadNode node;
+
+  @override
+  String get message {
+    final fragmentName = node.name.value;
+    final url = node.name.span?.file.url;
+    final line = node.name.span?.start.line;
+    var message = "no definition was found for $fragmentName fragment";
+    if (url != null && line != null) {
+      message = message + " in: $url:$line";
+    } else if (line != null) {
+      message = message + " in: line $line";
+    }
+    return message;
+  }
+}
+
+/// Validates that every [FragmentSpreadNode] has [FragmentDefinitionNode] within the same [DocumentNode]
+class MisingFragmentDefinition extends ValidatingVisitor {
+  @override
+  List<ValidationError> visitDocumentNode(DocumentNode node) {
+    final errors = <ValidationError>[];
+    // a workaround the fact that ValidatingVisitor is a SimpleVisitor which will only visit each node once.
+    // the document is recursively being visited here to ensure that all [FragmentSpreadNode]s and [FragmentDefiniton]s
+    // have been visited before returning an error.
+    final recusriveVisitor = _MisingFragmentDefinitionRecursive();
+    // visit all children of the given document node
+    node.accept(recusriveVisitor);
+    // validate that all FragmentSpreadNode has a FragmentDefinitionNode
+    for (final fragmentSpread in recusriveVisitor.fragmentSpreads) {
+      if (recusriveVisitor.fragmentDefinitions.any((f) => f.name.value == fragmentSpread.name.value)) {
+        continue;
+      } else {
+        errors.add(MissingFragmentDefinitionError(node: fragmentSpread));
+      }
+    }
+    return errors;
+  }
+}
+
+class _MisingFragmentDefinitionRecursive extends RecursiveVisitor {
+  final List<FragmentDefinitionNode> fragmentDefinitions = [];
+  final List<FragmentSpreadNode> fragmentSpreads = [];
+
+  @override
+  void visitFragmentDefinitionNode(FragmentDefinitionNode node) {
+    fragmentDefinitions.add(node);
+    super.visitFragmentDefinitionNode(node);
+  }
+
+  @override
+  void visitFragmentSpreadNode(FragmentSpreadNode node) {
+    fragmentSpreads.add(node);
+    super.visitFragmentSpreadNode(node);
+  }
+}

--- a/gql/lib/src/validation/validator.dart
+++ b/gql/lib/src/validation/validator.dart
@@ -1,5 +1,6 @@
 import "package:gql/ast.dart" as ast;
 import "package:gql/src/validation/rules/lone_schema_definition.dart";
+import "package:gql/src/validation/rules/missing_fragment_definitions.dart";
 import "package:gql/src/validation/rules/unique_argument_names.dart";
 import "package:gql/src/validation/rules/unique_directive_names.dart";
 import "package:gql/src/validation/rules/unique_enum_value_names.dart";
@@ -96,7 +97,8 @@ enum ValidationRule {
   uniqueOperationTypes,
   uniqueTypeNames,
   uniqueInputFieldNames,
-  uniqueArgumentNames
+  uniqueArgumentNames,
+  missingFragmentDefinition
 }
 
 ValidatingVisitor? _mapRule(ValidationRule rule) {
@@ -117,6 +119,8 @@ ValidatingVisitor? _mapRule(ValidationRule rule) {
       return UniqueInputFieldNames();
     case ValidationRule.uniqueArgumentNames:
       return UniqueArgumentNames();
+    case ValidationRule.missingFragmentDefinition:
+      return MisingFragmentDefinition();
     default:
       return null;
   }

--- a/gql/test/validation/missing_fragment_definition_test.dart
+++ b/gql/test/validation/missing_fragment_definition_test.dart
@@ -1,0 +1,56 @@
+import "package:gql/src/validation/rules/missing_fragment_definitions.dart";
+import "package:gql/src/validation/validator.dart";
+import "package:test/test.dart";
+
+import "./common.dart";
+
+final validate = createValidator({
+  ValidationRule.missingFragmentDefinition,
+});
+
+void main() {
+  group("Missing Fragement Definitions", () {
+    test("- error when fragement definition is missing", () {
+      expect(
+        validate(
+          """
+        query GetPerson {
+          people(id: "7") {
+            ...NameParts
+            avatar(size: LARGE)
+          }
+        }
+        """,
+        ),
+        contains(
+          errorOfType<MissingFragmentDefinitionError>(),
+        ),
+      );
+    });
+
+    test("- no errors when fragment definition is present", () {
+      expect(
+        validate(
+          """
+          query GetPerson {
+            people(id: "7") {
+              ...NameParts
+              avatar(size: LARGE)
+            }
+          }
+
+          fragment NameParts on Person {
+            firstName
+            lastName
+          }
+        """,
+        ),
+        isNot(
+          contains(
+            errorOfType<MissingFragmentDefinitionError>(),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
I added a rule that checks that all fragments are present for all fragment spreads within a document. This helps when validating an operation document.