### PR TITLE
Fix dependencies for gql_dio_link

### DIFF
--- a/links/gql_dio_link/pubspec.yaml
+++ b/links/gql_dio_link/pubspec.yaml
@@ -6,13 +6,13 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   dio: ^4.0.0
+  gql: ^0.13.0
   gql_exec: ^0.4.0
   gql_link: ^0.4.2
   meta: ^1.3.0
 dev_dependencies: 
   build_runner: ^2.0.0
   collection: ^1.15.0
-  gql: ^0.13.0
   gql_pedantic: ^1.0.2
   mockito: ^5.0.0
   test: ^1.14.3


### PR DESCRIPTION
This fixes the error mentioned in https://github.com/gql-dart/gql/pull/324#issuecomment-1204051957

I also suggest adding `depend_on_referenced_packages` to the lints.

cc @knaeckeKami