### PR TITLE
chore(vars-create-input): Adding Create Factories to Input types

### DIFF
--- a/codegen/end_to_end_test/build.yaml
+++ b/codegen/end_to_end_test/build.yaml
@@ -25,6 +25,7 @@ targets:
       gql_build|schema_builder:
         enabled: true
         options:
+          vars_create_factories: true
           enum_fallbacks:
             LengthUnit: METER
           type_overrides:

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
@@ -54,6 +54,18 @@ abstract class GReviewInput
   factory GReviewInput([void Function(GReviewInputBuilder b) updates]) =
       _$GReviewInput;
 
+  factory GReviewInput.create({
+    required int stars,
+    String? commentary,
+    GColorInput? favorite_color,
+    BuiltList<DateTime?>? seenOn,
+  }) =>
+      GReviewInput((b) => b
+        ..stars = stars
+        ..commentary = commentary
+        ..favorite_color = favorite_color?.toBuilder()
+        ..seenOn = seenOn?.toBuilder());
+
   int get stars;
   String? get commentary;
   GColorInput? get favorite_color;
@@ -80,6 +92,14 @@ abstract class GCustomFieldInput
           [void Function(GCustomFieldInputBuilder b) updates]) =
       _$GCustomFieldInput;
 
+  factory GCustomFieldInput.create({
+    required String id,
+    _i2.CustomField? customField,
+  }) =>
+      GCustomFieldInput((b) => b
+        ..id = id
+        ..customField = customField);
+
   String get id;
   _i2.CustomField? get customField;
   static Serializer<GCustomFieldInput> get serializer =>
@@ -102,6 +122,16 @@ abstract class GColorInput implements Built<GColorInput, GColorInputBuilder> {
 
   factory GColorInput([void Function(GColorInputBuilder b) updates]) =
       _$GColorInput;
+
+  factory GColorInput.create({
+    required int red,
+    required int green,
+    required int blue,
+  }) =>
+      GColorInput((b) => b
+        ..red = red
+        ..green = green
+        ..blue = blue);
 
   int get red;
   int get green;
@@ -127,6 +157,9 @@ abstract class GPostLikesInput
   factory GPostLikesInput([void Function(GPostLikesInputBuilder b) updates]) =
       _$GPostLikesInput;
 
+  factory GPostLikesInput.create({required String id}) =>
+      GPostLikesInput((b) => b..id = id);
+
   String get id;
   static Serializer<GPostLikesInput> get serializer =>
       _$gPostLikesInputSerializer;
@@ -150,6 +183,9 @@ abstract class GPostFavoritesInput
   factory GPostFavoritesInput(
           [void Function(GPostFavoritesInputBuilder b) updates]) =
       _$GPostFavoritesInput;
+
+  factory GPostFavoritesInput.create({required String id}) =>
+      GPostFavoritesInput((b) => b..id = id);
 
   String get id;
   static Serializer<GPostFavoritesInput> get serializer =>

--- a/codegen/end_to_end_test/test/schema/input_test.dart
+++ b/codegen/end_to_end_test/test/schema/input_test.dart
@@ -13,6 +13,13 @@ void main() {
         ..favorite_color.red = 225);
     });
 
+    test('can be instantiated via create factory', () {
+      GReviewInput.create(
+          stars: 4,
+          commentary: "This was a great movie!",
+          favorite_color: GColorInput.create(red: 255, green: 123, blue: 225));
+    });
+
     test('can be serialized and deserialized', () {
       final input = GReviewInput((b) => b
         ..stars = 4

--- a/codegen/end_to_end_test_tristate/build.yaml
+++ b/codegen/end_to_end_test_tristate/build.yaml
@@ -25,6 +25,7 @@ targets:
       gql_build|schema_builder:
         enabled: true
         options:
+          vars_create_factories: true
           tristate_optionals: true
           enum_fallbacks:
             LengthUnit: METER

--- a/codegen/end_to_end_test_tristate/lib/graphql/__generated__/schema.schema.gql.dart
+++ b/codegen/end_to_end_test_tristate/lib/graphql/__generated__/schema.schema.gql.dart
@@ -55,6 +55,18 @@ abstract class GReviewInput
   factory GReviewInput([void Function(GReviewInputBuilder b) updates]) =
       _$GReviewInput;
 
+  factory GReviewInput.create({
+    required int stars,
+    required _i1.Value<String> commentary,
+    required _i1.Value<GColorInput> favorite_color,
+    required _i1.Value<BuiltList<DateTime?>> seenOn,
+  }) =>
+      GReviewInput((b) => b
+        ..stars = stars
+        ..commentary = commentary
+        ..favorite_color = favorite_color
+        ..seenOn = seenOn);
+
   static void _initializeBuilder(GReviewInputBuilder b) => b
     ..commentary = const _i1.AbsentValue()
     ..favorite_color = const _i1.AbsentValue()
@@ -162,6 +174,14 @@ abstract class GCustomFieldInput
           [void Function(GCustomFieldInputBuilder b) updates]) =
       _$GCustomFieldInput;
 
+  factory GCustomFieldInput.create({
+    required String id,
+    required _i1.Value<_i2.CustomField> customField,
+  }) =>
+      GCustomFieldInput((b) => b
+        ..id = id
+        ..customField = customField);
+
   static void _initializeBuilder(GCustomFieldInputBuilder b) =>
       b..customField = const _i1.AbsentValue();
 
@@ -241,6 +261,16 @@ abstract class GColorInput implements Built<GColorInput, GColorInputBuilder> {
 
   factory GColorInput([void Function(GColorInputBuilder b) updates]) =
       _$GColorInput;
+
+  factory GColorInput.create({
+    required int red,
+    required int green,
+    required int blue,
+  }) =>
+      GColorInput((b) => b
+        ..red = red
+        ..green = green
+        ..blue = blue);
 
   int get red;
   int get green;
@@ -323,6 +353,9 @@ abstract class GPostLikesInput
   factory GPostLikesInput([void Function(GPostLikesInputBuilder b) updates]) =
       _$GPostLikesInput;
 
+  factory GPostLikesInput.create({required String id}) =>
+      GPostLikesInput((b) => b..id = id);
+
   String get id;
   Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GPostLikesInput.serializer,
@@ -388,6 +421,9 @@ abstract class GPostFavoritesInput
   factory GPostFavoritesInput(
           [void Function(GPostFavoritesInputBuilder b) updates]) =
       _$GPostFavoritesInput;
+
+  factory GPostFavoritesInput.create({required String id}) =>
+      GPostFavoritesInput((b) => b..id = id);
 
   String get id;
   Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(

--- a/codegen/gql_build/lib/gql_build.dart
+++ b/codegen/gql_build/lib/gql_build.dart
@@ -58,7 +58,8 @@ Builder schemaBuilder(
         typeOverrideMap(options.config["type_overrides"]),
         enumFallbackConfig(options.config),
         generatePossibleTypesConfig(options.config),
-        triStateOptionalsConfig(options.config));
+        triStateOptionalsConfig(options.config),
+        varsCreateFactoriesConfig(options.config));
 
 /// Builds an aggregate Serlializers object for [built_value]s
 ///

--- a/codegen/gql_build/lib/src/schema_builder.dart
+++ b/codegen/gql_build/lib/src/schema_builder.dart
@@ -15,9 +15,14 @@ class SchemaBuilder implements Builder {
   final EnumFallbackConfig enumFallbackConfig;
   final bool generatePossibleTypesMap;
   final TriStateValueConfig triStateValueConfig;
+  final bool generateVarsCreateFactories;
 
-  SchemaBuilder(this.typeOverrides, this.enumFallbackConfig,
-      this.generatePossibleTypesMap, this.triStateValueConfig);
+  SchemaBuilder(
+      this.typeOverrides,
+      this.enumFallbackConfig,
+      this.generatePossibleTypesMap,
+      this.triStateValueConfig,
+      this.generateVarsCreateFactories);
 
   @override
   Map<String, List<String>> get buildExtensions => {
@@ -49,6 +54,7 @@ class SchemaBuilder implements Builder {
       generatePossibleTypesMap: generatePossibleTypesMap,
       allocator: allocator,
       triStateValueConfig: triStateValueConfig,
+      generateVarsCreateFactories: generateVarsCreateFactories,
     );
 
     return writeDocument(

--- a/codegen/gql_code_builder/lib/schema.dart
+++ b/codegen/gql_code_builder/lib/schema.dart
@@ -13,9 +13,15 @@ Library buildSchemaLibrary(SourceNode schemaSource, String partUrl,
     Map<String, Reference> typeOverrides, EnumFallbackConfig enumFallbackConfig,
     {bool generatePossibleTypesMap = false,
     Allocator? allocator,
-    TriStateValueConfig triStateValueConfig = TriStateValueConfig.never}) {
-  final lib = buildSchema(schemaSource, typeOverrides, enumFallbackConfig,
-      allocator ?? Allocator(), triStateValueConfig) as Library;
+    TriStateValueConfig triStateValueConfig = TriStateValueConfig.never,
+    bool generateVarsCreateFactories = false}) {
+  final lib = buildSchema(
+      schemaSource,
+      typeOverrides,
+      enumFallbackConfig,
+      allocator ?? Allocator(),
+      triStateValueConfig,
+      generateVarsCreateFactories) as Library;
 
   final Code? possibleTypes;
   if (generatePossibleTypesMap && lib.body.isNotEmpty) {

--- a/codegen/gql_code_builder/lib/src/schema.dart
+++ b/codegen/gql_code_builder/lib/src/schema.dart
@@ -15,6 +15,7 @@ Spec? buildSchema(
   EnumFallbackConfig enumFallbackConfig,
   Allocator allocator,
   TriStateValueConfig triStateValueConfig,
+  bool generateVarsCreateFactories,
 ) =>
     schemaSource.document
         .accept(
@@ -24,6 +25,7 @@ Spec? buildSchema(
             enumFallbackConfig,
             allocator,
             triStateValueConfig,
+            generateVarsCreateFactories,
           ),
         )
         ?.first;
@@ -36,8 +38,15 @@ class _SchemaBuilderVisitor extends SimpleVisitor<List<Spec>?> {
   final Allocator allocator;
   final TriStateValueConfig triStateValueConfig;
 
-  const _SchemaBuilderVisitor(this.schemaSource, this.typeOverrides,
-      this.enumFallbackConfig, this.allocator, this.triStateValueConfig);
+  final bool generateVarsCreateFactories;
+
+  const _SchemaBuilderVisitor(
+      this.schemaSource,
+      this.typeOverrides,
+      this.enumFallbackConfig,
+      this.allocator,
+      this.triStateValueConfig,
+      this.generateVarsCreateFactories);
 
   @override
   List<Spec> visitDocumentNode(
@@ -57,8 +66,8 @@ class _SchemaBuilderVisitor extends SimpleVisitor<List<Spec>?> {
   List<Spec> visitInputObjectTypeDefinitionNode(
     InputObjectTypeDefinitionNode node,
   ) {
-    final inputClass =
-        buildInputClass(node, schemaSource, typeOverrides, triStateValueConfig);
+    final inputClass = buildInputClass(node, schemaSource, typeOverrides,
+        triStateValueConfig, generateVarsCreateFactories);
 
     return switch (triStateValueConfig) {
       TriStateValueConfig.never => [inputClass],


### PR DESCRIPTION
Hello 👋 

it's the `create` factories guy again! 

Since we've been busy using the create factories we've added a while back, we noticed that we must have forgotten to apply the same factories to input types *doh* 
This makes it hard using the `create` factories/initializer very hard since input types are kinda necessary to be covered when your `Vars`/Inputs  go beyond simple value types.

This PR fixes that previous oversight and adds `create` factories to Input types.

I've added a unit test as well for completeness, but please let mw know if there are any questions on this! 
Thanks