### PR TITLE
[gql_code_builder] optimize slow code generation to reduce build time as 10% of previous.

### DIFF
--- a/codegen/gql_build/lib/gql_build.dart
+++ b/codegen/gql_build/lib/gql_build.dart
@@ -19,12 +19,14 @@ Builder dataBuilder(
   BuilderOptions options,
 ) =>
     DataBuilder(
-        AssetId.parse(
-          options.config["schema"] as String,
-        ),
-        (options.config["add_typenames"] ?? true) as bool,
-        typeOverrideMap(options.config["type_overrides"]),
-        whenExtensionConfig: whenExtensionConfig(options.config));
+      AssetId.parse(
+        options.config["schema"] as String,
+      ),
+      (options.config["add_typenames"] ?? true) as bool,
+      typeOverrideMap(options.config["type_overrides"]),
+      whenExtensionConfig: whenExtensionConfig(options.config),
+      dataClassConfig: dataClassConfig(options.config),
+    );
 
 /// Builds GraphQL type-safe request builder
 Builder reqBuilder(

--- a/codegen/gql_build/lib/src/data_builder.dart
+++ b/codegen/gql_build/lib/src/data_builder.dart
@@ -14,6 +14,7 @@ class DataBuilder implements Builder {
   final bool addTypenames;
   final Map<String, Reference> typeOverrides;
   final InlineFragmentSpreadWhenExtensionConfig whenExtensionConfig;
+  final DataClassConfig dataClassConfig;
 
   DataBuilder(
     this.schemaId,
@@ -22,6 +23,9 @@ class DataBuilder implements Builder {
     this.whenExtensionConfig = const InlineFragmentSpreadWhenExtensionConfig(
       generateWhenExtensionMethod: false,
       generateMaybeWhenExtensionMethod: false,
+    ),
+    this.dataClassConfig = const DataClassConfig(
+      reuseFragments: false,
     ),
   });
 
@@ -41,11 +45,13 @@ class DataBuilder implements Builder {
         .path;
 
     final library = buildDataLibrary(
-        addTypenames ? introspection.addTypenames(doc) : doc,
-        introspection.addTypenames(schema),
-        basename(generatedPartUrl),
-        typeOverrides,
-        whenExtensionConfig);
+      addTypenames ? introspection.addTypenames(doc) : doc,
+      introspection.addTypenames(schema),
+      basename(generatedPartUrl),
+      typeOverrides,
+      whenExtensionConfig,
+      dataClassConfig,
+    );
 
     return writeDocument(
       library,

--- a/codegen/gql_build/lib/src/utils/config.dart
+++ b/codegen/gql_build/lib/src/utils/config.dart
@@ -42,6 +42,10 @@ EnumFallbackConfig enumFallbackConfig(Map<String, dynamic> config) =>
       fallbackValueMap: enumFallbackMap(config["enum_fallbacks"]),
     );
 
+DataClassConfig dataClassConfig(Map<String, dynamic> config) => DataClassConfig(
+      reuseFragments: config["reuse_fragments"] == true,
+    );
+
 InlineFragmentSpreadWhenExtensionConfig whenExtensionConfig(
     Map<String, dynamic> config) {
   final whenYamlConfig = config["when_extensions"] as YamlMap?;

--- a/codegen/gql_code_builder/lib/data.dart
+++ b/codegen/gql_code_builder/lib/data.dart
@@ -181,7 +181,7 @@ void _dataClassAliasMapDFS({
               "${typeRefPrefix}__as${node.typeCondition!.on.name.value}",
           getAliasTypeName: getAliasTypeName,
           selections: [
-            ...selections.where((s) => !(s is InlineFragmentNode)),
+            ...selections.where((s) => s != node),
             ...node.selectionSet.selections,
           ],
           fragmentMap: fragmentMap,

--- a/codegen/gql_code_builder/lib/data.dart
+++ b/codegen/gql_code_builder/lib/data.dart
@@ -1,6 +1,7 @@
 import "package:built_collection/built_collection.dart";
 import "package:code_builder/code_builder.dart";
 import "package:gql/ast.dart";
+import "package:gql_code_builder/src/common.dart";
 import "package:gql_code_builder/src/config/when_extension_config.dart";
 
 import "./source.dart";
@@ -19,6 +20,9 @@ Library buildDataLibrary(
     generateMaybeWhenExtensionMethod: false,
   ),
 ]) {
+  final fragmentMap = _fragmentMap(docSource);
+  final dataClassAliasMap = _dataClassAliasMap(docSource, fragmentMap);
+
   final operationDataClasses = docSource.document.definitions
       .whereType<OperationDefinitionNode>()
       .expand(
@@ -28,6 +32,8 @@ Library buildDataLibrary(
           schemaSource,
           typeOverrides,
           whenExtensionConfig,
+          fragmentMap,
+          dataClassAliasMap,
         ),
       )
       .toList();
@@ -41,6 +47,8 @@ Library buildDataLibrary(
           schemaSource,
           typeOverrides,
           whenExtensionConfig,
+          fragmentMap,
+          dataClassAliasMap,
         ),
       )
       .toList();
@@ -53,4 +61,128 @@ Library buildDataLibrary(
         ...fragmentDataClasses,
       ]),
   );
+}
+
+
+Map<String, SourceSelections> _fragmentMap(SourceNode source) => {
+  for (var def
+  in source.document.definitions.whereType<FragmentDefinitionNode>())
+    def.name.value: SourceSelections(
+      url: source.url,
+      selections: def.selectionSet.selections,
+    ),
+  for (var import in source.imports) ..._fragmentMap(import)
+};
+
+Map<String, Reference> _dataClassAliasMap(SourceNode source, Map<String, SourceSelections> fragmentMap, [Map<String, Reference>? aliasMap, Set<String>? visitedSource]) {
+  aliasMap ??= {};
+  visitedSource ??= {};
+
+  source.imports.forEach((s) {
+    if (!visitedSource!.contains(source.url)) {
+      visitedSource.add(source.url);
+      _dataClassAliasMap(s, fragmentMap, aliasMap);
+    }
+  });
+
+  for (final def in source.document.definitions.whereType<OperationDefinitionNode>()) {
+    _dataClassAliasMapDFS(
+      typeRefPrefix: builtClassName("${def.name!.value}Data"),
+      getAliasTypeName: (fragmentName) => "${builtClassName(fragmentName)}Data",
+      selections: def.selectionSet.selections,
+      fragmentMap: fragmentMap,
+      aliasMap: aliasMap,
+    );
+  }
+
+  for (final def in source.document.definitions.whereType<FragmentDefinitionNode>()) {
+    _dataClassAliasMapDFS(
+      typeRefPrefix: builtClassName(def.name.value),
+      getAliasTypeName: builtClassName,
+      selections: def.selectionSet.selections,
+      fragmentMap: fragmentMap,
+      aliasMap: aliasMap,
+    );
+    _dataClassAliasMapDFS(
+      typeRefPrefix: builtClassName("${def.name.value}Data"),
+      getAliasTypeName: (fragmentName) => "${builtClassName(fragmentName)}Data",
+      selections: def.selectionSet.selections,
+      fragmentMap: fragmentMap,
+      aliasMap: aliasMap,
+    );
+  }
+
+  return aliasMap;
+}
+
+void _dataClassAliasMapDFS({
+  required String typeRefPrefix,
+  required String Function(String fragmentName) getAliasTypeName,
+  required List<SelectionNode> selections,
+  required Map<String, SourceSelections> fragmentMap,
+  required Map<String, Reference> aliasMap,
+}) {
+  if (selections.isEmpty) return;
+
+  // flatten selections to extract untouched fragments while visiting children.
+  final shrunkenSelections = shrinkSelections(mergeSelections(selections, fragmentMap), fragmentMap);
+
+  // alias single fragment and finish
+  final selectionsWithoutTypename = shrunkenSelections.where((s) => !(s is FieldNode && s.name.value == "__typename"));
+  if (selectionsWithoutTypename.length == 1 && selectionsWithoutTypename.first is FragmentSpreadNode) {
+    final node = selectionsWithoutTypename.first as FragmentSpreadNode;
+    final fragment = fragmentMap[node.name.value];
+    final fragmentTypeName = getAliasTypeName(node.name.value);
+    aliasMap[typeRefPrefix] = refer(fragmentTypeName, "${fragment!.url ?? ""}#data");
+    // print("alias $typeRefPrefix => $fragmentTypeName");
+    return;
+  }
+
+  for (final node in selectionsWithoutTypename) {
+    if (node is FragmentSpreadNode) {
+      // exclude redefined selections from each fragment selections
+      final fragmentSelections = fragmentMap[node.name.value]!.selections;
+      final exclusiveFragmentSelections = mergeSelections(fragmentSelections, fragmentMap).where((s1) {
+        if (s1 is FieldNode) {
+          final name = (s1.alias ?? s1.name).value;
+          return selectionsWithoutTypename.whereType<FieldNode>().every((s2) => name != (s2.alias ?? s2.name).value);
+        } else if (s1 is InlineFragmentNode && s1.typeCondition != null) {
+          /// TODO: Handle inline fragments without a type condition
+          final name = s1.typeCondition!.on.name.value;
+          return selectionsWithoutTypename.whereType<InlineFragmentNode>().every((s2) => name != s2.typeCondition?.on.name.value);
+        }
+        return false;
+      }).toList();
+
+      _dataClassAliasMapDFS(
+        typeRefPrefix: typeRefPrefix,
+        getAliasTypeName: getAliasTypeName,
+        selections: exclusiveFragmentSelections,
+        fragmentMap: fragmentMap,
+        aliasMap: aliasMap,
+      );
+    } else if (node is InlineFragmentNode) {
+      if (node.typeCondition != null) {
+        /// TODO: Handle inline fragments without a type condition
+        _dataClassAliasMapDFS(
+          typeRefPrefix: "${typeRefPrefix}__as${node.typeCondition!.on.name.value}",
+          getAliasTypeName: getAliasTypeName,
+          selections: [
+            ...selections.where((s) => !(s is InlineFragmentNode)),
+            ...node.selectionSet.selections,
+          ],
+          fragmentMap: fragmentMap,
+          aliasMap: aliasMap,
+        );
+      }
+    } else if (node is FieldNode && node.selectionSet != null) {
+      _dataClassAliasMapDFS(
+        typeRefPrefix: "${typeRefPrefix}_${(node.alias ?? node.name).value}",
+        getAliasTypeName: getAliasTypeName,
+        selections: node.selectionSet!.selections,
+        fragmentMap: fragmentMap,
+        aliasMap: aliasMap,
+      );
+    }
+  }
 }

--- a/codegen/gql_code_builder/lib/data.dart
+++ b/codegen/gql_code_builder/lib/data.dart
@@ -2,11 +2,13 @@ import "package:built_collection/built_collection.dart";
 import "package:code_builder/code_builder.dart";
 import "package:gql/ast.dart";
 import "package:gql_code_builder/src/common.dart";
+import "package:gql_code_builder/src/config/data_class_config.dart";
 import "package:gql_code_builder/src/config/when_extension_config.dart";
 
 import "./source.dart";
 import "./src/operation/data.dart";
 
+export "package:gql_code_builder/src/config/data_class_config.dart";
 export "package:gql_code_builder/src/config/when_extension_config.dart";
 
 Library buildDataLibrary(
@@ -19,9 +21,14 @@ Library buildDataLibrary(
     generateWhenExtensionMethod: false,
     generateMaybeWhenExtensionMethod: false,
   ),
+  DataClassConfig dataClassConfig = const DataClassConfig(
+    reuseFragments: false,
+  ),
 ]) {
   final fragmentMap = _fragmentMap(docSource);
-  final dataClassAliasMap = _dataClassAliasMap(docSource, fragmentMap);
+  final dataClassAliasMap = dataClassConfig.reuseFragments
+      ? _dataClassAliasMap(docSource, fragmentMap)
+      : <String, Reference>{};
 
   final operationDataClasses = docSource.document.definitions
       .whereType<OperationDefinitionNode>()

--- a/codegen/gql_code_builder/lib/data.dart
+++ b/codegen/gql_code_builder/lib/data.dart
@@ -63,18 +63,19 @@ Library buildDataLibrary(
   );
 }
 
-
 Map<String, SourceSelections> _fragmentMap(SourceNode source) => {
-  for (var def
-  in source.document.definitions.whereType<FragmentDefinitionNode>())
-    def.name.value: SourceSelections(
-      url: source.url,
-      selections: def.selectionSet.selections,
-    ),
-  for (var import in source.imports) ..._fragmentMap(import)
-};
+      for (var def
+          in source.document.definitions.whereType<FragmentDefinitionNode>())
+        def.name.value: SourceSelections(
+          url: source.url,
+          selections: def.selectionSet.selections,
+        ),
+      for (var import in source.imports) ..._fragmentMap(import)
+    };
 
-Map<String, Reference> _dataClassAliasMap(SourceNode source, Map<String, SourceSelections> fragmentMap, [Map<String, Reference>? aliasMap, Set<String>? visitedSource]) {
+Map<String, Reference> _dataClassAliasMap(
+    SourceNode source, Map<String, SourceSelections> fragmentMap,
+    [Map<String, Reference>? aliasMap, Set<String>? visitedSource]) {
   aliasMap ??= {};
   visitedSource ??= {};
 
@@ -85,7 +86,8 @@ Map<String, Reference> _dataClassAliasMap(SourceNode source, Map<String, SourceS
     }
   });
 
-  for (final def in source.document.definitions.whereType<OperationDefinitionNode>()) {
+  for (final def
+      in source.document.definitions.whereType<OperationDefinitionNode>()) {
     _dataClassAliasMapDFS(
       typeRefPrefix: builtClassName("${def.name!.value}Data"),
       getAliasTypeName: (fragmentName) => "${builtClassName(fragmentName)}Data",
@@ -95,7 +97,8 @@ Map<String, Reference> _dataClassAliasMap(SourceNode source, Map<String, SourceS
     );
   }
 
-  for (final def in source.document.definitions.whereType<FragmentDefinitionNode>()) {
+  for (final def
+      in source.document.definitions.whereType<FragmentDefinitionNode>()) {
     _dataClassAliasMapDFS(
       typeRefPrefix: builtClassName(def.name.value),
       getAliasTypeName: builtClassName,
@@ -125,15 +128,19 @@ void _dataClassAliasMapDFS({
   if (selections.isEmpty) return;
 
   // flatten selections to extract untouched fragments while visiting children.
-  final shrunkenSelections = shrinkSelections(mergeSelections(selections, fragmentMap), fragmentMap);
+  final shrunkenSelections =
+      shrinkSelections(mergeSelections(selections, fragmentMap), fragmentMap);
 
   // alias single fragment and finish
-  final selectionsWithoutTypename = shrunkenSelections.where((s) => !(s is FieldNode && s.name.value == "__typename"));
-  if (selectionsWithoutTypename.length == 1 && selectionsWithoutTypename.first is FragmentSpreadNode) {
+  final selectionsWithoutTypename = shrunkenSelections
+      .where((s) => !(s is FieldNode && s.name.value == "__typename"));
+  if (selectionsWithoutTypename.length == 1 &&
+      selectionsWithoutTypename.first is FragmentSpreadNode) {
     final node = selectionsWithoutTypename.first as FragmentSpreadNode;
     final fragment = fragmentMap[node.name.value];
     final fragmentTypeName = getAliasTypeName(node.name.value);
-    aliasMap[typeRefPrefix] = refer(fragmentTypeName, "${fragment!.url ?? ""}#data");
+    aliasMap[typeRefPrefix] =
+        refer(fragmentTypeName, "${fragment!.url ?? ""}#data");
     // print("alias $typeRefPrefix => $fragmentTypeName");
     return;
   }
@@ -142,14 +149,19 @@ void _dataClassAliasMapDFS({
     if (node is FragmentSpreadNode) {
       // exclude redefined selections from each fragment selections
       final fragmentSelections = fragmentMap[node.name.value]!.selections;
-      final exclusiveFragmentSelections = mergeSelections(fragmentSelections, fragmentMap).where((s1) {
+      final exclusiveFragmentSelections =
+          mergeSelections(fragmentSelections, fragmentMap).where((s1) {
         if (s1 is FieldNode) {
           final name = (s1.alias ?? s1.name).value;
-          return selectionsWithoutTypename.whereType<FieldNode>().every((s2) => name != (s2.alias ?? s2.name).value);
+          return selectionsWithoutTypename
+              .whereType<FieldNode>()
+              .every((s2) => name != (s2.alias ?? s2.name).value);
         } else if (s1 is InlineFragmentNode && s1.typeCondition != null) {
           /// TODO: Handle inline fragments without a type condition
           final name = s1.typeCondition!.on.name.value;
-          return selectionsWithoutTypename.whereType<InlineFragmentNode>().every((s2) => name != s2.typeCondition?.on.name.value);
+          return selectionsWithoutTypename
+              .whereType<InlineFragmentNode>()
+              .every((s2) => name != s2.typeCondition?.on.name.value);
         }
         return false;
       }).toList();
@@ -165,7 +177,8 @@ void _dataClassAliasMapDFS({
       if (node.typeCondition != null) {
         /// TODO: Handle inline fragments without a type condition
         _dataClassAliasMapDFS(
-          typeRefPrefix: "${typeRefPrefix}__as${node.typeCondition!.on.name.value}",
+          typeRefPrefix:
+              "${typeRefPrefix}__as${node.typeCondition!.on.name.value}",
           getAliasTypeName: getAliasTypeName,
           selections: [
             ...selections.where((s) => !(s is InlineFragmentNode)),

--- a/codegen/gql_code_builder/lib/src/built_class.dart
+++ b/codegen/gql_code_builder/lib/src/built_class.dart
@@ -11,6 +11,7 @@ Class builtClass({
   Map<String, Expression>? initializers,
   Map<String, SourceSelections> superclassSelections = const {},
   List<Method> methods = const [],
+  Map<String, Reference>? dataClassAliasMap,
 }) {
   final className = builtClassName(name);
   return Class(
@@ -30,7 +31,9 @@ Class builtClass({
                 ],
               ),
           ),
-          ...superclassSelections.keys.map<Reference>(
+          ...superclassSelections.keys
+              .where((superName) => dataClassAliasMap?.containsKey(builtClassName(superName)) != true)
+              .map<Reference>(
             (superName) => refer(
               builtClassName(superName),
               (superclassSelections[superName]?.url ?? "") + "#data",

--- a/codegen/gql_code_builder/lib/src/built_class.dart
+++ b/codegen/gql_code_builder/lib/src/built_class.dart
@@ -32,13 +32,15 @@ Class builtClass({
               ),
           ),
           ...superclassSelections.keys
-              .where((superName) => dataClassAliasMap?.containsKey(builtClassName(superName)) != true)
+              .where((superName) =>
+                  dataClassAliasMap?.containsKey(builtClassName(superName)) !=
+                  true)
               .map<Reference>(
-            (superName) => refer(
-              builtClassName(superName),
-              (superclassSelections[superName]?.url ?? "") + "#data",
-            ),
-          )
+                (superName) => refer(
+                  builtClassName(superName),
+                  (superclassSelections[superName]?.url ?? "") + "#data",
+                ),
+              )
         ],
       )
       ..constructors.addAll(

--- a/codegen/gql_code_builder/lib/src/common.dart
+++ b/codegen/gql_code_builder/lib/src/common.dart
@@ -138,6 +138,7 @@ Method buildGetter({
   required TypeNode typeNode,
   required SourceNode schemaSource,
   Map<String, Reference> typeOverrides = const {},
+  Reference? typeRefAlias,
   String? typeRefPrefix,
   bool built = true,
   bool isOverride = false,
@@ -151,7 +152,9 @@ Method buildGetter({
 
   final typeMap = {
     ...defaultTypeMap,
-    if (typeRefPrefix != null)
+    if (typeRefAlias != null)
+      typeName: typeRefAlias
+    else if (typeRefPrefix != null)
       typeName: refer("${typeRefPrefix}_${nameNode.value}")
     else if (typeDef != null)
       typeName: refer(

--- a/codegen/gql_code_builder/lib/src/config/data_class_config.dart
+++ b/codegen/gql_code_builder/lib/src/config/data_class_config.dart
@@ -1,0 +1,8 @@
+/// config for the optimization of data class generation.
+class DataClassConfig {
+  final bool reuseFragments;
+
+  const DataClassConfig({
+    required this.reuseFragments,
+  });
+}

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -22,6 +22,7 @@ List<Spec> buildInlineFragmentClasses({
   required String type,
   required Map<String, Reference> typeOverrides,
   required Map<String, SourceSelections> fragmentMap,
+  required Map<String, Reference> dataClassAliasMap,
   required Map<String, SourceSelections> superclassSelections,
   required List<InlineFragmentNode> inlineFragments,
   required bool built,
@@ -31,6 +32,7 @@ List<Spec> buildInlineFragmentClasses({
     baseTypeName: name,
     inlineFragments: inlineFragments,
     config: whenExtensionConfig,
+    dataClassAliasMap: dataClassAliasMap,
   );
   return [
     Class(
@@ -38,12 +40,14 @@ List<Spec> buildInlineFragmentClasses({
         ..abstract = true
         ..name = builtClassName(name)
         ..implements.addAll(
-          superclassSelections.keys.map<Reference>(
-            (superName) => refer(
-              builtClassName(superName),
-              (superclassSelections[superName]?.url ?? "") + "#data",
+          superclassSelections.keys
+            .where((superName) => !dataClassAliasMap.containsKey(builtClassName(superName)))
+            .map<Reference>(
+              (superName) => refer(
+                builtClassName(superName),
+                (superclassSelections[superName]?.url ?? "") + "#data",
+              ),
             ),
-          ),
         )
         ..methods.addAll([
           ...fieldGetters,
@@ -51,6 +55,7 @@ List<Spec> buildInlineFragmentClasses({
             ..._inlineFragmentRootSerializationMethods(
               name: builtClassName(name),
               inlineFragments: inlineFragments,
+              dataClassAliasMap: dataClassAliasMap,
             ),
         ]),
     ),
@@ -65,6 +70,7 @@ List<Spec> buildInlineFragmentClasses({
         fragmentMap,
       ),
       fragmentMap: fragmentMap,
+      dataClassAliasMap: dataClassAliasMap,
       schemaSource: schemaSource,
       type: type,
       typeOverrides: typeOverrides,
@@ -77,7 +83,17 @@ List<Spec> buildInlineFragmentClasses({
 
     /// TODO: Handle inline fragments without a type condition
     /// https://spec.graphql.org/June2018/#sec-Inline-Fragments
-    ...inlineFragments.where((frag) => frag.typeCondition != null).expand(
+    ...inlineFragments.where((frag) {
+      if (frag.typeCondition == null) {
+        return false;
+      }
+      final typeName = builtClassName("${name}__as${frag.typeCondition!.on.name.value}");
+      if (dataClassAliasMap.containsKey(typeName)) {
+        // print("alias $typeName => ${dataClassAliasMap[typeName]!.symbol}");
+        return false;
+      }
+      return true;
+    }).expand(
           (inlineFragment) => buildSelectionSetDataClasses(
               name: "${name}__as${inlineFragment.typeCondition!.on.name.value}",
               selections: mergeSelections(
@@ -89,6 +105,7 @@ List<Spec> buildInlineFragmentClasses({
                 fragmentMap,
               ),
               fragmentMap: fragmentMap,
+              dataClassAliasMap: dataClassAliasMap,
               schemaSource: schemaSource,
               type: inlineFragment.typeCondition!.on.name.value,
               typeOverrides: typeOverrides,
@@ -104,6 +121,7 @@ List<Spec> buildInlineFragmentClasses({
 List<Method> _inlineFragmentRootSerializationMethods({
   required String name,
   required List<InlineFragmentNode> inlineFragments,
+  required Map<String, Reference> dataClassAliasMap,
 }) =>
     [
       buildSerializerGetter(name).rebuild(
@@ -121,7 +139,7 @@ List<Method> _inlineFragmentRootSerializationMethods({
               {
                 for (var v in inlineFragments
                     .where((frag) => frag.typeCondition != null))
-                  "${v.typeCondition!.on.name.value}": refer(
+                  "${v.typeCondition!.on.name.value}": dataClassAliasMap["${name}__as${v.typeCondition!.on.name.value}"] ?? refer(
                     "${name}__as${v.typeCondition!.on.name.value}",
                   )
               },

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -41,13 +41,14 @@ List<Spec> buildInlineFragmentClasses({
         ..name = builtClassName(name)
         ..implements.addAll(
           superclassSelections.keys
-            .where((superName) => !dataClassAliasMap.containsKey(builtClassName(superName)))
-            .map<Reference>(
-              (superName) => refer(
-                builtClassName(superName),
-                (superclassSelections[superName]?.url ?? "") + "#data",
+              .where((superName) =>
+                  !dataClassAliasMap.containsKey(builtClassName(superName)))
+              .map<Reference>(
+                (superName) => refer(
+                  builtClassName(superName),
+                  (superclassSelections[superName]?.url ?? "") + "#data",
+                ),
               ),
-            ),
         )
         ..methods.addAll([
           ...fieldGetters,
@@ -87,34 +88,35 @@ List<Spec> buildInlineFragmentClasses({
       if (frag.typeCondition == null) {
         return false;
       }
-      final typeName = builtClassName("${name}__as${frag.typeCondition!.on.name.value}");
+      final typeName =
+          builtClassName("${name}__as${frag.typeCondition!.on.name.value}");
       if (dataClassAliasMap.containsKey(typeName)) {
         // print("alias $typeName => ${dataClassAliasMap[typeName]!.symbol}");
         return false;
       }
       return true;
     }).expand(
-          (inlineFragment) => buildSelectionSetDataClasses(
-              name: "${name}__as${inlineFragment.typeCondition!.on.name.value}",
-              selections: mergeSelections(
-                [
-                  ...selections.whereType<FieldNode>(),
-                  ...selections.whereType<FragmentSpreadNode>(),
-                  ...inlineFragment.selectionSet.selections,
-                ],
-                fragmentMap,
-              ),
-              fragmentMap: fragmentMap,
-              dataClassAliasMap: dataClassAliasMap,
-              schemaSource: schemaSource,
-              type: inlineFragment.typeCondition!.on.name.value,
-              typeOverrides: typeOverrides,
-              superclassSelections: {
-                name: SourceSelections(url: null, selections: selections)
-              },
-              built: built,
-              whenExtensionConfig: whenExtensionConfig),
-        ),
+      (inlineFragment) => buildSelectionSetDataClasses(
+          name: "${name}__as${inlineFragment.typeCondition!.on.name.value}",
+          selections: mergeSelections(
+            [
+              ...selections.whereType<FieldNode>(),
+              ...selections.whereType<FragmentSpreadNode>(),
+              ...inlineFragment.selectionSet.selections,
+            ],
+            fragmentMap,
+          ),
+          fragmentMap: fragmentMap,
+          dataClassAliasMap: dataClassAliasMap,
+          schemaSource: schemaSource,
+          type: inlineFragment.typeCondition!.on.name.value,
+          typeOverrides: typeOverrides,
+          superclassSelections: {
+            name: SourceSelections(url: null, selections: selections)
+          },
+          built: built,
+          whenExtensionConfig: whenExtensionConfig),
+    ),
   ];
 }
 
@@ -139,9 +141,11 @@ List<Method> _inlineFragmentRootSerializationMethods({
               {
                 for (var v in inlineFragments
                     .where((frag) => frag.typeCondition != null))
-                  "${v.typeCondition!.on.name.value}": dataClassAliasMap["${name}__as${v.typeCondition!.on.name.value}"] ?? refer(
-                    "${name}__as${v.typeCondition!.on.name.value}",
-                  )
+                  "${v.typeCondition!.on.name.value}": dataClassAliasMap[
+                          "${name}__as${v.typeCondition!.on.name.value}"] ??
+                      refer(
+                        "${name}__as${v.typeCondition!.on.name.value}",
+                      )
               },
             ),
           ]).code,

--- a/codegen/gql_code_builder/lib/src/operation/data.dart
+++ b/codegen/gql_code_builder/lib/src/operation/data.dart
@@ -159,7 +159,8 @@ List<Spec> buildSelectionSetDataClasses({
         typeNode: typeNode,
         schemaSource: schemaSource,
         typeOverrides: typeOverrides,
-        typeRefAlias: dataClassAliasMap[builtClassName("${name}_${nameNode.value}")],
+        typeRefAlias:
+            dataClassAliasMap[builtClassName("${name}_${nameNode.value}")],
         typeRefPrefix: node.selectionSet != null ? builtClassName(name) : null,
         built: built,
         isOverride: superclassSelectionNodes.contains(node),
@@ -192,13 +193,14 @@ List<Spec> buildSelectionSetDataClasses({
           ..name = builtClassName(name)
           ..implements.addAll(
             superclassSelections.keys
-                .where((superName) => !dataClassAliasMap.containsKey(builtClassName(superName)))
+                .where((superName) =>
+                    !dataClassAliasMap.containsKey(builtClassName(superName)))
                 .map<Reference>(
-              (superName) => refer(
-                builtClassName(superName),
-                (superclassSelections[superName]?.url ?? "") + "#data",
-              ),
-            ),
+                  (superName) => refer(
+                    builtClassName(superName),
+                    (superclassSelections[superName]?.url ?? "") + "#data",
+                  ),
+                ),
           )
           ..methods.addAll([
             ...fieldGetters,
@@ -224,8 +226,10 @@ List<Spec> buildSelectionSetDataClasses({
     ...selections
         .whereType<FieldNode>()
         .where(
-          (field) => field.selectionSet != null
-              && !dataClassAliasMap.containsKey(builtClassName("${name}_${field.alias?.value ?? field.name.value}")),
+          (field) =>
+              field.selectionSet != null &&
+              !dataClassAliasMap.containsKey(builtClassName(
+                  "${name}_${field.alias?.value ?? field.name.value}")),
         )
         .expand(
           (field) => buildSelectionSetDataClasses(
@@ -257,9 +261,9 @@ List<Spec> buildSelectionSetDataClasses({
 
 /// Shrink merged fields nodes based on FragmentMap
 List<SelectionNode> shrinkSelections(
-    List<SelectionNode> selections,
-    Map<String, SourceSelections> fragmentMap,
-    )  {
+  List<SelectionNode> selections,
+  Map<String, SourceSelections> fragmentMap,
+) {
   final unmerged = [...selections];
 
   for (final selection in selections) {
@@ -269,17 +273,20 @@ List<SelectionNode> shrinkSelections(
         name: selection.name,
         alias: selection.alias,
         selectionSet: SelectionSetNode(
-          selections: shrinkSelections(selection.selectionSet!.selections, fragmentMap),
+          selections:
+              shrinkSelections(selection.selectionSet!.selections, fragmentMap),
         ),
       );
-    } else if (selection is InlineFragmentNode && selection.typeCondition != null) {
+    } else if (selection is InlineFragmentNode &&
+        selection.typeCondition != null) {
       /// TODO: Handle inline fragments without a type condition
       final index = unmerged.indexOf(selection);
       unmerged[index] = InlineFragmentNode(
         typeCondition: selection.typeCondition,
         directives: selection.directives,
         selectionSet: SelectionSetNode(
-          selections: shrinkSelections(selection.selectionSet.selections, fragmentMap),
+          selections:
+              shrinkSelections(selection.selectionSet.selections, fragmentMap),
         ),
       );
     }
@@ -290,7 +297,8 @@ List<SelectionNode> shrinkSelections(
     final spreadIndex = unmerged.indexOf(node);
     final duplicateIndexList = <int>[];
     unmerged.forEachIndexed((selectionIndex, selection) {
-      if (selectionIndex > spreadIndex && fragment.selections.any((s) => s.hashCode == selection.hashCode)) {
+      if (selectionIndex > spreadIndex &&
+          fragment.selections.any((s) => s.hashCode == selection.hashCode)) {
         duplicateIndexList.add(selectionIndex);
       }
     });
@@ -316,7 +324,7 @@ List<SelectionNode> mergeSelections(
               } else {
                 final existingNode = selectionMap[key];
                 final existingSelections = existingNode is FieldNode &&
-                    existingNode.selectionSet != null
+                        existingNode.selectionSet != null
                     ? existingNode.selectionSet!.selections
                     : <SelectionNode>[];
                 selectionMap[key] = FieldNode(
@@ -324,14 +332,15 @@ List<SelectionNode> mergeSelections(
                     alias: selection.alias,
                     selectionSet: SelectionSetNode(
                         selections: mergeSelections(
-                          [
-                            ...existingSelections,
-                            ...selection.selectionSet!.selections
-                          ],
-                          fragmentMap,
-                        )));
+                      [
+                        ...existingSelections,
+                        ...selection.selectionSet!.selections
+                      ],
+                      fragmentMap,
+                    )));
               }
-            } else if (selection is InlineFragmentNode && selection.typeCondition != null) {
+            } else if (selection is InlineFragmentNode &&
+                selection.typeCondition != null) {
               /// TODO: Handle inline fragments without a type condition
               final key = selection.typeCondition!.on.name.value;
               if (selectionMap.containsKey(key)) {
@@ -341,7 +350,9 @@ List<SelectionNode> mergeSelections(
                   selectionSet: SelectionSetNode(
                     selections: mergeSelections(
                       [
-                        ...(selectionMap[key] as InlineFragmentNode).selectionSet.selections,
+                        ...(selectionMap[key] as InlineFragmentNode)
+                            .selectionSet
+                            .selections,
                         ...selection.selectionSet.selections,
                       ],
                       fragmentMap,

--- a/codegen/gql_code_builder/lib/src/when_extension.dart
+++ b/codegen/gql_code_builder/lib/src/when_extension.dart
@@ -56,7 +56,8 @@ Extension? inlineFragmentWhenExtension(
   /// returns the name of the concrete built class for the inlineFragment
   /// so we can refer to it in the generated code
   String getGeneratedTypeName(InlineFragmentNode node) {
-    final typeName = builtClassName("${baseTypeName}__as${node.typeCondition!.on.name.value}");
+    final typeName = builtClassName(
+        "${baseTypeName}__as${node.typeCondition!.on.name.value}");
     return dataClassAliasMap[typeName]?.symbol ?? typeName;
   }
 

--- a/codegen/gql_code_builder/lib/src/when_extension.dart
+++ b/codegen/gql_code_builder/lib/src/when_extension.dart
@@ -39,7 +39,8 @@ Code _caseStatement(InlineFragmentNode inlineFragment) =>
 Extension? inlineFragmentWhenExtension(
     {required String baseTypeName,
     required List<InlineFragmentNode> inlineFragments,
-    required InlineFragmentSpreadWhenExtensionConfig config}) {
+    required InlineFragmentSpreadWhenExtensionConfig config,
+    required Map<String, Reference> dataClassAliasMap}) {
   final inlineFragmentsWithTypConditions = inlineFragments
       .where((inlineFragment) => inlineFragment.typeCondition != null)
       .toList();
@@ -54,8 +55,10 @@ Extension? inlineFragmentWhenExtension(
 
   /// returns the name of the concrete built class for the inlineFragment
   /// so we can refer to it in the generated code
-  String getGeneratedTypeName(InlineFragmentNode node) =>
-      builtClassName("${baseTypeName}__as${node.typeCondition!.on.name.value}");
+  String getGeneratedTypeName(InlineFragmentNode node) {
+    final typeName = builtClassName("${baseTypeName}__as${node.typeCondition!.on.name.value}");
+    return dataClassAliasMap[typeName]?.symbol ?? typeName;
+  }
 
   /// a pool of parameter names which have already been used
   /// so we can avoid name clashes


### PR DESCRIPTION
## Background

Hi Team and especially @knaeckeKami,

There is an old issue in this library. Which is gql-dart/ferry#143, first reported at Jan, 2021.
I made this PR to address this issue again and share the working draft of a possible solution.

There can be many aspects making build slower, but here I focused on how `gql_code_builder` generates data models.
A code generation for GraphQL type class and built value class gets extremely slower as schema and query gets larger.

The main reasons for that I found:
- With **recursively nesting fragments**, the number of models generated grows exponentially.
- Even for a **single FragmentSpreadNode selection** that is identical to a fragment model already created, a builder will generate the same code just with a different name.

## Example
```graphql
query TestQuery {
    currentUser {
        ...UserFragment
    }

    currentUser2: currentUser {
        ...UserFragment
        location {
            lat
            lng
        }
        moderation {
            ratingPlaceholder
        }
    }
}

fragment UserFragment on User {
   # ...OMITTED
   location {
      ...LocationFragment
   }
   moderation {
      ...ModerationFragment
   }
}

# ...OMITTED
```

Assume we have above query and fragments (though it seems strange).

- Here we can replace `GUserFragmentData_location` to `GLocationFragmentData`. Also for moderation field too.
- And, we know that we can reuse `GUserFragmentData` for `GTestQueryData_currentUser`.
- Furthermore, if `UserFragment` already includes both `location {lat, lng}` and `moderation {ratingPlaceholder}`, here `GUserFragmentData` can be used for  `GTestQueryData_currentUser2` too.

Because of this graph-way nature of GraphQL, we can reuse a lot of our model code. However, the current code generator does not reflect this reuse logic, and so recursively nested Fragments are generating a huge amount of similar code.

## Changes
I created this draft solution that performs the optimizations for **reusable fragment models** mentioned in the example above, including **InlineFragmentNode and WhenExtension support** too. So it covers all models generated from current builder.

I said it is a draft because if a builder with this patch generates code against an existing schema, it will not generate many of the models that were previously generated, and it will also change the type signatures of the reusable getters in many of the former models. This could be a breaking change for users, so for now, I look forward to discussing this approach further.

And there has been made **no regression tests** for this patch yet.
But I am using this patched builder with my own product and found no issues for now.

<details>
<summary>See, there were breaking changes as mentioned above, so I had to fix few type signatures and model names.</summary>

FYI: Below are full errors after using this patched build.
Be note that this app is on production with enough number of features.

```
lib/app/components/user.dart:199:48: Error: Type
'GUserFragment_viewerMatch' not found.
extension GUserViewerMatchFragmentExtension on GUserFragment_viewerMatch {
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/profile.female.dart:84:14: Error: Type
'GViewerSearchQueryData_searchUsers_matched' not found.
  final List<GViewerSearchQueryData_searchUsers_matched> users;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/components/moderation.dart:16:25: Error: Method not found:
'GUserFragmentData_moderation'.
  static final _guest = GUserFragmentData_moderation((b) {
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/account.blocked_contacts.dart:4:9: Error:
'GViewerUserBlockedContactsQueryData_currentUserBlockedContacts_items'
isn't a type.
        GViewerUserBlockedContactsQueryData_currentUserBlockedContacts_item
        s>(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        ^
lib/app/pages/sign_up.profile.dart:29:26: Error: The method
'GUserFragmentData_locationBuilder' isn't defined for the class
'SignUpProfilePage'.
 - 'SignUpProfilePage' is from 'package:app/app/pages/sign_up.dart'
 ('lib/app/pages/sign_up.dart').
Try correcting the name to the name of an existing method, or defining a
method named 'GUserFragmentData_locationBuilder'.
            b.location = GUserFragmentData_locationBuilder()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/sign_up.profile.dart:37:28: Error: The method
'GUserFragmentData_moderationBuilder' isn't defined for the class
'SignUpProfilePage'.
 - 'SignUpProfilePage' is from 'package:app/app/pages/sign_up.dart'
 ('lib/app/pages/sign_up.dart').
Try correcting the name to the name of an existing method, or defining a
method named 'GUserFragmentData_moderationBuilder'.
            b.moderation = GUserFragmentData_moderationBuilder()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/sign_up.profile.dart:43:25: Error: The method
'GUserFragmentData_profileBuilder' isn't defined for the class
'SignUpProfilePage'.
 - 'SignUpProfilePage' is from 'package:app/app/pages/sign_up.dart'
 ('lib/app/pages/sign_up.dart').
Try correcting the name to the name of an existing method, or defining a
method named 'GUserFragmentData_profileBuilder'.
            b.profile = GUserFragmentData_profileBuilder()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/sign_up.profile.dart:51:29: Error: The method
'GUserFragmentData_viewerMatchBuilder' isn't defined for the class
'SignUpProfilePage'.
 - 'SignUpProfilePage' is from 'package:app/app/pages/sign_up.dart'
 ('lib/app/pages/sign_up.dart').
Try correcting the name to the name of an existing method, or defining a
method named 'GUserFragmentData_viewerMatchBuilder'.
            b.viewerMatch = GUserFragmentData_viewerMatchBuilder()
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/profile.female.dart:84:14: Error:
'GViewerSearchQueryData_searchUsers_matched' isn't a type.
  final List<GViewerSearchQueryData_searchUsers_matched> users;
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/community.view.dart:250:22: Error: The getter
'GCommunityReplyDetailFragmentData_replies_nodes' isn't defined for the
class '_Body'.
 - '_Body' is from 'package:app/app/pages/community.view.dart'
 ('lib/app/pages/community.view.dart').
Try correcting the name to the name of an existing getter, or defining a
getter or field named 'GCommunityReplyDetailFragmentData_replies_nodes'.
              return
              GCommunityReplyDetailFragmentData_replies_nodes.fromJson(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/community.feed.edit.dart:80:20: Error:
'GCommunityFeedQueryData_node__asCommunityFeed' isn't a type.
                as GCommunityFeedQueryData_node__asCommunityFeed?) ??
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/app/pages/account.notification.dart:126:9: Error: The getter
'GUpdateNotificationSubscriptionData_updateNotificationSubscription' isn't
defined for the class 'AccountNotificationSettingsPage'.
 - 'AccountNotificationSettingsPage' is from
 'package:app/app/pages/account.notification.dart'
 ('lib/app/pages/account.notification.dart').
Try correcting the name to the name of an existing getter, or defining a
getter or field named
'GUpdateNotificationSubscriptionData_updateNotificationSubscription'.
        GUpdateNotificationSubscriptionData_updateNotificationSubscription
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
</details>

## Comparison
Here's a quick summary of the results with my own product:

- Reduced to about 10% of the previous in build time.
- Reduced to about 11% of the previous in amount of generated "data" codes.

Compared only with `*.data.g.dart` and `*.data.dart` files, which this patch is effectively applied to.

I think the result will fairly vary on the structure of scheme and query complexity.
For me, I have 7-depth nested fragment at most. And used fragments pretty much in anywhere.


<details>
<summary>*My product has about 2k lines of `*.graphql` codes.</summary>

```
scheme $ wc -l *
      51 query.admin.graphql
     258 query.community.graphql
     565 query.graphql
      67 scalar.dart
      11 schema.dart
    1095 schema.graphql
    2047 total
```

</details>

---

#### BEFORE

<details>
<summary>
It took about 20 minutes for a build, and generated about 552k lines of "data" dart codes .
The total number of characters in the generated codes is 22M.
</summary>

```
generated $ find . -type f -name "*data*" | xargs wc
   11845   26827  433099 ./query.admin.data.gql.g.dart
  348729  733625 14425654 ./query.community.data.gql.g.dart
  112482  243263 4116248 ./query.data.gql.g.dart
    1810    3517   58030 ./query.admin.data.gql.dart
   18976   35173  657436 ./query.data.gql.dart
   58155   99920 2418975 ./query.community.data.gql.dart
  551997 1142325 22109442 total
```

</details>

#### AFTER

<details>
<summary>
A builder with this patch, It took about 2 minutes for a build, and generated about 68k lines of "data" dart codes .
The total number of characters in the generated codes is 2.4M.
</summary>

```
generated $ find . -type f -name "*data*" | xargs wc -l
    6154   13718  220560 ./query.admin.data.gql.g.dart
   21882   47403  804926 ./query.community.data.gql.g.dart
   30665   69059 1085963 ./query.data.gql.g.dart
     981    1939   32695 ./query.admin.data.gql.dart
    4776    9733  156508 ./query.data.gql.dart
    3555    6833  123426 ./query.community.data.gql.dart
   68013  148685 2424078 total
```
</details>


#### Diff
Also please refer below broken tests as an example of effective changes.
- [Check gql_example_cli](https://github.com/gql-dart/gql/actions/runs/5811166406/job/15762038452?pr=413#logs)
- [Check end_to_end_test](https://github.com/gql-dart/gql/actions/runs/5811166406/job/15762035731?pr=413#logs)

### Note
Thank you for reviewing it.
And I am looking forward to any thoughts about this approach.