### PR TITLE
fix windows build on gql_build 0.4.1

### DIFF
--- a/codegen/gql_build/lib/src/config.dart
+++ b/codegen/gql_build/lib/src/config.dart
@@ -1,5 +1,4 @@
 import "package:build/build.dart";
-import "package:path/path.dart" as p;
 
 const sourceExtension = ".graphql";
 
@@ -21,9 +20,9 @@ String outputPattern(String extension) =>
     "{{inputDir}}/${outputDir}/{{file}}${extension}";
 
 String outputPath(String inputPath) {
-  final pathSegments = p.url.split(inputPath);
+  final pathSegments = inputPath.split('/');
   pathSegments.insert(pathSegments.length - 1, outputDir);
-  return p.joinAll(pathSegments);
+  return pathSegments.join('/');
 }
 
 AssetId outputAssetId(AssetId inputAssetId, String extension) => AssetId(


### PR DESCRIPTION
Use string split/join with forward slash instead of path library to fix Windows builds on gql_build 0.4.1. Tested on Windows and MacOS. Path library on Windows outputs backslash which is later translated to %5C, causing Dart import statements to be the malformed, such as: `import 'package:test%5Capi%5Cgql%5Cschema%5C__generated__%5Cschema.schema.gql.dart'
    as _i2;`

I can't seem to find a unit-test, so I've run it against my own schema on both Windows and MacOS.
I generally dislike removing 'path' library from code as @smkhalsa added it in https://github.com/gql-dart/gql/commit/3a10c83f6085e8ad903831a809d0274f0f4aecec for a reason I suspect. I'm just trying to fix windows builds for gql_build 0.4.1 without breaking something else in the process.

This attempts to fix https://github.com/gql-dart/gql/issues/306 and https://github.com/gql-dart/gql/issues/292
