### PR TITLE
stable versions 1.0

### DIFF
--- a/codegen/end_to_end_test/pubspec.yaml
+++ b/codegen/end_to_end_test/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 dependencies: 
   built_collection: ^5.0.0
   built_value: ^8.0.6
-  gql_exec: ^0.4.3
+  gql_exec: ^1.0.0
   gql_build: ^0.7.0
-  gql_code_builder: ^0.7.0
+  gql_code_builder: ^0.7.1
 dev_dependencies: 
   build: ^2.0.0
   build_runner: ^2.0.0

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   code_builder: ^4.3.0
   dart_style: ^2.2.4
   glob: ^2.0.0
-  gql: ^0.14.0
-  gql_code_builder: ^0.7.0
+  gql: ^1.0.0
+  gql_code_builder: ^0.7.1
   path: ^1.8.0
   yaml: ^3.1.0
 dev_dependencies: 

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   built_value: ^8.0.6
   code_builder: ^4.3.0
   collection: ^1.15.0
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
   path: ^1.8.0
 dev_dependencies: 
   build_runner: ^2.1.0

--- a/examples/gql_example_cli/pubspec.yaml
+++ b/examples/gql_example_cli/pubspec.yaml
@@ -3,10 +3,10 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   args: ^2.0.0
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
-  gql_http_link: ^0.4.4+1
-  gql_link: ^0.5.0
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_http_link: ^1.0.0
+  gql_link: ^1.0.0
 dev_dependencies: 
   build_runner: ^2.0.0
   gql_build: ^0.7.0

--- a/examples/gql_example_cli_github/pubspec.yaml
+++ b/examples/gql_example_cli_github/pubspec.yaml
@@ -3,11 +3,11 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   args: ^2.0.0
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
-  gql_http_link: ^0.4.4+1
-  gql_link: ^0.5.0
-  gql_transform_link: ^0.2.2
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_http_link: ^1.0.0
+  gql_link: ^1.0.0
+  gql_transform_link: ^1.0.0
 dev_dependencies: 
   build_runner: ^2.0.0
   gql_build: ^0.7.0

--- a/examples/gql_example_dio_link/pubspec.yaml
+++ b/examples/gql_example_dio_link/pubspec.yaml
@@ -4,7 +4,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies: 
   dio: ^5.0.0
-  gql: ^0.14.0
-  gql_link: ^0.5.0
-  gql_exec: ^0.4.3
-  gql_dio_link: ^0.3.0
+  gql: ^1.0.0
+  gql_link: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_dio_link: ^1.0.0

--- a/examples/gql_example_flutter/pubspec.yaml
+++ b/examples/gql_example_flutter/pubspec.yaml
@@ -3,10 +3,10 @@ version: 1.0.0+1
 environment: 
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
-  gql: ^0.14.0
-  gql_link: ^0.5.0
-  gql_http_link: ^0.4.4+1
-  gql_exec: ^0.4.3
+  gql: ^1.0.0
+  gql_link: ^1.0.0
+  gql_http_link: ^1.0.0
+  gql_exec: ^1.0.0
   cupertino_icons: ^1.0.2
   flutter: 
     sdk: flutter

--- a/examples/gql_example_http_auth_link/pubspec.yaml
+++ b/examples/gql_example_http_auth_link/pubspec.yaml
@@ -2,12 +2,12 @@ name: gql_example_http_auth_link
 environment: 
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
-  gql: ^0.14.0
-  gql_error_link: ^0.2.3
-  gql_exec: ^0.4.3
-  gql_http_link: ^0.4.4+1
-  gql_link: ^0.5.0
-  gql_transform_link: ^0.2.2
+  gql: ^1.0.0
+  gql_error_link: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_http_link: ^1.0.0
+  gql_link: ^1.0.0
+  gql_transform_link: ^1.0.0
   http: ^0.13.1
 dev_dependencies: 
   gql_build: ^0.7.0

--- a/gql/CHANGELOG.md
+++ b/gql/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
+
 ## 0.14.0
 
 - BREAKING: add DirectiveLocation.variableDefinition

--- a/gql/pubspec.yaml
+++ b/gql/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql
-version: 0.14.0
+version: 1.0.0
 description: GraphQL tools for parsing, transforming and printing GraphQL documents.
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_dedupe_link/pubspec.yaml
+++ b/links/gql_dedupe_link/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   async: ^2.5.0
-  gql_exec: ^0.4.3
-  gql_link: ^0.5.0
+  gql_exec: ^1.0.0
+  gql_link: ^1.0.0
   meta: ^1.3.0
 dev_dependencies: 
-  gql: ^0.14.0
+  gql: ^1.0.0
   gql_pedantic: ^1.0.2
   mockito: ^5.0.0-nullsafety.7
   test: ^1.16.2

--- a/links/gql_dio_link/CHANGELOG.md
+++ b/links/gql_dio_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.3.0
 
 * migrate to dio 5.0.0

--- a/links/gql_dio_link/pubspec.yaml
+++ b/links/gql_dio_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_dio_link
-version: 0.3.0
+version: 1.0.0
 description: Similar to gql_http_link, gql_dio_link is a GQL Terminating Link to execute requests via Dio using JSON
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_dio_link/pubspec.yaml
+++ b/links/gql_dio_link/pubspec.yaml
@@ -6,9 +6,9 @@ environment:
   sdk: '>=2.13.0 <3.0.0'
 dependencies: 
   dio: ^5.0.0
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
-  gql_link: ^0.5.1-alpha+1672143833373
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_link: ^1.0.0
   meta: ^1.3.0
 dev_dependencies: 
   build_runner: ^2.0.0

--- a/links/gql_error_link/CHANGELOG.md
+++ b/links/gql_error_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.2.3
 
 - Upgrade `gql_link`

--- a/links/gql_error_link/pubspec.yaml
+++ b/links/gql_error_link/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   async: ^2.5.0
-  gql_exec: ^0.4.3
-  gql_link: ^0.5.0
+  gql_exec: ^1.0.0
+  gql_link: ^1.0.0
   meta: ^1.3.0
 dev_dependencies: 
-  gql: ^0.14.0
+  gql: ^1.0.0
   gql_pedantic: ^1.0.2
   mockito: ^5.0.0-nullsafety.7
   test: ^1.16.2

--- a/links/gql_error_link/pubspec.yaml
+++ b/links/gql_error_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_error_link
-version: 0.2.3+1
+version: 1.0.0
 description: GQL Link to handle execution errors and exceptions
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_exec/CHANGELOG.md
+++ b/links/gql_exec/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.4.3
 
 - add HttpLinkResponseContext, HttpLinkHeaders for consumation by gql_http_link and gql_dio_link and 

--- a/links/gql_exec/pubspec.yaml
+++ b/links/gql_exec/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_exec
-version: 0.4.3
+version: 1.0.0
 description: Basis for GraphQL execution layer to support Link and Client.
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_exec/pubspec.yaml
+++ b/links/gql_exec/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
   collection: ^1.15.0
-  gql: ^0.14.0
+  gql: ^1.0.0
   meta: ^1.3.0
 dev_dependencies: 
   gql_pedantic: ^1.0.2

--- a/links/gql_http_link/CHANGELOG.md
+++ b/links/gql_http_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.4.6
 
 - add statusCode to HttpLinkServerException

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_http_link
-version: 0.4.5
+version: 1.0.0
 description: GQL Terminating Link to execute requests via HTTP using JSON.
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_http_link/pubspec.yaml
+++ b/links/gql_http_link/pubspec.yaml
@@ -5,9 +5,9 @@ repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.13.0 <3.0.0'
 dependencies: 
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
-  gql_link: ^0.5.1-alpha+1672143833373
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_link: ^1.0.0
   http: ^0.13.0
   http_parser: ^4.0.0
   meta: ^1.3.0

--- a/links/gql_link/CHANGELOG.md
+++ b/links/gql_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.5.1
 
 - add optional statusCode to ServerException 

--- a/links/gql_link/pubspec.yaml
+++ b/links/gql_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_link
-version: 0.5.1
+version: 1.0.0
 description: A simple and modular AST-based GraphQL request execution interface.
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_link/pubspec.yaml
+++ b/links/gql_link/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
   meta: ^1.1.7
 dev_dependencies: 
   gql_pedantic: ^1.0.2

--- a/links/gql_transform_link/CHANGELOG.md
+++ b/links/gql_transform_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.2.3
 
 - Upgrade `gql_link`

--- a/links/gql_transform_link/pubspec.yaml
+++ b/links/gql_transform_link/pubspec.yaml
@@ -5,10 +5,10 @@ repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
-  gql_exec: ^0.4.3
-  gql_link: ^0.5.0
+  gql_exec: ^1.0.0
+  gql_link: ^1.0.0
 dev_dependencies: 
-  gql: ^0.14.0
+  gql: ^1.0.0
   gql_pedantic: ^1.0.2
   mockito: ^5.0.0-nullsafety.7
   test: ^1.16.2

--- a/links/gql_transform_link/pubspec.yaml
+++ b/links/gql_transform_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_transform_link
-version: 0.2.2+1
+version: 1.0.0
 description: GQL Link to transform Requests and Responses. May be used to update context, document, variables, data, errors, etc.
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_websocket_link/CHANGELOG.md
+++ b/links/gql_websocket_link/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- Mark the package as stable with a `1.0.0` release.
+
 ## 0.3.4
 
 - add stackTrace to exceptions

--- a/links/gql_websocket_link/pubspec.yaml
+++ b/links/gql_websocket_link/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_websocket_link
-version: 0.3.4+1
+version: 1.0.0
 description: GQL Websocket Link
 repository: https://github.com/gql-dart/gql
 environment: 

--- a/links/gql_websocket_link/pubspec.yaml
+++ b/links/gql_websocket_link/pubspec.yaml
@@ -5,9 +5,9 @@ repository: https://github.com/gql-dart/gql
 environment: 
   sdk: '>=2.12.0 <3.0.0'
 dependencies: 
-  gql: ^0.14.0
-  gql_exec: ^0.4.3
-  gql_link: ^0.5.0
+  gql: ^1.0.0
+  gql_exec: ^1.0.0
+  gql_link: ^1.0.0
   meta: ^1.3.0
   rxdart: '>=0.26.0 <0.28.0'
   uuid: ^3.0.1


### PR DESCRIPTION
I would like to bump the version of the core packages of gql to 1.0.0.

I am aware that this might be an inconvenience for packages depending on gql packages because the jump to 1.0.0 is treated as a breaking change by pub.

However, they have been on 0.x version for a long time now, breaking changes are rare and I have been accused of using 
https://0ver.org/ based versioning ;)

@agent3bood @budde377 @vincenzopalazzo FYI