### PR TITLE
Fixed visitStringValueNode for string blocks

### DIFF
--- a/gql/lib/src/language/printer.dart
+++ b/gql/lib/src/language/printer.dart
@@ -184,7 +184,10 @@ class _PrintVisitor extends Visitor<String> {
       '"""',
       "\n",
       _indent(_tabs),
-      stringValueNode.value.replaceAll('"""', '\\"""'),
+      stringValueNode.value
+          .replaceAll('"""', '\\"""')
+          .replaceAll('\\', '\\\\')
+          .replaceAll('\n', '\\n'),
       "\n",
       _indent(_tabs),
       '"""',


### PR DESCRIPTION
Fix: https://github.com/gql-dart/gql/issues/453