### PR TITLE
chore: use latest dart docker image

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -20,7 +20,7 @@ jobs:
           - gql_transform_link
     runs-on: ubuntu-latest
     container:
-      image: google/dart
+      image: dart
     name: Check ${{ matrix.package }}
     env:
       PACKAGE: ${{ matrix.package }}
@@ -73,7 +73,7 @@ jobs:
           # gql_example_flutter would require flutter
     runs-on: ubuntu-latest
     container:
-      image: google/dart
+      image: dart
     name: Check ${{ matrix.package }}
     env:
       PACKAGE: ${{ matrix.package }}
@@ -119,7 +119,7 @@ jobs:
           - end_to_end_test
     runs-on: ubuntu-latest
     container:
-      image: google/dart
+      image: dart
     name: Check ${{ matrix.package }}
     env:
       PACKAGE: ${{ matrix.package }}
@@ -165,7 +165,7 @@ jobs:
   publish_dry_run:
     runs-on: ubuntu-latest
     container:
-      image: google/dart
+      image: dart
     env:
       PACKAGES: 'gql,gql_build,gql_code_builder,gql_dedupe_link,gql_dio_link,gql_exec,gql_http_link,gql_link,gql_pedantic,gql_transform_link,gql_error_link,gql_websocket_link'
       PUB_ACCESS_TOKEN: ${{ secrets.PUB_ACCESS_TOKEN }}
@@ -203,7 +203,7 @@ jobs:
   check_svg:
     runs-on: ubuntu-latest
     container:
-      image: google/dart
+      image: dart
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish_alpha.yml
+++ b/.github/workflows/publish_alpha.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:latest
+      image: dart:latest
     if: github.ref == 'refs/heads/master'
     env:
       PACKAGES: 'gql,gql_build,gql_code_builder,gql_dedupe_link,gql_dio_link,gql_exec,gql_http_link,gql_link,gql_pedantic,gql_transform_link,gql_error_link,gql_websocket_link'

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     container:
-      image: google/dart:latest
+      image: dart:latest
     if: github.ref == 'refs/heads/release'
     env:
       PACKAGES: 'gql,gql_build,gql_code_builder,gql_dedupe_link,gql_dio_link,gql_exec,gql_http_link,gql_link,gql_pedantic,gql_transform_link,gql_error_link,gql_websocket_link'


### PR DESCRIPTION
CI was using discontinued dart image. Using newer docker image will solve pass these tests. Currently using dart image which is discontinued -https://hub.docker.com/r/google/dart/ , one with latest update which we should use - https://hub.docker.com/_/dart.