### PR TITLE
feat(dedupe_link): Add shouldDedupe option

### DIFF
--- a/links/gql_dedupe_link/lib/gql_dedupe_link.dart
+++ b/links/gql_dedupe_link/lib/gql_dedupe_link.dart
@@ -2,28 +2,37 @@
 library gql_dedupe_link;
 
 import "package:async/async.dart";
+import "package:gql/ast.dart";
 import "package:gql_exec/gql_exec.dart";
 import "package:gql_link/gql_link.dart";
 
 /// A [Link] to deduplicate [Request]s
 class DedupeLink extends Link {
+  final List<OperationType> _nonDedupeTypes;
   final Map<Request, StreamSplitter<Response>> _inFlight = {};
+
+  DedupeLink({List<OperationType> nonDedupeTypes = const []})
+      : _nonDedupeTypes = nonDedupeTypes;
 
   @override
   Stream<Response> request(
     Request request, [
     NextLink? forward,
   ]) {
-    if (_inFlight.containsKey(request)) {
+    final shouldDedupe = !_nonDedupeTypes.contains(
+      request.operation.getOperationType(),
+    );
+
+    if (shouldDedupe && _inFlight.containsKey(request)) {
       return _inFlight[request]!.split();
     }
 
     final splitter = StreamSplitter(forward!(request));
 
-    _inFlight[request] = splitter;
+    if (shouldDedupe) _inFlight[request] = splitter;
 
     final closeSplitter = () {
-      _inFlight.remove(request);
+      if (shouldDedupe) _inFlight.remove(request);
 
       splitter.close();
     };

--- a/links/gql_dedupe_link/lib/gql_dedupe_link.dart
+++ b/links/gql_dedupe_link/lib/gql_dedupe_link.dart
@@ -8,18 +8,18 @@ import "package:gql_link/gql_link.dart";
 
 /// A [Link] to deduplicate [Request]s
 class DedupeLink extends Link {
-  final List<OperationType> _nonDedupeTypes;
+  final List<OperationType> _nonDedupeOperationTypes;
   final Map<Request, StreamSplitter<Response>> _inFlight = {};
 
-  DedupeLink({List<OperationType> nonDedupeTypes = const []})
-      : _nonDedupeTypes = nonDedupeTypes;
+  DedupeLink({List<OperationType> nonDedupeOperationTypes = const []})
+      : _nonDedupeOperationTypes = nonDedupeOperationTypes;
 
   @override
   Stream<Response> request(
     Request request, [
     NextLink? forward,
   ]) {
-    final shouldDedupe = !_nonDedupeTypes.contains(
+    final shouldDedupe = !_nonDedupeOperationTypes.contains(
       request.operation.getOperationType(),
     );
 

--- a/links/gql_dedupe_link/lib/gql_dedupe_link.dart
+++ b/links/gql_dedupe_link/lib/gql_dedupe_link.dart
@@ -7,21 +7,21 @@ import "package:gql_link/gql_link.dart";
 
 /// A [Link] to deduplicate [Request]s
 class DedupeLink extends Link {
-  final bool Function(Request request) _shouldPreventDedupe;
+  final bool Function(Request request) _shouldDedupe;
   final Map<Request, StreamSplitter<Response>> _inFlight = {};
 
-  static bool _defaultPreventDedupe(Request request) => false;
+  static bool _defaultShouldDedupe(Request request) => true;
 
   DedupeLink({
-    bool Function(Request request) shouldPreventDedupe = _defaultPreventDedupe,
-  }) : _shouldPreventDedupe = shouldPreventDedupe;
+    bool Function(Request request) shouldDedupe = _defaultShouldDedupe,
+  }) : _shouldDedupe = shouldDedupe;
 
   @override
   Stream<Response> request(
     Request request, [
     NextLink? forward,
   ]) {
-    final shouldDedupe = !_shouldPreventDedupe(request);
+    final shouldDedupe = _shouldDedupe(request);
 
     if (shouldDedupe && _inFlight.containsKey(request)) {
       return _inFlight[request]!.split();

--- a/links/gql_dedupe_link/pubspec.yaml
+++ b/links/gql_dedupe_link/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.12.0 <4.0.0'
 dependencies: 
   async: ^2.5.0
+  gql: ^1.0.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   meta: ^1.3.0
 dev_dependencies: 
-  gql: ^1.0.0
   gql_pedantic: ^1.0.2
   mockito: ^5.0.0-nullsafety.7
   test: ^1.16.2

--- a/links/gql_dedupe_link/pubspec.yaml
+++ b/links/gql_dedupe_link/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.12.0 <4.0.0'
 dependencies: 
   async: ^2.5.0
-  gql: ^1.0.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   meta: ^1.3.0
 dev_dependencies: 
+  gql: ^1.0.0
   gql_pedantic: ^1.0.2
   mockito: ^5.0.0-nullsafety.7
   test: ^1.16.2

--- a/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
+++ b/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
@@ -185,7 +185,8 @@ void main() {
       expect(await return2, result1);
     });
 
-    test("does not dedupe identical queries if of type in nonDedupeTypes",
+    test(
+        "does not dedupe identical queries if shouldPreventDedupe is true for request",
         () async {
       var count = 0;
       final document = parseString(
@@ -220,7 +221,10 @@ void main() {
       });
 
       final link = Link.from([
-        DedupeLink(nonDedupeOperationTypes: [OperationType.query]),
+        DedupeLink(
+          shouldPreventDedupe: (req) =>
+              req.operation.getOperationType() == OperationType.query,
+        ),
         mockLink,
       ]);
 

--- a/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
+++ b/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
@@ -220,7 +220,7 @@ void main() {
       });
 
       final link = Link.from([
-        DedupeLink(nonDedupeTypes: [OperationType.query]),
+        DedupeLink(nonDedupeOperationTypes: [OperationType.query]),
         mockLink,
       ]);
 

--- a/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
+++ b/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
@@ -186,7 +186,7 @@ void main() {
     });
 
     test(
-        "does not dedupe identical queries if shouldPreventDedupe is true for request",
+        "does not dedupe identical queries if shouldDedupe is false for request",
         () async {
       var count = 0;
       final document = parseString(
@@ -222,8 +222,8 @@ void main() {
 
       final link = Link.from([
         DedupeLink(
-          shouldPreventDedupe: (req) =>
-              req.operation.getOperationType() == OperationType.query,
+          shouldDedupe: (req) =>
+              req.operation.getOperationType() != OperationType.query,
         ),
         mockLink,
       ]);

--- a/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
+++ b/links/gql_dedupe_link/test/gql_dedupe_link_test.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:gql/ast.dart";
 import "package:gql/language.dart";
 import "package:gql_dedupe_link/gql_dedupe_link.dart";
 import "package:gql_exec/gql_exec.dart";
@@ -182,6 +183,72 @@ void main() {
       );
       expect(await return1, result1);
       expect(await return2, result1);
+    });
+
+    test("does not dedupe identical queries if of type in nonDedupeTypes",
+        () async {
+      var count = 0;
+      final document = parseString(
+        """
+        query withVar(\$i: Int) {
+          take(i: \$i)
+        }
+      """,
+      );
+
+      final req1 = Request(
+        operation: Operation(
+          document: document,
+        ),
+        variables: const <String, dynamic>{"i": 12},
+      );
+
+      final mockLink = MockLink();
+
+      when(
+        mockLink.request(req1, null),
+      ).thenAnswer((_) {
+        count++;
+        return Stream.fromIterable([
+          Response(
+            data: <String, dynamic>{"a": count},
+            response: <String, dynamic>{
+              "data": <String, dynamic>{"a": count}
+            },
+          )
+        ]);
+      });
+
+      final link = Link.from([
+        DedupeLink(nonDedupeTypes: [OperationType.query]),
+        mockLink,
+      ]);
+
+      final stream1 = link.request(req1);
+      final stream2 = link.request(req1);
+
+      final return1 = stream1.first;
+      final return2 = stream2.first;
+
+      verify(
+        mockLink.request(req1, null),
+      ).called(2);
+      expect(
+          await return1,
+          Response(
+            data: const <String, dynamic>{"a": 1},
+            response: const <String, dynamic>{
+              "data": <String, dynamic>{"a": 1}
+            },
+          ));
+      expect(
+          await return2,
+          Response(
+            data: const <String, dynamic>{"a": 2},
+            response: const <String, dynamic>{
+              "data": <String, dynamic>{"a": 2}
+            },
+          ));
     });
 
     test("does not dedup consequtive queries", () async {


### PR DESCRIPTION
Dedupe link is an all or nothing solution at the moment, but in use it is likely you would want to dedupe queries, but not mutations, or possibly filter deduplication in some other granular way. This modification allows for devs to consider the incoming request and prevent deduplication if desired.