### PR TITLE
Union types in web release mode

### DIFF
--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.dart
@@ -39,7 +39,7 @@ abstract class GHeroForEpisodeData_hero {
       _i2.InlineFragmentSerializer<GHeroForEpisodeData_hero>(
           'GHeroForEpisodeData_hero',
           GHeroForEpisodeData_hero__base,
-          { 'Droid': GHeroForEpisodeData_hero__asDroid });
+          {'Droid': GHeroForEpisodeData_hero__asDroid});
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GHeroForEpisodeData_hero.serializer, this)
           as Map<String, dynamic>);
@@ -61,12 +61,16 @@ abstract class GHeroForEpisodeData_hero__base
 
   static void _initializeBuilder(GHeroForEpisodeData_hero__baseBuilder b) =>
       b..G__typename = 'Character';
+  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  @override
   String get name;
+  @override
   BuiltList<GHeroForEpisodeData_hero__base_friends>? get friends;
   static Serializer<GHeroForEpisodeData_hero__base> get serializer =>
       _$gHeroForEpisodeDataHeroBaseSerializer;
+  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
       GHeroForEpisodeData_hero__base.serializer, this) as Map<String, dynamic>);
   static GHeroForEpisodeData_hero__base? fromJson(Map<String, dynamic> json) =>
@@ -88,11 +92,14 @@ abstract class GHeroForEpisodeData_hero__base_friends
   static void _initializeBuilder(
           GHeroForEpisodeData_hero__base_friendsBuilder b) =>
       b..G__typename = 'Character';
+  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  @override
   String get name;
   static Serializer<GHeroForEpisodeData_hero__base_friends> get serializer =>
       _$gHeroForEpisodeDataHeroBaseFriendsSerializer;
+  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GHeroForEpisodeData_hero__base_friends.serializer, this)
       as Map<String, dynamic>);
@@ -116,13 +123,18 @@ abstract class GHeroForEpisodeData_hero__asDroid
 
   static void _initializeBuilder(GHeroForEpisodeData_hero__asDroidBuilder b) =>
       b..G__typename = 'Droid';
+  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  @override
   String get name;
+  @override
   BuiltList<GHeroForEpisodeData_hero__asDroid_friends>? get friends;
+  @override
   String? get primaryFunction;
   static Serializer<GHeroForEpisodeData_hero__asDroid> get serializer =>
       _$gHeroForEpisodeDataHeroAsDroidSerializer;
+  @override
   Map<String, dynamic> toJson() => (_i1.serializers
           .serializeWith(GHeroForEpisodeData_hero__asDroid.serializer, this)
       as Map<String, dynamic>);
@@ -146,11 +158,14 @@ abstract class GHeroForEpisodeData_hero__asDroid_friends
   static void _initializeBuilder(
           GHeroForEpisodeData_hero__asDroid_friendsBuilder b) =>
       b..G__typename = 'Character';
+  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  @override
   String get name;
   static Serializer<GHeroForEpisodeData_hero__asDroid_friends> get serializer =>
       _$gHeroForEpisodeDataHeroAsDroidFriendsSerializer;
+  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GHeroForEpisodeData_hero__asDroid_friends.serializer, this)
       as Map<String, dynamic>);
@@ -183,11 +198,14 @@ abstract class GDroidFragmentData
 
   static void _initializeBuilder(GDroidFragmentDataBuilder b) =>
       b..G__typename = 'Droid';
+  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
+  @override
   String? get primaryFunction;
   static Serializer<GDroidFragmentData> get serializer =>
       _$gDroidFragmentDataSerializer;
+  @override
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GDroidFragmentData.serializer, this)
           as Map<String, dynamic>);

--- a/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/hero_for_episode.data.gql.dart
@@ -39,7 +39,7 @@ abstract class GHeroForEpisodeData_hero {
       _i2.InlineFragmentSerializer<GHeroForEpisodeData_hero>(
           'GHeroForEpisodeData_hero',
           GHeroForEpisodeData_hero__base,
-          [GHeroForEpisodeData_hero__asDroid]);
+          { 'Droid': GHeroForEpisodeData_hero__asDroid });
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GHeroForEpisodeData_hero.serializer, this)
           as Map<String, dynamic>);

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -104,14 +104,16 @@ List<Method> _inlineFragmentRootSerializationMethods({
             ..types.add(refer(name))).call([
             literalString(name),
             refer("${name}__base"),
-            literalList(
+            literalMap(
               /// TODO: Handle inline fragments without a type condition
               /// https://spec.graphql.org/June2018/#sec-Inline-Fragments
-              inlineFragments.where((frag) => frag.typeCondition != null).map(
-                    (inlineFragment) => refer(
-                      "${name}__as${inlineFragment.typeCondition!.on.name.value}",
-                    ),
-                  ),
+              {
+                for (var v in inlineFragments
+                    .where((frag) => frag.typeCondition != null))
+                  refer(v.typeCondition!.on.name.value): refer(
+                    "${name}__as${v.typeCondition!.on.name.value}",
+                  )
+              },
             ),
           ]).code,
       ),

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -110,7 +110,7 @@ List<Method> _inlineFragmentRootSerializationMethods({
               {
                 for (var v in inlineFragments
                     .where((frag) => frag.typeCondition != null))
-                  refer(v.typeCondition!.on.name.value): refer(
+                  "${v.typeCondition!.on.name.value}": refer(
                     "${name}__as${v.typeCondition!.on.name.value}",
                   )
               },

--- a/codegen/gql_code_builder/lib/src/serializers/inline_fragment_serializer.dart
+++ b/codegen/gql_code_builder/lib/src/serializers/inline_fragment_serializer.dart
@@ -2,14 +2,14 @@ import "package:built_value/serializer.dart";
 import "package:built_value/standard_json_plugin.dart";
 
 /// Deserializes a GraphQL selection with inline fragments into it's
-/// appropriate concrete data class based on its `__typename` field.
+/// appropriate concrete data class based on its  `__typename` field.
 ///
 /// If no `__typename` is found, it will simply return a base data class that
 /// only includes the common fields.
 class InlineFragmentSerializer<T> implements StructuredSerializer<T> {
   final String rootName;
   final Type baseClass;
-  final List<Type> asTypeClasses;
+  final Map<String, Type> asTypeClasses;
 
   InlineFragmentSerializer(
     this.rootName,
@@ -17,10 +17,7 @@ class InlineFragmentSerializer<T> implements StructuredSerializer<T> {
     this.asTypeClasses,
   );
 
-  Type _typeForTypename(String name) => asTypeClasses.firstWhere(
-        (c) => c.toString() == "${rootName}__as${name}",
-        orElse: () => baseClass,
-      );
+  Type _typeForTypename(String name) => asTypeClasses[name] ?? baseClass;
 
   @override
   T deserialize(


### PR DESCRIPTION
Release builds on web do code minification, this causes serialization issues when inline fragments are used. 

The InlineFragmentSerializer uses `toString()` on a type to compare to a graphql `__typename`. Unfortunately in minifed versions the `toString()` method on a dart Type returns a mangled class name and not the expected class name.