### PR TITLE
Support following redirects 

### DIFF
--- a/links/gql_http_link/lib/src/link.dart
+++ b/links/gql_http_link/lib/src/link.dart
@@ -160,6 +160,10 @@ class HttpLink extends Link {
     try {
       final responseBody = await httpResponseDecoder(httpResponse);
       return parser.parseResponse(responseBody!);
+    } on ResponseFormatException {
+      if (!followRedirects && (httpResponse.statusCode == 301 || httpResponse.statusCode == 302)) {
+        rethrow;
+      }
     } catch (e) {
       throw HttpLinkParserException(
         originalException: e,

--- a/links/gql_http_link/lib/src/link.dart
+++ b/links/gql_http_link/lib/src/link.dart
@@ -164,6 +164,7 @@ class HttpLink extends Link {
       if (!followRedirects && (httpResponse.statusCode == 301 || httpResponse.statusCode == 302)) {
         rethrow;
       }
+      return Response(response: const <String, dynamic>{});
     } catch (e) {
       throw HttpLinkParserException(
         originalException: e,


### PR DESCRIPTION
Observed that redirects were not being followed. 

Added `followRedirects` field and passed into `HttpLink` constructor, defaults to true.
Updated `_parseHttpResponse` to capture `FormatException` and send empty data object to bypass `HttpLinkServerException` when `followRedirects` is true