### PR TITLE
Disable lint on generated files

### DIFF
--- a/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.data.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.req.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.var.gql.dart
+++ b/codegen/end_to_end_test/lib/aliases/__generated__/aliased_hero.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.data.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.req.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.data.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.req.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.var.gql.dart
+++ b/codegen/end_to_end_test/lib/interfaces/__generated__/hero_for_episode.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.data.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.req.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.var.gql.dart
+++ b/codegen/end_to_end_test/lib/no_vars/__generated__/hero_no_vars.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.data.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.req.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.var.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/variables/__generated__/create_review.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/create_review.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/variables/__generated__/create_review.data.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/create_review.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/variables/__generated__/create_review.req.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/create_review.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/variables/__generated__/create_review.var.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/create_review.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.data.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.req.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.var.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/human_with_args.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/codegen/gql_build/lib/src/utils/writer.dart
+++ b/codegen/gql_build/lib/src/utils/writer.dart
@@ -33,7 +33,7 @@ Future<void> writeDocument(
 
   return buildStep.writeAsString(
     generatedAsset,
-    "// GENERATED CODE - DO NOT MODIFY BY HAND\n\n"
+    "// GENERATED CODE - DO NOT MODIFY BY HAND\n"
             "// ignore_for_file: type=lint\n\n" +
         genSrc,
   );

--- a/codegen/gql_build/lib/src/utils/writer.dart
+++ b/codegen/gql_build/lib/src/utils/writer.dart
@@ -33,6 +33,8 @@ Future<void> writeDocument(
 
   return buildStep.writeAsString(
     generatedAsset,
-    "// GENERATED CODE - DO NOT MODIFY BY HAND\n\n" + genSrc,
+    "// GENERATED CODE - DO NOT MODIFY BY HAND\n\n"
+            "// ignore_for_file: type=lint\n\n" +
+        genSrc,
   );
 }

--- a/examples/gql_example_build/lib/__generated__/schema.ast.gql.dart
+++ b/examples/gql_example_build/lib/__generated__/schema.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_build/lib/__generated__/schema.schema.gql.dart
+++ b/examples/gql_example_build/lib/__generated__/schema.schema.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/examples/gql_example_build/lib/fragments/__generated__/shape.ast.gql.dart
+++ b/examples/gql_example_build/lib/fragments/__generated__/shape.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_build/lib/fragments/__generated__/shape.data.gql.dart
+++ b/examples/gql_example_build/lib/fragments/__generated__/shape.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_build/lib/fragments/__generated__/shape.req.gql.dart
+++ b/examples/gql_example_build/lib/fragments/__generated__/shape.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_build/lib/fragments/__generated__/shape.var.gql.dart
+++ b/examples/gql_example_build/lib/fragments/__generated__/shape.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_build/lib/kitchen_sink/__generated__/query.ast.gql.dart
+++ b/examples/gql_example_build/lib/kitchen_sink/__generated__/query.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_build/lib/kitchen_sink/__generated__/query.data.gql.dart
+++ b/examples/gql_example_build/lib/kitchen_sink/__generated__/query.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_build/lib/kitchen_sink/__generated__/query.req.gql.dart
+++ b/examples/gql_example_build/lib/kitchen_sink/__generated__/query.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_build/lib/kitchen_sink/__generated__/query.var.gql.dart
+++ b/examples/gql_example_build/lib/kitchen_sink/__generated__/query.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/dimensions.ast.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/dimensions.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli/lib/__generated__/dimensions.data.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/dimensions.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/dimensions.var.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/dimensions.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/find_pokemon.ast.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/find_pokemon.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli/lib/__generated__/find_pokemon.data.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/find_pokemon.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/find_pokemon.req.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/find_pokemon.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/find_pokemon.var.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/find_pokemon.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/list_pokemon.ast.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/list_pokemon.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli/lib/__generated__/list_pokemon.data.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/list_pokemon.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/examples/gql_example_cli/lib/__generated__/list_pokemon.req.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/list_pokemon.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/list_pokemon.var.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/list_pokemon.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli/lib/__generated__/schema.ast.gql.dart
+++ b/examples/gql_example_cli/lib/__generated__/schema.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli_github/lib/__generated__/add_star.ast.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/add_star.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli_github/lib/__generated__/add_star.data.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/add_star.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/add_star.req.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/add_star.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/add_star.var.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/add_star.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/read_repos.ast.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/read_repos.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli_github/lib/__generated__/read_repos.data.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/read_repos.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/read_repos.req.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/read_repos.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/read_repos.var.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/read_repos.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/remove_star.ast.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/remove_star.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli_github/lib/__generated__/remove_star.data.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/remove_star.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/remove_star.req.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/remove_star.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/remove_star.var.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/remove_star.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_cli_github/lib/__generated__/schema.ast.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/schema.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_cli_github/lib/__generated__/schema.schema.gql.dart
+++ b/examples/gql_example_cli_github/lib/__generated__/schema.schema.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/examples/gql_example_flutter/lib/graphql/__generated__/schema.ast.gql.dart
+++ b/examples/gql_example_flutter/lib/graphql/__generated__/schema.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.ast.gql.dart
+++ b/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.data.gql.dart
+++ b/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_collection/built_collection.dart';

--- a/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.req.gql.dart
+++ b/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.var.gql.dart
+++ b/examples/gql_example_flutter/lib/src/all_pokemon/graphql/__generated__/all_pokemon.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/nested_fragment.ast.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/nested_fragment.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/nested_fragment.data.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/nested_fragment.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/nested_fragment.var.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/nested_fragment.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/pokemon_card_fragment.ast.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/pokemon_card_fragment.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/pokemon_card_fragment.data.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/pokemon_card_fragment.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/pokemon_card_fragment.var.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_card/graphql/__generated__/pokemon_card_fragment.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.ast.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.ast.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:gql/ast.dart' as _i1;

--- a/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.data.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.data.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.req.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.req.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';

--- a/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.var.gql.dart
+++ b/examples/gql_example_flutter/lib/src/pokemon_detail/graphql/__generated__/pokemon_detail.var.gql.dart
@@ -1,4 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:built_value/built_value.dart';


### PR DESCRIPTION
Related issue: https://github.com/gql-dart/ferry/issues/388
https://github.com/dart-lang/linter/issues/320

To avoid lints on generated files we have to exclude generated files from analyzer but it also disables static analysis.
https://github.com/dart-lang/sdk/issues/46957
