### PR TITLE
Add `BaseHttpLinkHeaders` and `BaseHttpLinkResponseContext` to gql_exec

### DIFF
--- a/links/gql_exec/lib/src/http.dart
+++ b/links/gql_exec/lib/src/http.dart
@@ -1,0 +1,36 @@
+import "package:gql_exec/gql_exec.dart";
+import "package:meta/meta.dart";
+
+/// HTTP link headers
+@immutable
+class BaseHttpLinkHeaders extends ContextEntry {
+  /// Headers to be added to the request.
+  ///
+  /// May overrides Apollo Client awareness headers.
+  final Map<String, String> headers;
+
+  const BaseHttpLinkHeaders({
+    this.headers = const {},
+  });
+
+  @override
+  List<Object> get fieldsForEquality => [
+        headers,
+      ];
+}
+
+/// HTTP link Response Context
+@immutable
+class BaseHttpLinkResponseContext extends ContextEntry {
+  /// HTTP status code of the response
+  final int statusCode;
+
+  const BaseHttpLinkResponseContext({
+    required this.statusCode,
+  });
+
+  @override
+  List<Object> get fieldsForEquality => [
+        statusCode,
+      ];
+}


### PR DESCRIPTION
This is a first step towards fixing #361. After this is merged and release, I'll change the contexts in `gql_http_link` and `gql_dio_link` to be subclasses of the classes introduced in this PR. Therefore, it will be a non-breaking change. 

If you have any other ideas on how to introduce this in a non-breaking change, feel free to suggest them.