### PR TITLE
feat/dioSerializableErrors

### DIFF
--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -43,8 +43,16 @@ class DioLink extends Link {
   /// Dio client instance.
   final dio.Dio client;
 
-  /// Wether to use a GET request for queries.
+  /// Whether to use a GET request for queries.
   final bool useGETForQueries;
+
+  /// Whether errors should be serializable.
+  /// Must be set to `true` when the errors should be able to be sent
+  /// across isolate boundaries.
+  /// In particular, setting this to true causes the [FormData] of
+  /// [dio.RequestOptions] of [dio.DioError] to be stripped out from thrown Exceptions, along with
+  /// other potentially non-serializable fields like callbacks or the cancel token.
+  final bool serializableErrors;
 
   DioLink(
     this.endpoint, {
@@ -53,6 +61,7 @@ class DioLink extends Link {
     this.serializer = const RequestSerializer(),
     this.parser = const ResponseParser(),
     this.useGETForQueries = false,
+    this.serializableErrors = false,
   });
 
   @override
@@ -202,37 +211,46 @@ class DioLink extends Link {
       }
       return res.castData<Map<String, dynamic>>();
     } on dio.DioError catch (e, stackTrace) {
-      switch (e.type) {
+      final dio.DioError resolvedError;
+      if (serializableErrors) {
+        print(
+            "DioLink: serializableErrors is true, stripping out non-serializable fields from DioError");
+        resolvedError = _serializableDioError(e);
+      } else {
+        resolvedError = e;
+      }
+
+      switch (resolvedError.type) {
         case dio.DioErrorType.connectTimeout:
         case dio.DioErrorType.receiveTimeout:
         case dio.DioErrorType.sendTimeout:
           throw DioLinkTimeoutException(
-            type: e.type,
-            originalException: e,
+            type: resolvedError.type,
+            originalException: resolvedError,
             originalStackTrace: stackTrace,
           );
         case dio.DioErrorType.cancel:
           throw DioLinkCanceledException(
-            originalException: e,
+            originalException: resolvedError,
             originalStackTrace: stackTrace,
           );
         case dio.DioErrorType.response:
           {
-            final res = e.response!;
+            final res = resolvedError.response!;
             final parsedResponse = (res.data is Map<String, dynamic>)
                 ? parser.parseResponse(res.data as Map<String, dynamic>)
                 : null;
             throw DioLinkServerException(
               response: res,
               parsedResponse: parsedResponse,
-              originalException: e,
+              originalException: resolvedError,
               originalStackTrace: stackTrace,
             );
           }
         case dio.DioErrorType.other:
         default:
           throw DioLinkUnkownException(
-            originalException: e,
+            originalException: resolvedError,
             originalStackTrace: stackTrace,
           );
       }
@@ -244,6 +262,38 @@ class DioLink extends Link {
       );
     }
   }
+
+  dio.DioError _serializableDioError(dio.DioError e) => dio.DioError(
+        type: e.type,
+        error: e.error,
+        response: e.response,
+        requestOptions: dio.RequestOptions(
+          data: e.requestOptions.data is Map<String, dynamic> ||
+                  e.requestOptions is String
+              ? e.requestOptions.data
+              : null, // could be FormData, which is not serializable
+          onSendProgress: null,
+          onReceiveProgress: null,
+          cancelToken: null,
+          responseDecoder: null,
+          requestEncoder: null,
+          validateStatus: null,
+          path: e.requestOptions.path,
+          method: e.requestOptions.method,
+          baseUrl: e.requestOptions.baseUrl,
+          headers: e.requestOptions.headers,
+          queryParameters: e.requestOptions.queryParameters,
+          extra: e.requestOptions.extra,
+          maxRedirects: e.requestOptions.maxRedirects,
+          followRedirects: e.requestOptions.followRedirects,
+          connectTimeout: e.requestOptions.connectTimeout,
+          contentType: e.requestOptions.contentType,
+          receiveTimeout: e.requestOptions.receiveTimeout,
+          receiveDataWhenStatusError:
+              e.requestOptions.receiveDataWhenStatusError,
+          sendTimeout: e.requestOptions.sendTimeout,
+        ),
+      );
 
   Response _parseDioResponse(dio.Response<Map<String, dynamic>> dioResponse) {
     try {

--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -66,8 +66,7 @@ class DioLink extends Link {
 
   @override
   Stream<Response> request(Request request, [forward]) async* {
-    final dio.Response<Map<String, dynamic>> dioResponse =
-        await _executeDioRequest(
+    final dio.Response<Map<String, dynamic>> dioResponse = await _executeDioRequest(
       request: request,
       headers: <String, String>{
         dio.Headers.acceptHeader: "*/*",
@@ -79,8 +78,7 @@ class DioLink extends Link {
     );
 
     if (dioResponse.statusCode! >= 300 ||
-        (dioResponse.data!["data"] == null &&
-            dioResponse.data!["errors"] == null)) {
+        (dioResponse.data!["data"] == null && dioResponse.data!["errors"] == null)) {
       throw DioLinkServerException(
         response: dioResponse,
         parsedResponse: _parseDioResponse(dioResponse),
@@ -111,8 +109,7 @@ class DioLink extends Link {
       request,
       (Map body) => json.encode(
         body,
-        toEncodable: (dynamic object) =>
-            (object is dio.MultipartFile) ? null : object.toJson(),
+        toEncodable: (dynamic object) => (object is dio.MultipartFile) ? null : object.toJson(),
       ),
     )(body);
 
@@ -175,8 +172,7 @@ class DioLink extends Link {
       final dynamic body = _prepareRequestBody(request);
       dio.Response<dynamic> res;
 
-      final useGet =
-          useGETForQueries && body is Map<String, dynamic> && isQuery;
+      final useGet = useGETForQueries && body is Map<String, dynamic> && isQuery;
       if (useGet) {
         res = await client.getUri<dynamic>(
           Uri.parse(endpoint).replace(
@@ -213,8 +209,6 @@ class DioLink extends Link {
     } on dio.DioError catch (e, stackTrace) {
       final dio.DioError resolvedError;
       if (serializableErrors) {
-        print(
-            "DioLink: serializableErrors is true, stripping out non-serializable fields from DioError");
         resolvedError = _serializableDioError(e);
       } else {
         resolvedError = e;
@@ -268,8 +262,7 @@ class DioLink extends Link {
         error: e.error,
         response: e.response,
         requestOptions: dio.RequestOptions(
-          data: e.requestOptions.data is Map<String, dynamic> ||
-                  e.requestOptions is String
+          data: e.requestOptions.data is Map<String, dynamic> || e.requestOptions is String
               ? e.requestOptions.data
               : null, // could be FormData, which is not serializable
           onSendProgress: null,
@@ -289,8 +282,7 @@ class DioLink extends Link {
           connectTimeout: e.requestOptions.connectTimeout,
           contentType: e.requestOptions.contentType,
           receiveTimeout: e.requestOptions.receiveTimeout,
-          receiveDataWhenStatusError:
-              e.requestOptions.receiveDataWhenStatusError,
+          receiveDataWhenStatusError: e.requestOptions.receiveDataWhenStatusError,
           sendTimeout: e.requestOptions.sendTimeout,
         ),
       );


### PR DESCRIPTION
- feat(gql_dio_link): add option to ensure thrown errors are serializable
- remove leftover debug print
