### PR TITLE
Wrap dio_link executeDioRequest in try-catch block

### DIFF
--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -67,7 +67,8 @@ class DioLink extends Link {
 
   @override
   Stream<Response> request(Request request, [forward]) async* {
-    final dio.Response<Map<String, dynamic>> dioResponse =
+    try {
+      final dio.Response<Map<String, dynamic>> dioResponse =
         await _executeDioRequest(
       request: request,
       headers: <String, String>{
@@ -96,6 +97,10 @@ class DioLink extends Link {
       response: gqlResponse.response,
       context: _updateResponseContext(gqlResponse, dioResponse),
     );
+    }
+    catch (e) {
+      yield* Stream.error(e);
+    }
   }
 
   dynamic _prepareRequestBody(Request request) {


### PR DESCRIPTION
The request function has a return type of `Stream<Response>`. As a result, the catch block will use `Stream.error()` to asynchronously propagate the exception.