### PR TITLE
[gql_example_http_auth_link] add request queuing while refreshing token

### DIFF
--- a/examples/gql_example_http_auth_link/lib/http_auth_link.dart
+++ b/examples/gql_example_http_auth_link/lib/http_auth_link.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:gql_error_link/gql_error_link.dart";
 import "package:gql_exec/gql_exec.dart";
 import "package:gql_http_link/gql_http_link.dart";
@@ -8,6 +10,9 @@ class HttpAuthLink extends Link {
   late Link _link;
   String? _token;
 
+  bool _isRefreshing = false;
+  final List<Completer> _tokenRefreshQueue = [];
+
   HttpAuthLink() {
     _link = Link.concat(
       ErrorLink(onException: handleException),
@@ -16,10 +21,25 @@ class HttpAuthLink extends Link {
   }
 
   Future<void> updateToken() async {
-    _token = await Future.delayed(
-      Duration(milliseconds: 10),
-      () => "Valid token",
-    );
+    if (!_isRefreshing) {
+      _isRefreshing = true;
+
+      _token = await Future.delayed(
+        Duration(milliseconds: 10),
+        () => "Valid token",
+      );
+
+      _isRefreshing = false;
+      _tokenRefreshQueue.forEach((completer) {
+        completer.complete(_token!);
+      });
+      _tokenRefreshQueue.clear();
+    } else {
+      // If token refresh is already in progress, queue the request
+      final completer = Completer<String>();
+      _tokenRefreshQueue.add(completer);
+      _token = await completer.future;
+    }
   }
 
   Stream<Response> handleException(


### PR DESCRIPTION
This PR will queue incoming requests during the token refresh process. The token refresh queue ensures that only one token refresh occurs at a time, preventing multiple concurrent refreshes.