### PR TITLE
Fix: JsonObject fields should not use replace() method with tristate_optionals

### DIFF
--- a/codegen/gql_code_builder/lib/src/tristate_optionals.dart
+++ b/codegen/gql_code_builder/lib/src/tristate_optionals.dart
@@ -187,8 +187,14 @@ String _generateFieldDeserializers(
           getTypeDefinitionNode(schemaSource.document, originalSymbolName);
 
       //TODO this feels flaky, find a better way
+      // Check if type is a built collection (has replace method)
+      // JsonObject from built_value doesn't have replace method
+      final isJsonObject = type.symbol == "JsonObject" && 
+          type.url == "package:built_value/json_object.dart";
+      
       final isBuilder = type.url != null &&
           !isWrappedValue &&
+          !isJsonObject &&
           (typeDefNode is! ScalarTypeDefinitionNode &&
               typeDefNode is! EnumTypeDefinitionNode);
 


### PR DESCRIPTION
## Description
This PR fixes an issue where `JsonObject` fields incorrectly generate calls to `.replace()` method when `tristate_optionals` is enabled.

## Problem
When using Ferry with `JsonObject` type (from `built_value` package) and `tristate_optionals: true` option enabled, the generated serializer code contains calls to `.replace()` method on `JsonObject?` fields. However, `JsonObject` doesn't have a `replace` method, causing compilation errors.

## Solution
Added special handling for `JsonObject` type in the tristate optionals code generator to ensure it's treated as a simple value type (using direct assignment) rather than a built collection type (which would use `.replace()` method).

## Changes
- Modified `/codegen/gql_code_builder/lib/src/tristate_optionals.dart` to detect `JsonObject` type and exclude it from being treated as a builder type

## Testing
Tested with a real-world Flutter project using:
- `tristate_optionals: true`
- `JsonObject` type override for JSON scalar
- Verified that generated code now compiles successfully

## Related Issues
- Fixes gql-dart/ferry#649

## Before/After

**Before (causes compilation error):**
```dart
case 'params':
  var _$fieldValue = serializers.deserialize(value,
      specifiedType: const FullType(_i1.JsonObject)) as _i1.JsonObject;
  builder.params.replace(_$fieldValue);  // ❌ Error: replace() not defined
  break;
```

**After (works correctly):**
```dart
case 'params':
  var _$fieldValue = serializers.deserialize(value,
      specifiedType: const FullType(_i1.JsonObject)) as _i1.JsonObject;
  builder.params = _$fieldValue;  // ✅ Direct assignment
  break;
```