### PR TITLE
[gql_code_builder ] bugfix for reuse-fragments feature

### DIFF
--- a/codegen/gql_code_builder/lib/data.dart
+++ b/codegen/gql_code_builder/lib/data.dart
@@ -27,7 +27,7 @@ Library buildDataLibrary(
   ),
 ]) {
   final fragmentMap = _fragmentMap(docSource);
-  final possibleTypesMap = _possibleTypesMap(schemaSource);
+  final possibleTypesMap = dataClassConfig.reuseFragments ? _possibleTypesMap(schemaSource) : <String, Set<String>>{};
   final dataClassAliasMap = dataClassConfig.reuseFragments
       ? _dataClassAliasMap(docSource, fragmentMap, possibleTypesMap)
       : <String, Reference>{};
@@ -75,13 +75,13 @@ Library buildDataLibrary(
 }
 
 Map<String, SourceSelections> _fragmentMap(SourceNode source) => {
-      for (var def
+      for (final def
           in source.document.definitions.whereType<FragmentDefinitionNode>())
         def.name.value: SourceSelections(
           url: source.url,
           selections: def.selectionSet.selections,
         ),
-      for (var import in source.imports) ..._fragmentMap(import)
+      for (final import in source.imports) ..._fragmentMap(import)
     };
 
 Map<String, Set<String>> _possibleTypesMap(SourceNode source,

--- a/codegen/gql_code_builder/lib/data.dart
+++ b/codegen/gql_code_builder/lib/data.dart
@@ -27,7 +27,9 @@ Library buildDataLibrary(
   ),
 ]) {
   final fragmentMap = _fragmentMap(docSource);
-  final possibleTypesMap = dataClassConfig.reuseFragments ? _possibleTypesMap(schemaSource) : <String, Set<String>>{};
+  final possibleTypesMap = dataClassConfig.reuseFragments
+      ? _possibleTypesMap(schemaSource)
+      : <String, Set<String>>{};
   final dataClassAliasMap = dataClassConfig.reuseFragments
       ? _dataClassAliasMap(docSource, fragmentMap, possibleTypesMap)
       : <String, Reference>{};

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -101,26 +101,30 @@ List<Spec> buildInlineFragmentClasses({
       return true;
     }).expand(
       (inlineFragment) => buildSelectionSetDataClasses(
-          name: "${name}__as${inlineFragment.typeCondition!.on.name.value}",
-          selections: mergeSelections(
-            [
-              ...selections.whereType<FieldNode>(),
-              ...selections.whereType<FragmentSpreadNode>(),
-              ...inlineFragment.selectionSet.selections,
-            ],
-            fragmentMap,
-          ),
-          fragmentMap: fragmentMap,
-          possibleTypesMap: possibleTypesMap,
-          dataClassAliasMap: dataClassAliasMap,
-          schemaSource: schemaSource,
-          type: inlineFragment.typeCondition!.on.name.value,
-          typeOverrides: typeOverrides,
-          superclassSelections: {
-            name: SourceSelections(url: null, selections: selections)
-          },
-          built: built,
-          whenExtensionConfig: whenExtensionConfig),
+        name: "${name}__as${inlineFragment.typeCondition!.on.name.value}",
+        selections: mergeSelections(
+          [
+            ...selections.whereType<FieldNode>(),
+            ...selections.whereType<FragmentSpreadNode>(),
+            ...inlineFragment.selectionSet.selections,
+          ],
+          fragmentMap,
+        ),
+        fragmentMap: fragmentMap,
+        possibleTypesMap: possibleTypesMap,
+        dataClassAliasMap: dataClassAliasMap,
+        schemaSource: schemaSource,
+        type: inlineFragment.typeCondition!.on.name.value,
+        typeOverrides: typeOverrides,
+        superclassSelections: {
+          name: SourceSelections(url: null, selections: selections),
+          ...Map.fromEntries(superclassSelections.entries.map((e) => MapEntry(
+              "${e.key}__as${inlineFragment.typeCondition!.on.name.value}",
+              e.value))),
+        },
+        built: built,
+        whenExtensionConfig: whenExtensionConfig,
+      ),
     ),
   ];
 }

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -22,6 +22,7 @@ List<Spec> buildInlineFragmentClasses({
   required String type,
   required Map<String, Reference> typeOverrides,
   required Map<String, SourceSelections> fragmentMap,
+  required Map<String, Set<String>> possibleTypesMap,
   required Map<String, Reference> dataClassAliasMap,
   required Map<String, SourceSelections> superclassSelections,
   required List<InlineFragmentNode> inlineFragments,
@@ -32,6 +33,7 @@ List<Spec> buildInlineFragmentClasses({
     baseTypeName: name,
     inlineFragments: inlineFragments,
     config: whenExtensionConfig,
+    possibleTypesMap: possibleTypesMap,
     dataClassAliasMap: dataClassAliasMap,
   );
   return [
@@ -71,6 +73,7 @@ List<Spec> buildInlineFragmentClasses({
         fragmentMap,
       ),
       fragmentMap: fragmentMap,
+      possibleTypesMap: possibleTypesMap,
       dataClassAliasMap: dataClassAliasMap,
       schemaSource: schemaSource,
       type: type,
@@ -94,6 +97,7 @@ List<Spec> buildInlineFragmentClasses({
         // print("alias $typeName => ${dataClassAliasMap[typeName]!.symbol}");
         return false;
       }
+      // is it okay to inlcude interfaces?
       return true;
     }).expand(
       (inlineFragment) => buildSelectionSetDataClasses(
@@ -107,6 +111,7 @@ List<Spec> buildInlineFragmentClasses({
             fragmentMap,
           ),
           fragmentMap: fragmentMap,
+          possibleTypesMap: possibleTypesMap,
           dataClassAliasMap: dataClassAliasMap,
           schemaSource: schemaSource,
           type: inlineFragment.typeCondition!.on.name.value,

--- a/codegen/gql_code_builder/lib/src/operation/data.dart
+++ b/codegen/gql_code_builder/lib/src/operation/data.dart
@@ -302,6 +302,9 @@ List<SelectionNode> shrinkSelections(
 
   final duplicateIndices = <int>{};
   for (final node in unmerged.whereType<FragmentSpreadNode>().toList()) {
+    if (!fragmentMap.containsKey(node.name.value)) {
+      throw "Cannot find a fragment ${node.name.value} from current file.";
+    }
     final fragment = fragmentMap[node.name.value]!;
     final fragmentSpreadIndex = unmerged.indexOf(node);
     unmerged.forEachIndexed((selectionIndex, selection) {

--- a/codegen/gql_code_builder/lib/src/operation/data.dart
+++ b/codegen/gql_code_builder/lib/src/operation/data.dart
@@ -15,6 +15,7 @@ List<Spec> buildOperationDataClasses(
   Map<String, Reference> typeOverrides,
   InlineFragmentSpreadWhenExtensionConfig whenExtensionConfig,
   Map<String, SourceSelections> fragmentMap,
+  Map<String, Set<String>> possibleTypesMap,
   Map<String, Reference> dataClassAliasMap,
 ) {
   if (op.name == null) {
@@ -34,6 +35,7 @@ List<Spec> buildOperationDataClasses(
     ),
     typeOverrides: typeOverrides,
     fragmentMap: fragmentMap,
+    possibleTypesMap: possibleTypesMap,
     dataClassAliasMap: dataClassAliasMap,
     superclassSelections: {},
     whenExtensionConfig: whenExtensionConfig,
@@ -47,6 +49,7 @@ List<Spec> buildFragmentDataClasses(
   Map<String, Reference> typeOverrides,
   InlineFragmentSpreadWhenExtensionConfig whenExtensionConfig,
   Map<String, SourceSelections> fragmentMap,
+  Map<String, Set<String>> possibleTypesMap,
   Map<String, Reference> dataClassAliasMap,
 ) {
   final selections = mergeSelections(
@@ -62,6 +65,7 @@ List<Spec> buildFragmentDataClasses(
       type: frag.typeCondition.on.name.value,
       typeOverrides: typeOverrides,
       fragmentMap: fragmentMap,
+      possibleTypesMap: possibleTypesMap,
       dataClassAliasMap: dataClassAliasMap,
       superclassSelections: {},
       built: false,
@@ -75,6 +79,7 @@ List<Spec> buildFragmentDataClasses(
       type: frag.typeCondition.on.name.value,
       typeOverrides: typeOverrides,
       fragmentMap: fragmentMap,
+      possibleTypesMap: possibleTypesMap,
       dataClassAliasMap: dataClassAliasMap,
       superclassSelections: {
         frag.name.value: SourceSelections(
@@ -120,6 +125,7 @@ List<Spec> buildSelectionSetDataClasses({
   required String type,
   required Map<String, Reference> typeOverrides,
   required Map<String, SourceSelections> fragmentMap,
+  required Map<String, Set<String>> possibleTypesMap,
   required Map<String, Reference> dataClassAliasMap,
   required Map<String, SourceSelections> superclassSelections,
   bool built = true,
@@ -180,6 +186,7 @@ List<Spec> buildSelectionSetDataClasses({
         type: type,
         typeOverrides: typeOverrides,
         fragmentMap: fragmentMap,
+        possibleTypesMap: possibleTypesMap,
         dataClassAliasMap: dataClassAliasMap,
         superclassSelections: superclassSelections,
         inlineFragments: inlineFragments,
@@ -236,6 +243,7 @@ List<Spec> buildSelectionSetDataClasses({
             name: "${name}_${field.alias?.value ?? field.name.value}",
             selections: field.selectionSet!.selections,
             fragmentMap: fragmentMap,
+            possibleTypesMap: possibleTypesMap,
             dataClassAliasMap: dataClassAliasMap,
             schemaSource: schemaSource,
             type: unwrapTypeNode(
@@ -292,20 +300,25 @@ List<SelectionNode> shrinkSelections(
     }
   }
 
+  final duplicateIndices = <int>{};
   for (final node in unmerged.whereType<FragmentSpreadNode>().toList()) {
     final fragment = fragmentMap[node.name.value]!;
-    final spreadIndex = unmerged.indexOf(node);
-    final duplicateIndexList = <int>[];
+    final fragmentSpreadIndex = unmerged.indexOf(node);
     unmerged.forEachIndexed((selectionIndex, selection) {
-      if (selectionIndex > spreadIndex &&
+      if (selectionIndex != fragmentSpreadIndex &&
+          !(selection is FieldNode && selection.name.value == "__typename") &&
           fragment.selections.any((s) => s.hashCode == selection.hashCode)) {
-        duplicateIndexList.add(selectionIndex);
+        duplicateIndices.add(selectionIndex);
       }
     });
-    duplicateIndexList.reversed.forEach(unmerged.removeAt);
   }
 
-  return unmerged;
+  return unmerged
+      .asMap()
+      .entries
+      .where((e) => !duplicateIndices.contains(e.key))
+      .map((e) => e.value)
+      .toList();
 }
 
 /// Deeply merges field nodes

--- a/codegen/gql_code_builder/lib/src/when_extension.dart
+++ b/codegen/gql_code_builder/lib/src/when_extension.dart
@@ -40,9 +40,15 @@ Extension? inlineFragmentWhenExtension(
     {required String baseTypeName,
     required List<InlineFragmentNode> inlineFragments,
     required InlineFragmentSpreadWhenExtensionConfig config,
+    required Map<String, Set<String>> possibleTypesMap,
     required Map<String, Reference> dataClassAliasMap}) {
   final inlineFragmentsWithTypConditions = inlineFragments
-      .where((inlineFragment) => inlineFragment.typeCondition != null)
+      .where((inlineFragment) =>
+          inlineFragment.typeCondition != null
+          // except interfaces on when extension
+          &&
+          !possibleTypesMap
+              .containsKey(inlineFragment.typeCondition!.on.name.value))
       .toList();
 
   final nothingToDo = inlineFragmentsWithTypConditions.isEmpty ||
@@ -187,8 +193,7 @@ Extension? inlineFragmentWhenExtension(
               [
                 _switchTypeName,
                 _curlyBracketOpen,
-                ...inlineFragments
-                    .where((element) => element.typeCondition != null)
+                ...inlineFragmentsWithTypConditions
                     .map((inlineFragment) => Block.of([
                           _caseStatement(inlineFragment),
                           maybeWhenCaseBody(inlineFragment),


### PR DESCRIPTION
This PR is a succession of https://github.com/gql-dart/gql/pull/413
After the above PR, our team have developed our ongoing project with dev release version which includes above PR.
And we found a improvement point and a bug to make the reuse-fragment feature stable.
So here made a PR to finalize this feature.

## Changes
- Fix inline fragments data class serialization runtime error with reuse-fragments option enabled.
- Fix WhenExtension to not to create redundant mappers for interfaces which doesn't make sense because interfaces don't have __typename. (But for the backward compatibility, this change is only applied when reuseFragment option is enabled.)