### PR TITLE
[gql_code_builder] fix: vars_create_factories handle BuiltList type

### DIFF
--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
@@ -75,7 +75,19 @@ const Query = _i1.ObjectTypeDefinitionNode(
             isNonNull: true,
           ),
           defaultValue: null,
-        )
+        ),
+        _i1.InputValueDefinitionNode(
+          name: _i1.NameNode(value: 'stars'),
+          directives: [],
+          type: _i1.ListTypeNode(
+            type: _i1.NamedTypeNode(
+              name: _i1.NameNode(value: 'Int'),
+              isNonNull: true,
+            ),
+            isNonNull: false,
+          ),
+          defaultValue: null,
+        ),
       ],
       type: _i1.ListTypeNode(
         type: _i1.NamedTypeNode(

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.dart
@@ -144,6 +144,12 @@ import 'package:end_to_end_test/variables/__generated__/human_with_args.req.gql.
     show GHumanWithArgs;
 import 'package:end_to_end_test/variables/__generated__/human_with_args.var.gql.dart'
     show GHumanWithArgsVars;
+import 'package:end_to_end_test/variables/__generated__/list_argument.data.gql.dart'
+    show GreviewsWithListArgumentData, GreviewsWithListArgumentData_reviews;
+import 'package:end_to_end_test/variables/__generated__/list_argument.req.gql.dart'
+    show GreviewsWithListArgument;
+import 'package:end_to_end_test/variables/__generated__/list_argument.var.gql.dart'
+    show GreviewsWithListArgumentVars;
 import 'package:gql_code_builder/src/serializers/operation_serializer.dart'
     show OperationSerializer;
 
@@ -259,5 +265,9 @@ final SerializersBuilder _serializersBuilder = _$serializers.toBuilder()
   GhumanFieldsFragmentData_friends__asHuman,
   GhumanFieldsFragmentData_friends__base,
   GhumanFieldsFragmentVars,
+  GreviewsWithListArgument,
+  GreviewsWithListArgumentData,
+  GreviewsWithListArgumentData_reviews,
+  GreviewsWithListArgumentVars,
 ])
 final Serializers serializers = _serializersBuilder.build();

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
@@ -107,12 +107,19 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(GhumanFieldsFragmentData_friends__asHuman.serializer)
       ..add(GhumanFieldsFragmentData_friends__base.serializer)
       ..add(GhumanFieldsFragmentVars.serializer)
+      ..add(GreviewsWithListArgument.serializer)
+      ..add(GreviewsWithListArgumentData.serializer)
+      ..add(GreviewsWithListArgumentData_reviews.serializer)
+      ..add(GreviewsWithListArgumentVars.serializer)
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(DateTime)]),
           () => new ListBuilder<DateTime>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(CustomField)]),
           () => new ListBuilder<CustomField>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(int)]),
+          () => new ListBuilder<int>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType.nullable(DateTime)]),
           () => new ListBuilder<DateTime?>())
@@ -164,7 +171,12 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltList, const [
             const FullType.nullable(GhumanFieldsFragmentData_friends)
           ]),
-          () => new ListBuilder<GhumanFieldsFragmentData_friends?>()))
+          () => new ListBuilder<GhumanFieldsFragmentData_friends?>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType.nullable(GreviewsWithListArgumentData_reviews)
+          ]),
+          () => new ListBuilder<GreviewsWithListArgumentData_reviews?>()))
     .build();
 
 // ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/graphql/schema.graphql
+++ b/codegen/end_to_end_test/lib/graphql/schema.graphql
@@ -8,11 +8,10 @@ schema {
 
 directive @extends on OBJECT | INTERFACE
 
-
 # The query type, represents all of the entry points into our object graph
 type Query {
   hero(episode: Episode): Character
-  reviews(episode: Episode!): [Review]
+  reviews(episode: Episode!, stars: [Int!]): [Review]
   search(text: String): [SearchResult]
   character(id: ID!): Character
   droid(id: ID!): Droid

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.ast.gql.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:gql/ast.dart' as _i1;
+
+const reviewsWithListArgument = _i1.OperationDefinitionNode(
+  type: _i1.OperationType.query,
+  name: _i1.NameNode(value: 'reviewsWithListArgument'),
+  variableDefinitions: [
+    _i1.VariableDefinitionNode(
+      variable: _i1.VariableNode(name: _i1.NameNode(value: 'episode')),
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Episode'),
+        isNonNull: true,
+      ),
+      defaultValue: _i1.DefaultValueNode(value: null),
+      directives: [],
+    ),
+    _i1.VariableDefinitionNode(
+      variable: _i1.VariableNode(name: _i1.NameNode(value: 'stars')),
+      type: _i1.ListTypeNode(
+        type: _i1.NamedTypeNode(
+          name: _i1.NameNode(value: 'Int'),
+          isNonNull: true,
+        ),
+        isNonNull: false,
+      ),
+      defaultValue: _i1.DefaultValueNode(value: null),
+      directives: [],
+    ),
+  ],
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'reviews'),
+      alias: null,
+      arguments: [
+        _i1.ArgumentNode(
+          name: _i1.NameNode(value: 'episode'),
+          value: _i1.VariableNode(name: _i1.NameNode(value: 'episode')),
+        ),
+        _i1.ArgumentNode(
+          name: _i1.NameNode(value: 'stars'),
+          value: _i1.VariableNode(name: _i1.NameNode(value: 'stars')),
+        ),
+      ],
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'episode'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        )
+      ]),
+    )
+  ]),
+);
+const document = _i1.DocumentNode(definitions: [reviewsWithListArgument]);

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.data.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.data.gql.dart
@@ -1,0 +1,77 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/graphql/__generated__/schema.schema.gql.dart'
+    as _i2;
+import 'package:end_to_end_test/graphql/__generated__/serializers.gql.dart'
+    as _i1;
+
+part 'list_argument.data.gql.g.dart';
+
+abstract class GreviewsWithListArgumentData
+    implements
+        Built<GreviewsWithListArgumentData,
+            GreviewsWithListArgumentDataBuilder> {
+  GreviewsWithListArgumentData._();
+
+  factory GreviewsWithListArgumentData(
+          [void Function(GreviewsWithListArgumentDataBuilder b) updates]) =
+      _$GreviewsWithListArgumentData;
+
+  static void _initializeBuilder(GreviewsWithListArgumentDataBuilder b) =>
+      b..G__typename = 'Query';
+
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  BuiltList<GreviewsWithListArgumentData_reviews?>? get reviews;
+  static Serializer<GreviewsWithListArgumentData> get serializer =>
+      _$greviewsWithListArgumentDataSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GreviewsWithListArgumentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GreviewsWithListArgumentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GreviewsWithListArgumentData.serializer,
+        json,
+      );
+}
+
+abstract class GreviewsWithListArgumentData_reviews
+    implements
+        Built<GreviewsWithListArgumentData_reviews,
+            GreviewsWithListArgumentData_reviewsBuilder> {
+  GreviewsWithListArgumentData_reviews._();
+
+  factory GreviewsWithListArgumentData_reviews(
+      [void Function(GreviewsWithListArgumentData_reviewsBuilder b)
+          updates]) = _$GreviewsWithListArgumentData_reviews;
+
+  static void _initializeBuilder(
+          GreviewsWithListArgumentData_reviewsBuilder b) =>
+      b..G__typename = 'Review';
+
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  _i2.GEpisode? get episode;
+  static Serializer<GreviewsWithListArgumentData_reviews> get serializer =>
+      _$greviewsWithListArgumentDataReviewsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GreviewsWithListArgumentData_reviews.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GreviewsWithListArgumentData_reviews? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GreviewsWithListArgumentData_reviews.serializer,
+        json,
+      );
+}

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.data.gql.g.dart
@@ -1,0 +1,363 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'list_argument.data.gql.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GreviewsWithListArgumentData>
+    _$greviewsWithListArgumentDataSerializer =
+    new _$GreviewsWithListArgumentDataSerializer();
+Serializer<GreviewsWithListArgumentData_reviews>
+    _$greviewsWithListArgumentDataReviewsSerializer =
+    new _$GreviewsWithListArgumentData_reviewsSerializer();
+
+class _$GreviewsWithListArgumentDataSerializer
+    implements StructuredSerializer<GreviewsWithListArgumentData> {
+  @override
+  final Iterable<Type> types = const [
+    GreviewsWithListArgumentData,
+    _$GreviewsWithListArgumentData
+  ];
+  @override
+  final String wireName = 'GreviewsWithListArgumentData';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GreviewsWithListArgumentData object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.reviews;
+    if (value != null) {
+      result
+        ..add('reviews')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(BuiltList, const [
+              const FullType.nullable(GreviewsWithListArgumentData_reviews)
+            ])));
+    }
+    return result;
+  }
+
+  @override
+  GreviewsWithListArgumentData deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GreviewsWithListArgumentDataBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'reviews':
+          result.reviews.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType.nullable(GreviewsWithListArgumentData_reviews)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GreviewsWithListArgumentData_reviewsSerializer
+    implements StructuredSerializer<GreviewsWithListArgumentData_reviews> {
+  @override
+  final Iterable<Type> types = const [
+    GreviewsWithListArgumentData_reviews,
+    _$GreviewsWithListArgumentData_reviews
+  ];
+  @override
+  final String wireName = 'GreviewsWithListArgumentData_reviews';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GreviewsWithListArgumentData_reviews object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+    ];
+    Object? value;
+    value = object.episode;
+    if (value != null) {
+      result
+        ..add('episode')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(_i2.GEpisode)));
+    }
+    return result;
+  }
+
+  @override
+  GreviewsWithListArgumentData_reviews deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GreviewsWithListArgumentData_reviewsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'episode':
+          result.episode = serializers.deserialize(value,
+              specifiedType: const FullType(_i2.GEpisode)) as _i2.GEpisode?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GreviewsWithListArgumentData extends GreviewsWithListArgumentData {
+  @override
+  final String G__typename;
+  @override
+  final BuiltList<GreviewsWithListArgumentData_reviews?>? reviews;
+
+  factory _$GreviewsWithListArgumentData(
+          [void Function(GreviewsWithListArgumentDataBuilder)? updates]) =>
+      (new GreviewsWithListArgumentDataBuilder()..update(updates))._build();
+
+  _$GreviewsWithListArgumentData._({required this.G__typename, this.reviews})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, r'GreviewsWithListArgumentData', 'G__typename');
+  }
+
+  @override
+  GreviewsWithListArgumentData rebuild(
+          void Function(GreviewsWithListArgumentDataBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GreviewsWithListArgumentDataBuilder toBuilder() =>
+      new GreviewsWithListArgumentDataBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GreviewsWithListArgumentData &&
+        G__typename == other.G__typename &&
+        reviews == other.reviews;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, reviews.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GreviewsWithListArgumentData')
+          ..add('G__typename', G__typename)
+          ..add('reviews', reviews))
+        .toString();
+  }
+}
+
+class GreviewsWithListArgumentDataBuilder
+    implements
+        Builder<GreviewsWithListArgumentData,
+            GreviewsWithListArgumentDataBuilder> {
+  _$GreviewsWithListArgumentData? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  ListBuilder<GreviewsWithListArgumentData_reviews?>? _reviews;
+  ListBuilder<GreviewsWithListArgumentData_reviews?> get reviews =>
+      _$this._reviews ??=
+          new ListBuilder<GreviewsWithListArgumentData_reviews?>();
+  set reviews(ListBuilder<GreviewsWithListArgumentData_reviews?>? reviews) =>
+      _$this._reviews = reviews;
+
+  GreviewsWithListArgumentDataBuilder() {
+    GreviewsWithListArgumentData._initializeBuilder(this);
+  }
+
+  GreviewsWithListArgumentDataBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _reviews = $v.reviews?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GreviewsWithListArgumentData other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GreviewsWithListArgumentData;
+  }
+
+  @override
+  void update(void Function(GreviewsWithListArgumentDataBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GreviewsWithListArgumentData build() => _build();
+
+  _$GreviewsWithListArgumentData _build() {
+    _$GreviewsWithListArgumentData _$result;
+    try {
+      _$result = _$v ??
+          new _$GreviewsWithListArgumentData._(
+              G__typename: BuiltValueNullFieldError.checkNotNull(
+                  G__typename, r'GreviewsWithListArgumentData', 'G__typename'),
+              reviews: _reviews?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'reviews';
+        _reviews?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'GreviewsWithListArgumentData', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GreviewsWithListArgumentData_reviews
+    extends GreviewsWithListArgumentData_reviews {
+  @override
+  final String G__typename;
+  @override
+  final _i2.GEpisode? episode;
+
+  factory _$GreviewsWithListArgumentData_reviews(
+          [void Function(GreviewsWithListArgumentData_reviewsBuilder)?
+              updates]) =>
+      (new GreviewsWithListArgumentData_reviewsBuilder()..update(updates))
+          ._build();
+
+  _$GreviewsWithListArgumentData_reviews._(
+      {required this.G__typename, this.episode})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        G__typename, r'GreviewsWithListArgumentData_reviews', 'G__typename');
+  }
+
+  @override
+  GreviewsWithListArgumentData_reviews rebuild(
+          void Function(GreviewsWithListArgumentData_reviewsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GreviewsWithListArgumentData_reviewsBuilder toBuilder() =>
+      new GreviewsWithListArgumentData_reviewsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GreviewsWithListArgumentData_reviews &&
+        G__typename == other.G__typename &&
+        episode == other.episode;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GreviewsWithListArgumentData_reviews')
+          ..add('G__typename', G__typename)
+          ..add('episode', episode))
+        .toString();
+  }
+}
+
+class GreviewsWithListArgumentData_reviewsBuilder
+    implements
+        Builder<GreviewsWithListArgumentData_reviews,
+            GreviewsWithListArgumentData_reviewsBuilder> {
+  _$GreviewsWithListArgumentData_reviews? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  _i2.GEpisode? _episode;
+  _i2.GEpisode? get episode => _$this._episode;
+  set episode(_i2.GEpisode? episode) => _$this._episode = episode;
+
+  GreviewsWithListArgumentData_reviewsBuilder() {
+    GreviewsWithListArgumentData_reviews._initializeBuilder(this);
+  }
+
+  GreviewsWithListArgumentData_reviewsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _episode = $v.episode;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GreviewsWithListArgumentData_reviews other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GreviewsWithListArgumentData_reviews;
+  }
+
+  @override
+  void update(
+      void Function(GreviewsWithListArgumentData_reviewsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GreviewsWithListArgumentData_reviews build() => _build();
+
+  _$GreviewsWithListArgumentData_reviews _build() {
+    final _$result = _$v ??
+        new _$GreviewsWithListArgumentData_reviews._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                r'GreviewsWithListArgumentData_reviews', 'G__typename'),
+            episode: episode);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.req.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.req.gql.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/graphql/__generated__/serializers.gql.dart'
+    as _i4;
+import 'package:end_to_end_test/variables/__generated__/list_argument.ast.gql.dart'
+    as _i2;
+import 'package:end_to_end_test/variables/__generated__/list_argument.var.gql.dart'
+    as _i3;
+import 'package:gql_exec/gql_exec.dart' as _i1;
+
+part 'list_argument.req.gql.g.dart';
+
+abstract class GreviewsWithListArgument
+    implements
+        Built<GreviewsWithListArgument, GreviewsWithListArgumentBuilder> {
+  GreviewsWithListArgument._();
+
+  factory GreviewsWithListArgument(
+          [void Function(GreviewsWithListArgumentBuilder b) updates]) =
+      _$GreviewsWithListArgument;
+
+  static void _initializeBuilder(GreviewsWithListArgumentBuilder b) => b
+    ..operation = _i1.Operation(
+      document: _i2.document,
+      operationName: 'reviewsWithListArgument',
+    );
+
+  _i3.GreviewsWithListArgumentVars get vars;
+  _i1.Operation get operation;
+  static Serializer<GreviewsWithListArgument> get serializer =>
+      _$greviewsWithListArgumentSerializer;
+
+  Map<String, dynamic> toJson() => (_i4.serializers.serializeWith(
+        GreviewsWithListArgument.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GreviewsWithListArgument? fromJson(Map<String, dynamic> json) =>
+      _i4.serializers.deserializeWith(
+        GreviewsWithListArgument.serializer,
+        json,
+      );
+}

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.req.gql.g.dart
@@ -1,0 +1,187 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'list_argument.req.gql.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GreviewsWithListArgument> _$greviewsWithListArgumentSerializer =
+    new _$GreviewsWithListArgumentSerializer();
+
+class _$GreviewsWithListArgumentSerializer
+    implements StructuredSerializer<GreviewsWithListArgument> {
+  @override
+  final Iterable<Type> types = const [
+    GreviewsWithListArgument,
+    _$GreviewsWithListArgument
+  ];
+  @override
+  final String wireName = 'GreviewsWithListArgument';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GreviewsWithListArgument object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'vars',
+      serializers.serialize(object.vars,
+          specifiedType: const FullType(_i3.GreviewsWithListArgumentVars)),
+      'operation',
+      serializers.serialize(object.operation,
+          specifiedType: const FullType(_i1.Operation)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GreviewsWithListArgument deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GreviewsWithListArgumentBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'vars':
+          result.vars.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(_i3.GreviewsWithListArgumentVars))!
+              as _i3.GreviewsWithListArgumentVars);
+          break;
+        case 'operation':
+          result.operation = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.Operation))! as _i1.Operation;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GreviewsWithListArgument extends GreviewsWithListArgument {
+  @override
+  final _i3.GreviewsWithListArgumentVars vars;
+  @override
+  final _i1.Operation operation;
+
+  factory _$GreviewsWithListArgument(
+          [void Function(GreviewsWithListArgumentBuilder)? updates]) =>
+      (new GreviewsWithListArgumentBuilder()..update(updates))._build();
+
+  _$GreviewsWithListArgument._({required this.vars, required this.operation})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        vars, r'GreviewsWithListArgument', 'vars');
+    BuiltValueNullFieldError.checkNotNull(
+        operation, r'GreviewsWithListArgument', 'operation');
+  }
+
+  @override
+  GreviewsWithListArgument rebuild(
+          void Function(GreviewsWithListArgumentBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GreviewsWithListArgumentBuilder toBuilder() =>
+      new GreviewsWithListArgumentBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GreviewsWithListArgument &&
+        vars == other.vars &&
+        operation == other.operation;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GreviewsWithListArgument')
+          ..add('vars', vars)
+          ..add('operation', operation))
+        .toString();
+  }
+}
+
+class GreviewsWithListArgumentBuilder
+    implements
+        Builder<GreviewsWithListArgument, GreviewsWithListArgumentBuilder> {
+  _$GreviewsWithListArgument? _$v;
+
+  _i3.GreviewsWithListArgumentVarsBuilder? _vars;
+  _i3.GreviewsWithListArgumentVarsBuilder get vars =>
+      _$this._vars ??= new _i3.GreviewsWithListArgumentVarsBuilder();
+  set vars(_i3.GreviewsWithListArgumentVarsBuilder? vars) =>
+      _$this._vars = vars;
+
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
+
+  GreviewsWithListArgumentBuilder() {
+    GreviewsWithListArgument._initializeBuilder(this);
+  }
+
+  GreviewsWithListArgumentBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GreviewsWithListArgument other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GreviewsWithListArgument;
+  }
+
+  @override
+  void update(void Function(GreviewsWithListArgumentBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GreviewsWithListArgument build() => _build();
+
+  _$GreviewsWithListArgument _build() {
+    _$GreviewsWithListArgument _$result;
+    try {
+      _$result = _$v ??
+          new _$GreviewsWithListArgument._(
+              vars: vars.build(),
+              operation: BuiltValueNullFieldError.checkNotNull(
+                  operation, r'GreviewsWithListArgument', 'operation'));
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'vars';
+        vars.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'GreviewsWithListArgument', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.var.gql.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.var.gql.dart
@@ -1,0 +1,48 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/graphql/__generated__/schema.schema.gql.dart'
+    as _i1;
+import 'package:end_to_end_test/graphql/__generated__/serializers.gql.dart'
+    as _i2;
+
+part 'list_argument.var.gql.g.dart';
+
+abstract class GreviewsWithListArgumentVars
+    implements
+        Built<GreviewsWithListArgumentVars,
+            GreviewsWithListArgumentVarsBuilder> {
+  GreviewsWithListArgumentVars._();
+
+  factory GreviewsWithListArgumentVars(
+          [void Function(GreviewsWithListArgumentVarsBuilder b) updates]) =
+      _$GreviewsWithListArgumentVars;
+
+  factory GreviewsWithListArgumentVars.create({
+    required _i1.GEpisode episode,
+    BuiltList<int>? stars,
+  }) =>
+      GreviewsWithListArgumentVars((b) => b
+        ..episode = episode
+        ..stars = stars?.toBuilder());
+
+  _i1.GEpisode get episode;
+  BuiltList<int>? get stars;
+  static Serializer<GreviewsWithListArgumentVars> get serializer =>
+      _$greviewsWithListArgumentVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+        GreviewsWithListArgumentVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GreviewsWithListArgumentVars? fromJson(Map<String, dynamic> json) =>
+      _i2.serializers.deserializeWith(
+        GreviewsWithListArgumentVars.serializer,
+        json,
+      );
+}

--- a/codegen/end_to_end_test/lib/variables/__generated__/list_argument.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/variables/__generated__/list_argument.var.gql.g.dart
@@ -1,0 +1,188 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'list_argument.var.gql.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GreviewsWithListArgumentVars>
+    _$greviewsWithListArgumentVarsSerializer =
+    new _$GreviewsWithListArgumentVarsSerializer();
+
+class _$GreviewsWithListArgumentVarsSerializer
+    implements StructuredSerializer<GreviewsWithListArgumentVars> {
+  @override
+  final Iterable<Type> types = const [
+    GreviewsWithListArgumentVars,
+    _$GreviewsWithListArgumentVars
+  ];
+  @override
+  final String wireName = 'GreviewsWithListArgumentVars';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GreviewsWithListArgumentVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'episode',
+      serializers.serialize(object.episode,
+          specifiedType: const FullType(_i1.GEpisode)),
+    ];
+    Object? value;
+    value = object.stars;
+    if (value != null) {
+      result
+        ..add('stars')
+        ..add(serializers.serialize(value,
+            specifiedType:
+                const FullType(BuiltList, const [const FullType(int)])));
+    }
+    return result;
+  }
+
+  @override
+  GreviewsWithListArgumentVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new GreviewsWithListArgumentVarsBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'episode':
+          result.episode = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode))! as _i1.GEpisode;
+          break;
+        case 'stars':
+          result.stars.replace(serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, const [const FullType(int)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GreviewsWithListArgumentVars extends GreviewsWithListArgumentVars {
+  @override
+  final _i1.GEpisode episode;
+  @override
+  final BuiltList<int>? stars;
+
+  factory _$GreviewsWithListArgumentVars(
+          [void Function(GreviewsWithListArgumentVarsBuilder)? updates]) =>
+      (new GreviewsWithListArgumentVarsBuilder()..update(updates))._build();
+
+  _$GreviewsWithListArgumentVars._({required this.episode, this.stars})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(
+        episode, r'GreviewsWithListArgumentVars', 'episode');
+  }
+
+  @override
+  GreviewsWithListArgumentVars rebuild(
+          void Function(GreviewsWithListArgumentVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GreviewsWithListArgumentVarsBuilder toBuilder() =>
+      new GreviewsWithListArgumentVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GreviewsWithListArgumentVars &&
+        episode == other.episode &&
+        stars == other.stars;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GreviewsWithListArgumentVars')
+          ..add('episode', episode)
+          ..add('stars', stars))
+        .toString();
+  }
+}
+
+class GreviewsWithListArgumentVarsBuilder
+    implements
+        Builder<GreviewsWithListArgumentVars,
+            GreviewsWithListArgumentVarsBuilder> {
+  _$GreviewsWithListArgumentVars? _$v;
+
+  _i1.GEpisode? _episode;
+  _i1.GEpisode? get episode => _$this._episode;
+  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
+
+  ListBuilder<int>? _stars;
+  ListBuilder<int> get stars => _$this._stars ??= new ListBuilder<int>();
+  set stars(ListBuilder<int>? stars) => _$this._stars = stars;
+
+  GreviewsWithListArgumentVarsBuilder();
+
+  GreviewsWithListArgumentVarsBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _episode = $v.episode;
+      _stars = $v.stars?.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GreviewsWithListArgumentVars other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$GreviewsWithListArgumentVars;
+  }
+
+  @override
+  void update(void Function(GreviewsWithListArgumentVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GreviewsWithListArgumentVars build() => _build();
+
+  _$GreviewsWithListArgumentVars _build() {
+    _$GreviewsWithListArgumentVars _$result;
+    try {
+      _$result = _$v ??
+          new _$GreviewsWithListArgumentVars._(
+              episode: BuiltValueNullFieldError.checkNotNull(
+                  episode, r'GreviewsWithListArgumentVars', 'episode'),
+              stars: _stars?.build());
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'stars';
+        _stars?.build();
+      } catch (e) {
+        throw new BuiltValueNestedFieldError(
+            r'GreviewsWithListArgumentVars', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/variables/list_argument.graphql
+++ b/codegen/end_to_end_test/lib/variables/list_argument.graphql
@@ -1,0 +1,5 @@
+query reviewsWithListArgument($episode: Episode!, $stars: [Int!]) {
+  reviews(episode: $episode, stars: $stars) {
+    episode
+  }
+}

--- a/codegen/gql_code_builder/lib/src/required_vars_constructor.dart
+++ b/codegen/gql_code_builder/lib/src/required_vars_constructor.dart
@@ -38,12 +38,17 @@ Constructor builtCreateConstructor({
     final typeDefinitionNode = getTypeDefinitionNode(
         schemaSource.document, g.returns!.symbol!.replaceFirst("G", ""));
 
+    final bool isFromBuiltCollectionPackage =
+        g.returns?.url?.contains("built_collection") ?? false;
+
     /// "$BuiltList" is a String "BuiltList<dynamic>" and
     /// [g.returns!.symbol!] returns "BuiltList"
     ///  so we cannot use equality operator here.
-    final isBuiltList = g.returns?.symbol != null
-        ? "$BuiltList".contains(g.returns!.symbol!)
-        : false;
+    final isBuiltList = (g.returns?.symbol != null
+            ? "$BuiltList".contains(g.returns!.symbol!)
+            : false) &&
+        isFromBuiltCollectionPackage;
+
     final isBuiltType = typeDefinitionNode is InputObjectTypeDefinitionNode ||
         typeDefinitionNode is ScalarTypeDefinitionNode ||
         isBuiltList;

--- a/codegen/gql_code_builder/lib/src/required_vars_constructor.dart
+++ b/codegen/gql_code_builder/lib/src/required_vars_constructor.dart
@@ -37,9 +37,16 @@ Constructor builtCreateConstructor({
   final assignments = filteredGetters.map((g) {
     final typeDefinitionNode = getTypeDefinitionNode(
         schemaSource.document, g.returns!.symbol!.replaceFirst("G", ""));
-    final isBuiltType = typeDefinitionNode is InputObjectTypeDefinitionNode ||
-        typeDefinitionNode is ScalarTypeDefinitionNode;
 
+    /// "$BuiltList" is a String "BuiltList<dynamic>" and
+    /// [g.returns!.symbol!] returns "BuiltList"
+    ///  so we cannot use equality operator here.
+    final isBuiltList = g.returns?.symbol != null
+        ? "$BuiltList".contains(g.returns!.symbol!)
+        : false;
+    final isBuiltType = typeDefinitionNode is InputObjectTypeDefinitionNode ||
+        typeDefinitionNode is ScalarTypeDefinitionNode ||
+        isBuiltList;
     final isTypeOverride = typeOverrides.values.contains(g.returns!);
     final isNullable = (g.returns! as TypeReference).isNullable ?? false;
 

--- a/links/gql_websocket_link/lib/src/messages.dart
+++ b/links/gql_websocket_link/lib/src/messages.dart
@@ -165,7 +165,7 @@ class SubscriptionData extends GraphQLSocketMessage {
   int get hashCode => toJson().hashCode;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is SubscriptionData && jsonEncode(other) == jsonEncode(this);
 }
 


### PR DESCRIPTION
Hi! 👋 
I've tried to use that feature [vars_create_factories](https://github.com/gql-dart/gql/pull/434) and I've encounter an issue with arguments being lists. The parameter of a factory requires a `BuiltList` that is assigned to `ListBuilder` and that is not allowed.
<img width="795" alt="image" src="https://github.com/gql-dart/gql/assets/30510627/ac9e4fd8-e610-4b33-be68-59246113b51e">

@caffeineflo I've found some solution. Not sure whether it's the best way, but it works for me. So if you could take a look 🙏 