### PR TITLE
publish release branch

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,8 +1,8 @@
 name: Publish Alpha
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - release
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,4 +1,4 @@
-name: Publish Alpha
+name: Publish Release
 on:
   push:
     branches:


### PR DESCRIPTION
Publish the packages when we push to `release` branch. Same as `publish_alpha` workflow.