### PR TITLE
fix(gql_websocket_link): Fix race condition causing exception and double complete

### DIFF
--- a/links/gql_websocket_link/lib/src/graphql_transport_ws.dart
+++ b/links/gql_websocket_link/lib/src/graphql_transport_ws.dart
@@ -853,7 +853,12 @@ class _ConnectionState {
             retrying = false; // future lazy connects are not retries
             retries = 0; // reset the retries on connect
             final _completer = Completer<void>();
-            errorOrClosed(_completer.completeError);
+
+            errorOrClosed((error) {
+              if (_completer.isCompleted) return;
+              _completer.completeError(error);
+            });
+
             connected(_Connected(
               socket,
               _completer.future,


### PR DESCRIPTION
There is a race condition in the `subscribe` function of the _Client class.  If the dispose function returned by the `subscribe` method is called which calls the `releaser()` method, and then a `CompleteMessage` is received on the websocket while the `releaser()` is awaiting to compose its own `CompleteMessage`, then `releaser()` is called twice and the request is double released causing an exception.  I've added a flag to avoid a double release.

The second patch simply avoids the situation where a websocket is already closed when an error occurs, causing an already completed exception when `completeError()` is called on the completer.