### PR TITLE
chore(vars-builder-bugfix): Fixing nullables and type overrides for vars create factories

### DIFF
--- a/codegen/end_to_end_test/lib/fragments/__generated__/fragment_with_scalar_var.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/fragment_with_scalar_var.var.gql.dart
@@ -20,7 +20,7 @@ abstract class GPostsWithFixedVariableVars
           [void Function(GPostsWithFixedVariableVarsBuilder b) updates]) =
       _$GPostsWithFixedVariableVars;
 
-  factory GPostsWithFixedVariableVars.create({required _i1.GJson? filter}) =>
+  factory GPostsWithFixedVariableVars.create({_i1.GJson? filter}) =>
       GPostsWithFixedVariableVars((b) => b..filter = filter?.toBuilder());
 
   _i1.GJson? get filter;

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_fragments.var.gql.dart
@@ -17,7 +17,7 @@ abstract class GHeroWithFragmentsVars
           [void Function(GHeroWithFragmentsVarsBuilder b) updates]) =
       _$GHeroWithFragmentsVars;
 
-  factory GHeroWithFragmentsVars.create({required int? first}) =>
+  factory GHeroWithFragmentsVars.create({int? first}) =>
       GHeroWithFragmentsVars((b) => b..first = first);
 
   int? get first;
@@ -67,7 +67,7 @@ abstract class GcomparisonFieldsVars
           [void Function(GcomparisonFieldsVarsBuilder b) updates]) =
       _$GcomparisonFieldsVars;
 
-  factory GcomparisonFieldsVars.create({required int? first}) =>
+  factory GcomparisonFieldsVars.create({int? first}) =>
       GcomparisonFieldsVars((b) => b..first = first);
 
   int? get first;

--- a/codegen/end_to_end_test/lib/fragments/__generated__/multiple_fragments.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/multiple_fragments.var.gql.dart
@@ -17,7 +17,7 @@ abstract class GHeroWith2FragmentsVars
           [void Function(GHeroWith2FragmentsVarsBuilder b) updates]) =
       _$GHeroWith2FragmentsVars;
 
-  factory GHeroWith2FragmentsVars.create({required int? first}) =>
+  factory GHeroWith2FragmentsVars.create({int? first}) =>
       GHeroWith2FragmentsVars((b) => b..first = first);
 
   int? get first;

--- a/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.var.gql.dart
+++ b/codegen/end_to_end_test/lib/scalars/__generated__/review_with_date.var.gql.dart
@@ -20,9 +20,9 @@ abstract class GReviewWithDateVars
       _$GReviewWithDateVars;
 
   factory GReviewWithDateVars.create({
-    required _i1.GEpisode? episode,
+    _i1.GEpisode? episode,
     required _i1.GReviewInput review,
-    required DateTime? createdAt,
+    DateTime? createdAt,
   }) =>
       GReviewWithDateVars((b) => b
         ..episode = episode

--- a/codegen/end_to_end_test/lib/variables/__generated__/create_review.var.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/create_review.var.gql.dart
@@ -20,7 +20,7 @@ abstract class GCreateReviewVars
       _$GCreateReviewVars;
 
   factory GCreateReviewVars.create({
-    required _i1.GEpisode? episode,
+    _i1.GEpisode? episode,
     required _i1.GReviewInput review,
   }) =>
       GCreateReviewVars((b) => b

--- a/codegen/end_to_end_test_tristate/lib/fragments/__generated__/hero_with_fragments.var.gql.dart
+++ b/codegen/end_to_end_test_tristate/lib/fragments/__generated__/hero_with_fragments.var.gql.dart
@@ -73,7 +73,7 @@ abstract class GcomparisonFieldsVars
           [void Function(GcomparisonFieldsVarsBuilder b) updates]) =
       _$GcomparisonFieldsVars;
 
-  factory GcomparisonFieldsVars.create({required int? first}) =>
+  factory GcomparisonFieldsVars.create({int? first}) =>
       GcomparisonFieldsVars((b) => b..first = first);
 
   int? get first;

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -2,9 +2,9 @@ name: gql_build
 version: 0.11.0+1
 description: Useful builders for your GraphQL SDL and documents. Based on package:gql_code_builder and package:build
 repository: https://github.com/gql-dart/gql
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
-dependencies:
+dependencies: 
   analyzer: '>=4.6.0 <7.0.0'
   build: ^2.1.0
   built_collection: ^5.0.0
@@ -18,10 +18,10 @@ dependencies:
   path: ^1.8.0
   yaml: ^3.1.0
   gql_tristate_value: ^1.0.0
-dev_dependencies:
+dev_dependencies: 
   build_test: ^2.0.0
   gql_pedantic: ^1.0.2
-topics:
+topics: 
   - graphql
   - gql
   - codegen

--- a/codegen/gql_code_builder/lib/var.dart
+++ b/codegen/gql_code_builder/lib/var.dart
@@ -52,6 +52,7 @@ Library buildVarLibrary(
                     ),
                   ),
                   schemaSource: schemaSource,
+                  typeOverrides: typeOverrides,
                 ),
             ],
             initializers: switch (useTriStateValueForNullableTypes) {

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -2,9 +2,9 @@ name: gql_code_builder
 version: 0.10.0
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
-dependencies:
+dependencies: 
   analyzer: '>=4.6.0 <7.0.0'
   built_collection: ^5.0.0
   built_value: ^8.0.6
@@ -14,11 +14,11 @@ dependencies:
   gql_exec: ^1.0.0
   path: ^1.8.0
   gql_tristate_value: ^1.0.0
-dev_dependencies:
+dev_dependencies: 
   build_runner: ^2.1.0
   gql_pedantic: ^1.0.2
   test: ^1.16.8
-topics:
+topics: 
   - graphql
   - gql
   - codegen


### PR DESCRIPTION
Hi @knaeckeKami!

Unfortunately I found a bug in my previous commit for the vars create factories 🙈 

Nullables were still required and types that were in the typeOverrides, were called with the `toBuilder()` function causing the compiler to fail for these files.

🙈 🙈 🙈 🤦 🤦 🤦 🙈🙈🙈

I fixed it on this branch and hoping we can merge this as a new bugfix version. Sorry for the initial oversight.

As for Ferry: Happy to open a PR making this new bugfix version a dependency if that helps you at all!

Thanks,
Florian!