### PR TITLE
Fix typo in schema getter

### DIFF
--- a/gql/lib/src/schema/schema.dart
+++ b/gql/lib/src/schema/schema.dart
@@ -78,7 +78,7 @@ class GraphQLSchema extends TypeSystemDefinition {
   ObjectTypeDefinition? get mutation => _getObjectType("mutation");
   ObjectTypeDefinition? get subscription => _getObjectType("subscription");
 
-  List<InterfaceTypeDefinition> get interaces =>
+  List<InterfaceTypeDefinition> get interfaces =>
       _getAll<InterfaceTypeDefinition>();
 
   List<EnumTypeDefinition> get enums => _getAll<EnumTypeDefinition>();

--- a/gql/test/schema_test.dart
+++ b/gql/test/schema_test.dart
@@ -22,7 +22,7 @@ void main() {
       );
     });
 
-    test("Can dereference an object interace", () {
+    test("Can dereference an object interface", () {
       final droid = schema.getType("Droid") as ObjectTypeDefinition;
       expect(
         droid.interfaces[0]!.name,


### PR DESCRIPTION
## Summary
- fix a misspelt getter `interaces` -> `interfaces`
- adjust test wording accordingly

## Testing
- `n/a`