### PR TITLE
Fixes issue with multiple nested fragments on interface and union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ doc/api/
 
 **/test/**/*.mocks.dart
 pubspec_overrides.yaml
+
+examples/gql_example_flutter/ios/Flutter/ephemeral/

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.data.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.data.gql.dart
@@ -343,8 +343,7 @@ abstract class GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__as
             GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asDroidBuilder>,
         GheroFieldsFragment__asHuman_friends,
         GhumanFieldsFragment_friends,
-        GheroFieldsFragment,
-        GheroFieldsFragment__asDroid,
+        GheroFieldsFragment__asHuman_friends__asDroid,
         GhumanFieldsFragment_friends__asDroid,
         GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends,
         GdroidFieldsFragment {
@@ -397,8 +396,7 @@ abstract class GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__as
             GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanBuilder>,
         GheroFieldsFragment__asHuman_friends,
         GhumanFieldsFragment_friends,
-        GheroFieldsFragment,
-        GheroFieldsFragment__asHuman,
+        GheroFieldsFragment__asHuman_friends__asHuman,
         GhumanFieldsFragment_friends__asHuman,
         GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends {
   GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman._();
@@ -902,8 +900,7 @@ abstract class GheroFieldsFragmentData__asHuman_friends__asDroid
             GheroFieldsFragmentData__asHuman_friends__asDroidBuilder>,
         GheroFieldsFragment__asHuman_friends,
         GhumanFieldsFragment_friends,
-        GheroFieldsFragment,
-        GheroFieldsFragment__asDroid,
+        GheroFieldsFragment__asHuman_friends__asDroid,
         GhumanFieldsFragment_friends__asDroid,
         GheroFieldsFragmentData__asHuman_friends,
         GdroidFieldsFragment {
@@ -949,8 +946,7 @@ abstract class GheroFieldsFragmentData__asHuman_friends__asHuman
             GheroFieldsFragmentData__asHuman_friends__asHumanBuilder>,
         GheroFieldsFragment__asHuman_friends,
         GhumanFieldsFragment_friends,
-        GheroFieldsFragment,
-        GheroFieldsFragment__asHuman,
+        GheroFieldsFragment__asHuman_friends__asHuman,
         GhumanFieldsFragment_friends__asHuman,
         GheroFieldsFragmentData__asHuman_friends {
   GheroFieldsFragmentData__asHuman_friends__asHuman._();

--- a/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.data.gql.g.dart
@@ -434,15 +434,6 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanSe
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
-    value = object.friends;
-    if (value != null) {
-      result
-        ..add('friends')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType.nullable(GheroFieldsFragment__asHuman_friends)
-            ])));
-    }
     return result;
   }
 
@@ -474,12 +465,6 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanSe
         case 'homePlanet':
           result.homePlanet = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
-          break;
-        case 'friends':
-          result.friends.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltList, const [
-                const FullType.nullable(GheroFieldsFragment__asHuman_friends)
-              ]))! as BuiltList<Object?>);
           break;
       }
     }
@@ -855,15 +840,6 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHumanSerializer
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
-    value = object.friends;
-    if (value != null) {
-      result
-        ..add('friends')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(BuiltList, const [
-              const FullType.nullable(GheroFieldsFragment__asHuman_friends)
-            ])));
-    }
     return result;
   }
 
@@ -894,12 +870,6 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHumanSerializer
         case 'homePlanet':
           result.homePlanet = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
-          break;
-        case 'friends':
-          result.friends.replace(serializers.deserialize(value,
-              specifiedType: const FullType(BuiltList, const [
-                const FullType.nullable(GheroFieldsFragment__asHuman_friends)
-              ]))! as BuiltList<Object?>);
           break;
       }
     }
@@ -1987,8 +1957,6 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
   final String name;
   @override
   final String? homePlanet;
-  @override
-  final BuiltList<GheroFieldsFragment__asHuman_friends?>? friends;
 
   factory _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman(
           [void Function(
@@ -2002,8 +1970,7 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
       {required this.G__typename,
       required this.id,
       required this.name,
-      this.homePlanet,
-      this.friends})
+      this.homePlanet})
       : super._();
   @override
   GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman rebuild(
@@ -2026,8 +1993,7 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
         G__typename == other.G__typename &&
         id == other.id &&
         name == other.name &&
-        homePlanet == other.homePlanet &&
-        friends == other.friends;
+        homePlanet == other.homePlanet;
   }
 
   @override
@@ -2037,7 +2003,6 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
     _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, homePlanet.hashCode);
-    _$hash = $jc(_$hash, friends.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -2049,8 +2014,7 @@ class _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
           ..add('G__typename', G__typename)
           ..add('id', id)
           ..add('name', name)
-          ..add('homePlanet', homePlanet)
-          ..add('friends', friends))
+          ..add('homePlanet', homePlanet))
         .toString();
   }
 }
@@ -2078,12 +2042,6 @@ class GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanBuil
   String? get homePlanet => _$this._homePlanet;
   set homePlanet(String? homePlanet) => _$this._homePlanet = homePlanet;
 
-  ListBuilder<GheroFieldsFragment__asHuman_friends?>? _friends;
-  ListBuilder<GheroFieldsFragment__asHuman_friends?> get friends =>
-      _$this._friends ??= ListBuilder<GheroFieldsFragment__asHuman_friends?>();
-  set friends(ListBuilder<GheroFieldsFragment__asHuman_friends?>? friends) =>
-      _$this._friends = friends;
-
   GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanBuilder() {
     GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
         ._initializeBuilder(this);
@@ -2097,7 +2055,6 @@ class GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanBuil
       _id = $v.id;
       _name = $v.name;
       _homePlanet = $v.homePlanet;
-      _friends = $v.friends?.toBuilder();
       _$v = null;
     }
     return this;
@@ -2125,40 +2082,23 @@ class GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHumanBuil
 
   _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
       _build() {
-    _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
-        _$result;
-    try {
-      _$result = _$v ??
-          _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
-              ._(
-            G__typename: BuiltValueNullFieldError.checkNotNull(
-                G__typename,
-                r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
-                'G__typename'),
-            id: BuiltValueNullFieldError.checkNotNull(
-                id,
-                r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
-                'id'),
-            name: BuiltValueNullFieldError.checkNotNull(
-                name,
-                r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
-                'name'),
-            homePlanet: homePlanet,
-            friends: _friends?.build(),
-          );
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'friends';
-        _friends?.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(
-            r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
-            _$failedField,
-            e.toString());
-      }
-      rethrow;
-    }
+    final _$result = _$v ??
+        _$GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman
+            ._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
+              'G__typename'),
+          id: BuiltValueNullFieldError.checkNotNull(
+              id,
+              r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
+              'id'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name,
+              r'GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends__asHuman',
+              'name'),
+          homePlanet: homePlanet,
+        );
     replace(_$result);
     return _$result;
   }
@@ -2828,8 +2768,6 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHuman
   final String name;
   @override
   final String? homePlanet;
-  @override
-  final BuiltList<GheroFieldsFragment__asHuman_friends?>? friends;
 
   factory _$GheroFieldsFragmentData__asHuman_friends__asHuman(
           [void Function(
@@ -2843,8 +2781,7 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHuman
       {required this.G__typename,
       required this.id,
       required this.name,
-      this.homePlanet,
-      this.friends})
+      this.homePlanet})
       : super._();
   @override
   GheroFieldsFragmentData__asHuman_friends__asHuman rebuild(
@@ -2864,8 +2801,7 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHuman
         G__typename == other.G__typename &&
         id == other.id &&
         name == other.name &&
-        homePlanet == other.homePlanet &&
-        friends == other.friends;
+        homePlanet == other.homePlanet;
   }
 
   @override
@@ -2875,7 +2811,6 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHuman
     _$hash = $jc(_$hash, id.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, homePlanet.hashCode);
-    _$hash = $jc(_$hash, friends.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -2887,8 +2822,7 @@ class _$GheroFieldsFragmentData__asHuman_friends__asHuman
           ..add('G__typename', G__typename)
           ..add('id', id)
           ..add('name', name)
-          ..add('homePlanet', homePlanet)
-          ..add('friends', friends))
+          ..add('homePlanet', homePlanet))
         .toString();
   }
 }
@@ -2915,12 +2849,6 @@ class GheroFieldsFragmentData__asHuman_friends__asHumanBuilder
   String? get homePlanet => _$this._homePlanet;
   set homePlanet(String? homePlanet) => _$this._homePlanet = homePlanet;
 
-  ListBuilder<GheroFieldsFragment__asHuman_friends?>? _friends;
-  ListBuilder<GheroFieldsFragment__asHuman_friends?> get friends =>
-      _$this._friends ??= ListBuilder<GheroFieldsFragment__asHuman_friends?>();
-  set friends(ListBuilder<GheroFieldsFragment__asHuman_friends?>? friends) =>
-      _$this._friends = friends;
-
   GheroFieldsFragmentData__asHuman_friends__asHumanBuilder() {
     GheroFieldsFragmentData__asHuman_friends__asHuman._initializeBuilder(this);
   }
@@ -2932,7 +2860,6 @@ class GheroFieldsFragmentData__asHuman_friends__asHumanBuilder
       _id = $v.id;
       _name = $v.name;
       _homePlanet = $v.homePlanet;
-      _friends = $v.friends?.toBuilder();
       _$v = null;
     }
     return this;
@@ -2954,34 +2881,18 @@ class GheroFieldsFragmentData__asHuman_friends__asHumanBuilder
   GheroFieldsFragmentData__asHuman_friends__asHuman build() => _build();
 
   _$GheroFieldsFragmentData__asHuman_friends__asHuman _build() {
-    _$GheroFieldsFragmentData__asHuman_friends__asHuman _$result;
-    try {
-      _$result = _$v ??
-          _$GheroFieldsFragmentData__asHuman_friends__asHuman._(
-            G__typename: BuiltValueNullFieldError.checkNotNull(
-                G__typename,
-                r'GheroFieldsFragmentData__asHuman_friends__asHuman',
-                'G__typename'),
-            id: BuiltValueNullFieldError.checkNotNull(
-                id, r'GheroFieldsFragmentData__asHuman_friends__asHuman', 'id'),
-            name: BuiltValueNullFieldError.checkNotNull(name,
-                r'GheroFieldsFragmentData__asHuman_friends__asHuman', 'name'),
-            homePlanet: homePlanet,
-            friends: _friends?.build(),
-          );
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'friends';
-        _friends?.build();
-      } catch (e) {
-        throw BuiltValueNestedFieldError(
-            r'GheroFieldsFragmentData__asHuman_friends__asHuman',
-            _$failedField,
-            e.toString());
-      }
-      rethrow;
-    }
+    final _$result = _$v ??
+        _$GheroFieldsFragmentData__asHuman_friends__asHuman._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GheroFieldsFragmentData__asHuman_friends__asHuman',
+              'G__typename'),
+          id: BuiltValueNullFieldError.checkNotNull(
+              id, r'GheroFieldsFragmentData__asHuman_friends__asHuman', 'id'),
+          name: BuiltValueNullFieldError.checkNotNull(name,
+              r'GheroFieldsFragmentData__asHuman_friends__asHuman', 'name'),
+          homePlanet: homePlanet,
+        );
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.ast.gql.dart
@@ -24,65 +24,6 @@ const GetBooks = _i1.OperationDefinitionNode(
     )
   ]),
 );
-const AuthorFragment = _i1.FragmentDefinitionNode(
-  name: _i1.NameNode(value: 'AuthorFragment'),
-  typeCondition: _i1.TypeConditionNode(
-      on: _i1.NamedTypeNode(
-    name: _i1.NameNode(value: 'Author'),
-    isNonNull: false,
-  )),
-  directives: [],
-  selectionSet: _i1.SelectionSetNode(selections: [
-    _i1.FieldNode(
-      name: _i1.NameNode(value: 'displayName'),
-      alias: null,
-      arguments: [],
-      directives: [],
-      selectionSet: null,
-    ),
-    _i1.InlineFragmentNode(
-      typeCondition: _i1.TypeConditionNode(
-          on: _i1.NamedTypeNode(
-        name: _i1.NameNode(value: 'Person'),
-        isNonNull: false,
-      )),
-      directives: [],
-      selectionSet: _i1.SelectionSetNode(selections: [
-        _i1.FieldNode(
-          name: _i1.NameNode(value: 'firstName'),
-          alias: null,
-          arguments: [],
-          directives: [],
-          selectionSet: null,
-        ),
-        _i1.FieldNode(
-          name: _i1.NameNode(value: 'lastName'),
-          alias: null,
-          arguments: [],
-          directives: [],
-          selectionSet: null,
-        ),
-      ]),
-    ),
-    _i1.InlineFragmentNode(
-      typeCondition: _i1.TypeConditionNode(
-          on: _i1.NamedTypeNode(
-        name: _i1.NameNode(value: 'Company'),
-        isNonNull: false,
-      )),
-      directives: [],
-      selectionSet: _i1.SelectionSetNode(selections: [
-        _i1.FieldNode(
-          name: _i1.NameNode(value: 'name'),
-          alias: null,
-          arguments: [],
-          directives: [],
-          selectionSet: null,
-        )
-      ]),
-    ),
-  ]),
-);
 const BookFragment = _i1.FragmentDefinitionNode(
   name: _i1.NameNode(value: 'BookFragment'),
   typeCondition: _i1.TypeConditionNode(
@@ -147,8 +88,168 @@ const BookFragment = _i1.FragmentDefinitionNode(
     ),
   ]),
 );
+const AuthorFragment = _i1.FragmentDefinitionNode(
+  name: _i1.NameNode(value: 'AuthorFragment'),
+  typeCondition: _i1.TypeConditionNode(
+      on: _i1.NamedTypeNode(
+    name: _i1.NameNode(value: 'Author'),
+    isNonNull: false,
+  )),
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'displayName'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Person'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FragmentSpreadNode(
+          name: _i1.NameNode(value: 'AuthorPersonFragment'),
+          directives: [],
+        )
+      ]),
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Company'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FragmentSpreadNode(
+          name: _i1.NameNode(value: 'AuthorCompanyFragment'),
+          directives: [],
+        )
+      ]),
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Group'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'members'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: _i1.SelectionSetNode(selections: [
+            _i1.FragmentSpreadNode(
+              name: _i1.NameNode(value: 'AuthorGroupFragment'),
+              directives: [],
+            )
+          ]),
+        )
+      ]),
+    ),
+  ]),
+);
+const AuthorPersonFragment = _i1.FragmentDefinitionNode(
+  name: _i1.NameNode(value: 'AuthorPersonFragment'),
+  typeCondition: _i1.TypeConditionNode(
+      on: _i1.NamedTypeNode(
+    name: _i1.NameNode(value: 'Person'),
+    isNonNull: false,
+  )),
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'firstName'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    ),
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'lastName'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    ),
+  ]),
+);
+const AuthorCompanyFragment = _i1.FragmentDefinitionNode(
+  name: _i1.NameNode(value: 'AuthorCompanyFragment'),
+  typeCondition: _i1.TypeConditionNode(
+      on: _i1.NamedTypeNode(
+    name: _i1.NameNode(value: 'Company'),
+    isNonNull: false,
+  )),
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'name'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    )
+  ]),
+);
+const AuthorGroupFragment = _i1.FragmentDefinitionNode(
+  name: _i1.NameNode(value: 'AuthorGroupFragment'),
+  typeCondition: _i1.TypeConditionNode(
+      on: _i1.NamedTypeNode(
+    name: _i1.NameNode(value: 'Author'),
+    isNonNull: false,
+  )),
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'displayName'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Person'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FragmentSpreadNode(
+          name: _i1.NameNode(value: 'AuthorPersonFragment'),
+          directives: [],
+        )
+      ]),
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Company'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FragmentSpreadNode(
+          name: _i1.NameNode(value: 'AuthorCompanyFragment'),
+          directives: [],
+        )
+      ]),
+    ),
+  ]),
+);
 const document = _i1.DocumentNode(definitions: [
   GetBooks,
-  AuthorFragment,
   BookFragment,
+  AuthorFragment,
+  AuthorPersonFragment,
+  AuthorCompanyFragment,
+  AuthorGroupFragment,
 ]);

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.ast.gql.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:gql/ast.dart' as _i1;
+
+const GetBooks = _i1.OperationDefinitionNode(
+  type: _i1.OperationType.query,
+  name: _i1.NameNode(value: 'GetBooks'),
+  variableDefinitions: [],
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'books'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FragmentSpreadNode(
+          name: _i1.NameNode(value: 'BookFragment'),
+          directives: [],
+        )
+      ]),
+    )
+  ]),
+);
+const AuthorFragment = _i1.FragmentDefinitionNode(
+  name: _i1.NameNode(value: 'AuthorFragment'),
+  typeCondition: _i1.TypeConditionNode(
+      on: _i1.NamedTypeNode(
+    name: _i1.NameNode(value: 'Author'),
+    isNonNull: false,
+  )),
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'displayName'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Person'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'firstName'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'lastName'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        ),
+      ]),
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Company'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'name'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        )
+      ]),
+    ),
+  ]),
+);
+const BookFragment = _i1.FragmentDefinitionNode(
+  name: _i1.NameNode(value: 'BookFragment'),
+  typeCondition: _i1.TypeConditionNode(
+      on: _i1.NamedTypeNode(
+    name: _i1.NameNode(value: 'Book'),
+    isNonNull: false,
+  )),
+  directives: [],
+  selectionSet: _i1.SelectionSetNode(selections: [
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'author'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FragmentSpreadNode(
+          name: _i1.NameNode(value: 'AuthorFragment'),
+          directives: [],
+        )
+      ]),
+    ),
+    _i1.FieldNode(
+      name: _i1.NameNode(value: 'title'),
+      alias: null,
+      arguments: [],
+      directives: [],
+      selectionSet: null,
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Textbook'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'courses'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        )
+      ]),
+    ),
+    _i1.InlineFragmentNode(
+      typeCondition: _i1.TypeConditionNode(
+          on: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'ColoringBook'),
+        isNonNull: false,
+      )),
+      directives: [],
+      selectionSet: _i1.SelectionSetNode(selections: [
+        _i1.FieldNode(
+          name: _i1.NameNode(value: 'colors'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null,
+        )
+      ]),
+    ),
+  ]),
+);
+const document = _i1.DocumentNode(definitions: [
+  GetBooks,
+  AuthorFragment,
+  BookFragment,
+]);

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.dart
@@ -500,8 +500,7 @@ abstract class GGetBooksData_books__asTextbook_author__asPerson
         GGetBooksData_books_author,
         GAuthorFragment,
         GBookFragment_author__asPerson,
-        GBookFragment,
-        GBookFragment__asPerson,
+        GBookFragment__asTextbook_author__asPerson,
         GGetBooksData_books_author__asPerson,
         GAuthorFragment__asPerson,
         GGetBooksData_books__asTextbook_author {
@@ -549,8 +548,7 @@ abstract class GGetBooksData_books__asTextbook_author__asCompany
         GGetBooksData_books_author,
         GAuthorFragment,
         GBookFragment_author__asCompany,
-        GBookFragment,
-        GBookFragment__asCompany,
+        GBookFragment__asTextbook_author__asCompany,
         GGetBooksData_books_author__asCompany,
         GAuthorFragment__asCompany,
         GGetBooksData_books__asTextbook_author {
@@ -753,8 +751,7 @@ abstract class GGetBooksData_books__asColoringBook_author__asPerson
         GGetBooksData_books_author,
         GAuthorFragment,
         GBookFragment_author__asPerson,
-        GBookFragment,
-        GBookFragment__asPerson,
+        GBookFragment__asColoringBook_author__asPerson,
         GGetBooksData_books_author__asPerson,
         GAuthorFragment__asPerson,
         GGetBooksData_books__asColoringBook_author {
@@ -804,8 +801,7 @@ abstract class GGetBooksData_books__asColoringBook_author__asCompany
         GGetBooksData_books_author,
         GAuthorFragment,
         GBookFragment_author__asCompany,
-        GBookFragment,
-        GBookFragment__asCompany,
+        GBookFragment__asColoringBook_author__asCompany,
         GGetBooksData_books_author__asCompany,
         GAuthorFragment__asCompany,
         GGetBooksData_books__asColoringBook_author {
@@ -2025,8 +2021,7 @@ abstract class GBookFragmentData__asTextbook_author__asPerson
         GBookFragmentData_author,
         GAuthorFragment,
         GBookFragment_author__asPerson,
-        GBookFragment,
-        GBookFragment__asPerson,
+        GBookFragment__asTextbook_author__asPerson,
         GBookFragmentData_author__asPerson,
         GAuthorFragment__asPerson,
         GBookFragmentData__asTextbook_author {
@@ -2074,8 +2069,7 @@ abstract class GBookFragmentData__asTextbook_author__asCompany
         GBookFragmentData_author,
         GAuthorFragment,
         GBookFragment_author__asCompany,
-        GBookFragment,
-        GBookFragment__asCompany,
+        GBookFragment__asTextbook_author__asCompany,
         GBookFragmentData_author__asCompany,
         GAuthorFragment__asCompany,
         GBookFragmentData__asTextbook_author {
@@ -2276,8 +2270,7 @@ abstract class GBookFragmentData__asColoringBook_author__asPerson
         GBookFragmentData_author,
         GAuthorFragment,
         GBookFragment_author__asPerson,
-        GBookFragment,
-        GBookFragment__asPerson,
+        GBookFragment__asColoringBook_author__asPerson,
         GBookFragmentData_author__asPerson,
         GAuthorFragment__asPerson,
         GBookFragmentData__asColoringBook_author {
@@ -2327,8 +2320,7 @@ abstract class GBookFragmentData__asColoringBook_author__asCompany
         GBookFragmentData_author,
         GAuthorFragment,
         GBookFragment_author__asCompany,
-        GBookFragment,
-        GBookFragment__asCompany,
+        GBookFragment__asColoringBook_author__asCompany,
         GBookFragmentData_author__asCompany,
         GAuthorFragment__asCompany,
         GBookFragmentData__asColoringBook_author {

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.dart
@@ -1,0 +1,2452 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:built_collection/built_collection.dart';
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/graphql/__generated__/serializers.gql.dart'
+    as _i1;
+import 'package:gql_code_builder_serializers/gql_code_builder_serializers.dart'
+    as _i2;
+
+part 'nested_fragments_on_interface.data.gql.g.dart';
+
+abstract class GGetBooksData
+    implements Built<GGetBooksData, GGetBooksDataBuilder> {
+  GGetBooksData._();
+
+  factory GGetBooksData([void Function(GGetBooksDataBuilder b) updates]) =
+      _$GGetBooksData;
+
+  static void _initializeBuilder(GGetBooksDataBuilder b) =>
+      b..G__typename = 'Query';
+
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  BuiltList<GGetBooksData_books> get books;
+  static Serializer<GGetBooksData> get serializer => _$gGetBooksDataSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books implements GBookFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GGetBooksData_books_author get author;
+  @override
+  String get title;
+  static Serializer<GGetBooksData_books> get serializer =>
+      _i2.InlineFragmentSerializer<GGetBooksData_books>(
+        'GGetBooksData_books',
+        GGetBooksData_books__base,
+        {
+          'Textbook': GGetBooksData_books__asTextbook,
+          'ColoringBook': GGetBooksData_books__asColoringBook,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_booksWhenExtension on GGetBooksData_books {
+  _T when<_T>({
+    required _T Function(GGetBooksData_books__asTextbook) textbook,
+    required _T Function(GGetBooksData_books__asColoringBook) coloringBook,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Textbook':
+        return textbook((this as GGetBooksData_books__asTextbook));
+      case 'ColoringBook':
+        return coloringBook((this as GGetBooksData_books__asColoringBook));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GGetBooksData_books__asTextbook)? textbook,
+    _T Function(GGetBooksData_books__asColoringBook)? coloringBook,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Textbook':
+        return textbook != null
+            ? textbook((this as GGetBooksData_books__asTextbook))
+            : orElse();
+      case 'ColoringBook':
+        return coloringBook != null
+            ? coloringBook((this as GGetBooksData_books__asColoringBook))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__base
+    implements
+        Built<GGetBooksData_books__base, GGetBooksData_books__baseBuilder>,
+        GGetBooksData_books,
+        GBookFragment {
+  GGetBooksData_books__base._();
+
+  factory GGetBooksData_books__base(
+          [void Function(GGetBooksData_books__baseBuilder b) updates]) =
+      _$GGetBooksData_books__base;
+
+  static void _initializeBuilder(GGetBooksData_books__baseBuilder b) =>
+      b..G__typename = 'Book';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GGetBooksData_books__base_author get author;
+  @override
+  String get title;
+  static Serializer<GGetBooksData_books__base> get serializer =>
+      _$gGetBooksDataBooksBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author
+    implements
+        GGetBooksData_books_author,
+        GBookFragment_author,
+        GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__base_author> get serializer =>
+      _i2.InlineFragmentSerializer<GGetBooksData_books__base_author>(
+        'GGetBooksData_books__base_author',
+        GGetBooksData_books__base_author__base,
+        {
+          'Person': GGetBooksData_books__base_author__asPerson,
+          'Company': GGetBooksData_books__base_author__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_books__base_authorWhenExtension
+    on GGetBooksData_books__base_author {
+  _T when<_T>({
+    required _T Function(GGetBooksData_books__base_author__asPerson) person,
+    required _T Function(GGetBooksData_books__base_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GGetBooksData_books__base_author__asPerson));
+      case 'Company':
+        return company((this as GGetBooksData_books__base_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GGetBooksData_books__base_author__asPerson)? person,
+    _T Function(GGetBooksData_books__base_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GGetBooksData_books__base_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GGetBooksData_books__base_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__base_author__base
+    implements
+        Built<GGetBooksData_books__base_author__base,
+            GGetBooksData_books__base_author__baseBuilder>,
+        GGetBooksData_books__base_author,
+        GAuthorFragment {
+  GGetBooksData_books__base_author__base._();
+
+  factory GGetBooksData_books__base_author__base(
+      [void Function(GGetBooksData_books__base_author__baseBuilder b)
+          updates]) = _$GGetBooksData_books__base_author__base;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__base_author__base> get serializer =>
+      _$gGetBooksDataBooksBaseAuthorBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__base.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author__asPerson
+    implements
+        Built<GGetBooksData_books__base_author__asPerson,
+            GGetBooksData_books__base_author__asPersonBuilder>,
+        GGetBooksData_books_author,
+        GBookFragment_author,
+        GAuthorFragment,
+        GGetBooksData_books_author__asPerson,
+        GBookFragment_author__asPerson,
+        GAuthorFragment__asPerson,
+        GGetBooksData_books__base_author {
+  GGetBooksData_books__base_author__asPerson._();
+
+  factory GGetBooksData_books__base_author__asPerson(
+      [void Function(GGetBooksData_books__base_author__asPersonBuilder b)
+          updates]) = _$GGetBooksData_books__base_author__asPerson;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GGetBooksData_books__base_author__asPerson>
+      get serializer => _$gGetBooksDataBooksBaseAuthorAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author__asCompany
+    implements
+        Built<GGetBooksData_books__base_author__asCompany,
+            GGetBooksData_books__base_author__asCompanyBuilder>,
+        GGetBooksData_books_author,
+        GBookFragment_author,
+        GAuthorFragment,
+        GGetBooksData_books_author__asCompany,
+        GBookFragment_author__asCompany,
+        GAuthorFragment__asCompany,
+        GGetBooksData_books__base_author {
+  GGetBooksData_books__base_author__asCompany._();
+
+  factory GGetBooksData_books__base_author__asCompany(
+      [void Function(GGetBooksData_books__base_author__asCompanyBuilder b)
+          updates]) = _$GGetBooksData_books__base_author__asCompany;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GGetBooksData_books__base_author__asCompany>
+      get serializer => _$gGetBooksDataBooksBaseAuthorAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asTextbook
+    implements
+        Built<GGetBooksData_books__asTextbook,
+            GGetBooksData_books__asTextbookBuilder>,
+        GBookFragment,
+        GBookFragment__asTextbook,
+        GGetBooksData_books {
+  GGetBooksData_books__asTextbook._();
+
+  factory GGetBooksData_books__asTextbook(
+          [void Function(GGetBooksData_books__asTextbookBuilder b) updates]) =
+      _$GGetBooksData_books__asTextbook;
+
+  static void _initializeBuilder(GGetBooksData_books__asTextbookBuilder b) =>
+      b..G__typename = 'Textbook';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GGetBooksData_books__asTextbook_author get author;
+  @override
+  String get title;
+  @override
+  BuiltList<String> get courses;
+  static Serializer<GGetBooksData_books__asTextbook> get serializer =>
+      _$gGetBooksDataBooksAsTextbookSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asTextbook_author
+    implements
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__asTextbook_author> get serializer =>
+      _i2.InlineFragmentSerializer<GGetBooksData_books__asTextbook_author>(
+        'GGetBooksData_books__asTextbook_author',
+        GGetBooksData_books__asTextbook_author__base,
+        {
+          'Person': GGetBooksData_books__asTextbook_author__asPerson,
+          'Company': GGetBooksData_books__asTextbook_author__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook_author.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_books__asTextbook_authorWhenExtension
+    on GGetBooksData_books__asTextbook_author {
+  _T when<_T>({
+    required _T Function(GGetBooksData_books__asTextbook_author__asPerson)
+        person,
+    required _T Function(GGetBooksData_books__asTextbook_author__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person(
+            (this as GGetBooksData_books__asTextbook_author__asPerson));
+      case 'Company':
+        return company(
+            (this as GGetBooksData_books__asTextbook_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GGetBooksData_books__asTextbook_author__asPerson)? person,
+    _T Function(GGetBooksData_books__asTextbook_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GGetBooksData_books__asTextbook_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company(
+                (this as GGetBooksData_books__asTextbook_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__asTextbook_author__base
+    implements
+        Built<GGetBooksData_books__asTextbook_author__base,
+            GGetBooksData_books__asTextbook_author__baseBuilder>,
+        GGetBooksData_books__asTextbook_author,
+        GAuthorFragment {
+  GGetBooksData_books__asTextbook_author__base._();
+
+  factory GGetBooksData_books__asTextbook_author__base(
+      [void Function(GGetBooksData_books__asTextbook_author__baseBuilder b)
+          updates]) = _$GGetBooksData_books__asTextbook_author__base;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__asTextbook_author__base>
+      get serializer => _$gGetBooksDataBooksAsTextbookAuthorBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook_author__base.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asPerson
+    implements
+        Built<GGetBooksData_books__asTextbook_author__asPerson,
+            GGetBooksData_books__asTextbook_author__asPersonBuilder>,
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GBookFragment,
+        GBookFragment__asPerson,
+        GGetBooksData_books_author__asPerson,
+        GAuthorFragment__asPerson,
+        GGetBooksData_books__asTextbook_author {
+  GGetBooksData_books__asTextbook_author__asPerson._();
+
+  factory GGetBooksData_books__asTextbook_author__asPerson(
+      [void Function(GGetBooksData_books__asTextbook_author__asPersonBuilder b)
+          updates]) = _$GGetBooksData_books__asTextbook_author__asPerson;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GGetBooksData_books__asTextbook_author__asPerson>
+      get serializer => _$gGetBooksDataBooksAsTextbookAuthorAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook_author__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asCompany
+    implements
+        Built<GGetBooksData_books__asTextbook_author__asCompany,
+            GGetBooksData_books__asTextbook_author__asCompanyBuilder>,
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GBookFragment,
+        GBookFragment__asCompany,
+        GGetBooksData_books_author__asCompany,
+        GAuthorFragment__asCompany,
+        GGetBooksData_books__asTextbook_author {
+  GGetBooksData_books__asTextbook_author__asCompany._();
+
+  factory GGetBooksData_books__asTextbook_author__asCompany(
+      [void Function(GGetBooksData_books__asTextbook_author__asCompanyBuilder b)
+          updates]) = _$GGetBooksData_books__asTextbook_author__asCompany;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GGetBooksData_books__asTextbook_author__asCompany>
+      get serializer => _$gGetBooksDataBooksAsTextbookAuthorAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asColoringBook
+    implements
+        Built<GGetBooksData_books__asColoringBook,
+            GGetBooksData_books__asColoringBookBuilder>,
+        GBookFragment,
+        GBookFragment__asColoringBook,
+        GGetBooksData_books {
+  GGetBooksData_books__asColoringBook._();
+
+  factory GGetBooksData_books__asColoringBook(
+      [void Function(GGetBooksData_books__asColoringBookBuilder b)
+          updates]) = _$GGetBooksData_books__asColoringBook;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBookBuilder b) =>
+      b..G__typename = 'ColoringBook';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GGetBooksData_books__asColoringBook_author get author;
+  @override
+  String get title;
+  @override
+  BuiltList<String> get colors;
+  static Serializer<GGetBooksData_books__asColoringBook> get serializer =>
+      _$gGetBooksDataBooksAsColoringBookSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asColoringBook_author
+    implements
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__asColoringBook_author>
+      get serializer => _i2.InlineFragmentSerializer<
+              GGetBooksData_books__asColoringBook_author>(
+            'GGetBooksData_books__asColoringBook_author',
+            GGetBooksData_books__asColoringBook_author__base,
+            {
+              'Person': GGetBooksData_books__asColoringBook_author__asPerson,
+              'Company': GGetBooksData_books__asColoringBook_author__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook_author.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_books__asColoringBook_authorWhenExtension
+    on GGetBooksData_books__asColoringBook_author {
+  _T when<_T>({
+    required _T Function(GGetBooksData_books__asColoringBook_author__asPerson)
+        person,
+    required _T Function(GGetBooksData_books__asColoringBook_author__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person(
+            (this as GGetBooksData_books__asColoringBook_author__asPerson));
+      case 'Company':
+        return company(
+            (this as GGetBooksData_books__asColoringBook_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GGetBooksData_books__asColoringBook_author__asPerson)? person,
+    _T Function(GGetBooksData_books__asColoringBook_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person(
+                (this as GGetBooksData_books__asColoringBook_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company(
+                (this as GGetBooksData_books__asColoringBook_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__base
+    implements
+        Built<GGetBooksData_books__asColoringBook_author__base,
+            GGetBooksData_books__asColoringBook_author__baseBuilder>,
+        GGetBooksData_books__asColoringBook_author,
+        GAuthorFragment {
+  GGetBooksData_books__asColoringBook_author__base._();
+
+  factory GGetBooksData_books__asColoringBook_author__base(
+      [void Function(GGetBooksData_books__asColoringBook_author__baseBuilder b)
+          updates]) = _$GGetBooksData_books__asColoringBook_author__base;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__asColoringBook_author__base>
+      get serializer => _$gGetBooksDataBooksAsColoringBookAuthorBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook_author__base.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__asPerson
+    implements
+        Built<GGetBooksData_books__asColoringBook_author__asPerson,
+            GGetBooksData_books__asColoringBook_author__asPersonBuilder>,
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GBookFragment,
+        GBookFragment__asPerson,
+        GGetBooksData_books_author__asPerson,
+        GAuthorFragment__asPerson,
+        GGetBooksData_books__asColoringBook_author {
+  GGetBooksData_books__asColoringBook_author__asPerson._();
+
+  factory GGetBooksData_books__asColoringBook_author__asPerson(
+      [void Function(
+              GGetBooksData_books__asColoringBook_author__asPersonBuilder b)
+          updates]) = _$GGetBooksData_books__asColoringBook_author__asPerson;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GGetBooksData_books__asColoringBook_author__asPerson>
+      get serializer =>
+          _$gGetBooksDataBooksAsColoringBookAuthorAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook_author__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__asCompany
+    implements
+        Built<GGetBooksData_books__asColoringBook_author__asCompany,
+            GGetBooksData_books__asColoringBook_author__asCompanyBuilder>,
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GBookFragment,
+        GBookFragment__asCompany,
+        GGetBooksData_books_author__asCompany,
+        GAuthorFragment__asCompany,
+        GGetBooksData_books__asColoringBook_author {
+  GGetBooksData_books__asColoringBook_author__asCompany._();
+
+  factory GGetBooksData_books__asColoringBook_author__asCompany(
+      [void Function(
+              GGetBooksData_books__asColoringBook_author__asCompanyBuilder b)
+          updates]) = _$GGetBooksData_books__asColoringBook_author__asCompany;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GGetBooksData_books__asColoringBook_author__asCompany>
+      get serializer =>
+          _$gGetBooksDataBooksAsColoringBookAuthorAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books_author
+    implements GBookFragment_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GGetBooksData_books_authorWhenExtension
+    on GGetBooksData_books_author {
+  _T when<_T>({
+    required _T Function(GGetBooksData_books_author__asPerson) person,
+    required _T Function(GGetBooksData_books_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GGetBooksData_books_author__asPerson));
+      case 'Company':
+        return company((this as GGetBooksData_books_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GGetBooksData_books_author__asPerson)? person,
+    _T Function(GGetBooksData_books_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GGetBooksData_books_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GGetBooksData_books_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books_author__base
+    implements GGetBooksData_books_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GGetBooksData_books_author__asPerson
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GAuthorFragment__asPerson,
+        GGetBooksData_books_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GGetBooksData_books_author__asCompany
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GAuthorFragment__asCompany,
+        GGetBooksData_books_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GAuthorFragment {
+  String get G__typename;
+  String get displayName;
+}
+
+extension GAuthorFragmentWhenExtension on GAuthorFragment {
+  _T when<_T>({
+    required _T Function(GAuthorFragment__asPerson) person,
+    required _T Function(GAuthorFragment__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorFragment__asPerson));
+      case 'Company':
+        return company((this as GAuthorFragment__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorFragment__asPerson)? person,
+    _T Function(GAuthorFragment__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorFragment__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorFragment__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorFragment__base implements GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GAuthorFragment__asPerson implements GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  String get firstName;
+  String get lastName;
+}
+
+abstract class GAuthorFragment__asCompany implements GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  String get name;
+}
+
+abstract class GAuthorFragmentData implements GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorFragmentData> get serializer =>
+      _i2.InlineFragmentSerializer<GAuthorFragmentData>(
+        'GAuthorFragmentData',
+        GAuthorFragmentData__base,
+        {
+          'Person': GAuthorFragmentData__asPerson,
+          'Company': GAuthorFragmentData__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData.serializer,
+        json,
+      );
+}
+
+extension GAuthorFragmentDataWhenExtension on GAuthorFragmentData {
+  _T when<_T>({
+    required _T Function(GAuthorFragmentData__asPerson) person,
+    required _T Function(GAuthorFragmentData__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorFragmentData__asPerson));
+      case 'Company':
+        return company((this as GAuthorFragmentData__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorFragmentData__asPerson)? person,
+    _T Function(GAuthorFragmentData__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorFragmentData__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorFragmentData__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorFragmentData__base
+    implements
+        Built<GAuthorFragmentData__base, GAuthorFragmentData__baseBuilder>,
+        GAuthorFragmentData {
+  GAuthorFragmentData__base._();
+
+  factory GAuthorFragmentData__base(
+          [void Function(GAuthorFragmentData__baseBuilder b) updates]) =
+      _$GAuthorFragmentData__base;
+
+  static void _initializeBuilder(GAuthorFragmentData__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorFragmentData__base> get serializer =>
+      _$gAuthorFragmentDataBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__base? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__base.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asPerson
+    implements
+        Built<GAuthorFragmentData__asPerson,
+            GAuthorFragmentData__asPersonBuilder>,
+        GAuthorFragment,
+        GAuthorFragment__asPerson,
+        GAuthorFragmentData {
+  GAuthorFragmentData__asPerson._();
+
+  factory GAuthorFragmentData__asPerson(
+          [void Function(GAuthorFragmentData__asPersonBuilder b) updates]) =
+      _$GAuthorFragmentData__asPerson;
+
+  static void _initializeBuilder(GAuthorFragmentData__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GAuthorFragmentData__asPerson> get serializer =>
+      _$gAuthorFragmentDataAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asPerson? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asCompany
+    implements
+        Built<GAuthorFragmentData__asCompany,
+            GAuthorFragmentData__asCompanyBuilder>,
+        GAuthorFragment,
+        GAuthorFragment__asCompany,
+        GAuthorFragmentData {
+  GAuthorFragmentData__asCompany._();
+
+  factory GAuthorFragmentData__asCompany(
+          [void Function(GAuthorFragmentData__asCompanyBuilder b) updates]) =
+      _$GAuthorFragmentData__asCompany;
+
+  static void _initializeBuilder(GAuthorFragmentData__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GAuthorFragmentData__asCompany> get serializer =>
+      _$gAuthorFragmentDataAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asCompany? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragment {
+  String get G__typename;
+  GBookFragment_author get author;
+  String get title;
+}
+
+extension GBookFragmentWhenExtension on GBookFragment {
+  _T when<_T>({
+    required _T Function(GBookFragment__asTextbook) textbook,
+    required _T Function(GBookFragment__asColoringBook) coloringBook,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Textbook':
+        return textbook((this as GBookFragment__asTextbook));
+      case 'ColoringBook':
+        return coloringBook((this as GBookFragment__asColoringBook));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment__asTextbook)? textbook,
+    _T Function(GBookFragment__asColoringBook)? coloringBook,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Textbook':
+        return textbook != null
+            ? textbook((this as GBookFragment__asTextbook))
+            : orElse();
+      case 'ColoringBook':
+        return coloringBook != null
+            ? coloringBook((this as GBookFragment__asColoringBook))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__base implements GBookFragment {
+  @override
+  String get G__typename;
+  @override
+  GBookFragment__base_author get author;
+  @override
+  String get title;
+}
+
+abstract class GBookFragment__base_author
+    implements GBookFragment_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment__base_authorWhenExtension
+    on GBookFragment__base_author {
+  _T when<_T>({
+    required _T Function(GBookFragment__base_author__asPerson) person,
+    required _T Function(GBookFragment__base_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragment__base_author__asPerson));
+      case 'Company':
+        return company((this as GBookFragment__base_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment__base_author__asPerson)? person,
+    _T Function(GBookFragment__base_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragment__base_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragment__base_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__base_author__base
+    implements GBookFragment__base_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment__base_author__asPerson
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragment__base_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment__base_author__asCompany
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragment__base_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment__asTextbook implements GBookFragment {
+  @override
+  String get G__typename;
+  @override
+  GBookFragment__asTextbook_author get author;
+  @override
+  String get title;
+  BuiltList<String> get courses;
+}
+
+abstract class GBookFragment__asTextbook_author
+    implements GBookFragment_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment__asTextbook_authorWhenExtension
+    on GBookFragment__asTextbook_author {
+  _T when<_T>({
+    required _T Function(GBookFragment__asTextbook_author__asPerson) person,
+    required _T Function(GBookFragment__asTextbook_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragment__asTextbook_author__asPerson));
+      case 'Company':
+        return company((this as GBookFragment__asTextbook_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment__asTextbook_author__asPerson)? person,
+    _T Function(GBookFragment__asTextbook_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragment__asTextbook_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragment__asTextbook_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__asTextbook_author__base
+    implements GBookFragment__asTextbook_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment__asTextbook_author__asPerson
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragment__asTextbook_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment__asTextbook_author__asCompany
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragment__asTextbook_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment__asColoringBook implements GBookFragment {
+  @override
+  String get G__typename;
+  @override
+  GBookFragment__asColoringBook_author get author;
+  @override
+  String get title;
+  BuiltList<String> get colors;
+}
+
+abstract class GBookFragment__asColoringBook_author
+    implements GBookFragment_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment__asColoringBook_authorWhenExtension
+    on GBookFragment__asColoringBook_author {
+  _T when<_T>({
+    required _T Function(GBookFragment__asColoringBook_author__asPerson) person,
+    required _T Function(GBookFragment__asColoringBook_author__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragment__asColoringBook_author__asPerson));
+      case 'Company':
+        return company(
+            (this as GBookFragment__asColoringBook_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment__asColoringBook_author__asPerson)? person,
+    _T Function(GBookFragment__asColoringBook_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragment__asColoringBook_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragment__asColoringBook_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__asColoringBook_author__base
+    implements GBookFragment__asColoringBook_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment__asColoringBook_author__asPerson
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragment__asColoringBook_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment__asColoringBook_author__asCompany
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragment__asColoringBook_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment_author implements GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment_authorWhenExtension on GBookFragment_author {
+  _T when<_T>({
+    required _T Function(GBookFragment_author__asPerson) person,
+    required _T Function(GBookFragment_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragment_author__asPerson));
+      case 'Company':
+        return company((this as GBookFragment_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment_author__asPerson)? person,
+    _T Function(GBookFragment_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragment_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragment_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment_author__base
+    implements GBookFragment_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment_author__asPerson
+    implements
+        GAuthorFragment,
+        GAuthorFragment__asPerson,
+        GBookFragment_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment_author__asCompany
+    implements
+        GAuthorFragment,
+        GAuthorFragment__asCompany,
+        GBookFragment_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragmentData implements GBookFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GBookFragmentData_author get author;
+  @override
+  String get title;
+  static Serializer<GBookFragmentData> get serializer =>
+      _i2.InlineFragmentSerializer<GBookFragmentData>(
+        'GBookFragmentData',
+        GBookFragmentData__base,
+        {
+          'Textbook': GBookFragmentData__asTextbook,
+          'ColoringBook': GBookFragmentData__asColoringBook,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentDataWhenExtension on GBookFragmentData {
+  _T when<_T>({
+    required _T Function(GBookFragmentData__asTextbook) textbook,
+    required _T Function(GBookFragmentData__asColoringBook) coloringBook,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Textbook':
+        return textbook((this as GBookFragmentData__asTextbook));
+      case 'ColoringBook':
+        return coloringBook((this as GBookFragmentData__asColoringBook));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData__asTextbook)? textbook,
+    _T Function(GBookFragmentData__asColoringBook)? coloringBook,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Textbook':
+        return textbook != null
+            ? textbook((this as GBookFragmentData__asTextbook))
+            : orElse();
+      case 'ColoringBook':
+        return coloringBook != null
+            ? coloringBook((this as GBookFragmentData__asColoringBook))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__base
+    implements
+        Built<GBookFragmentData__base, GBookFragmentData__baseBuilder>,
+        GBookFragmentData {
+  GBookFragmentData__base._();
+
+  factory GBookFragmentData__base(
+          [void Function(GBookFragmentData__baseBuilder b) updates]) =
+      _$GBookFragmentData__base;
+
+  static void _initializeBuilder(GBookFragmentData__baseBuilder b) =>
+      b..G__typename = 'Book';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GBookFragmentData__base_author get author;
+  @override
+  String get title;
+  static Serializer<GBookFragmentData__base> get serializer =>
+      _$gBookFragmentDataBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author
+    implements GBookFragmentData_author, GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__base_author> get serializer =>
+      _i2.InlineFragmentSerializer<GBookFragmentData__base_author>(
+        'GBookFragmentData__base_author',
+        GBookFragmentData__base_author__base,
+        {
+          'Person': GBookFragmentData__base_author__asPerson,
+          'Company': GBookFragmentData__base_author__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentData__base_authorWhenExtension
+    on GBookFragmentData__base_author {
+  _T when<_T>({
+    required _T Function(GBookFragmentData__base_author__asPerson) person,
+    required _T Function(GBookFragmentData__base_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragmentData__base_author__asPerson));
+      case 'Company':
+        return company((this as GBookFragmentData__base_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData__base_author__asPerson)? person,
+    _T Function(GBookFragmentData__base_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragmentData__base_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragmentData__base_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__base_author__base
+    implements
+        Built<GBookFragmentData__base_author__base,
+            GBookFragmentData__base_author__baseBuilder>,
+        GBookFragmentData__base_author,
+        GAuthorFragment {
+  GBookFragmentData__base_author__base._();
+
+  factory GBookFragmentData__base_author__base(
+      [void Function(GBookFragmentData__base_author__baseBuilder b)
+          updates]) = _$GBookFragmentData__base_author__base;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__base_author__base> get serializer =>
+      _$gBookFragmentDataBaseAuthorBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__base.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author__asPerson
+    implements
+        Built<GBookFragmentData__base_author__asPerson,
+            GBookFragmentData__base_author__asPersonBuilder>,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragmentData_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragmentData__base_author {
+  GBookFragmentData__base_author__asPerson._();
+
+  factory GBookFragmentData__base_author__asPerson(
+      [void Function(GBookFragmentData__base_author__asPersonBuilder b)
+          updates]) = _$GBookFragmentData__base_author__asPerson;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GBookFragmentData__base_author__asPerson> get serializer =>
+      _$gBookFragmentDataBaseAuthorAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author__asCompany
+    implements
+        Built<GBookFragmentData__base_author__asCompany,
+            GBookFragmentData__base_author__asCompanyBuilder>,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragmentData_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragmentData__base_author {
+  GBookFragmentData__base_author__asCompany._();
+
+  factory GBookFragmentData__base_author__asCompany(
+      [void Function(GBookFragmentData__base_author__asCompanyBuilder b)
+          updates]) = _$GBookFragmentData__base_author__asCompany;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GBookFragmentData__base_author__asCompany> get serializer =>
+      _$gBookFragmentDataBaseAuthorAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asTextbook
+    implements
+        Built<GBookFragmentData__asTextbook,
+            GBookFragmentData__asTextbookBuilder>,
+        GBookFragment,
+        GBookFragment__asTextbook,
+        GBookFragmentData {
+  GBookFragmentData__asTextbook._();
+
+  factory GBookFragmentData__asTextbook(
+          [void Function(GBookFragmentData__asTextbookBuilder b) updates]) =
+      _$GBookFragmentData__asTextbook;
+
+  static void _initializeBuilder(GBookFragmentData__asTextbookBuilder b) =>
+      b..G__typename = 'Textbook';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GBookFragmentData__asTextbook_author get author;
+  @override
+  String get title;
+  @override
+  BuiltList<String> get courses;
+  static Serializer<GBookFragmentData__asTextbook> get serializer =>
+      _$gBookFragmentDataAsTextbookSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asTextbook_author
+    implements
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GBookFragmentData_author,
+        GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asTextbook_author> get serializer =>
+      _i2.InlineFragmentSerializer<GBookFragmentData__asTextbook_author>(
+        'GBookFragmentData__asTextbook_author',
+        GBookFragmentData__asTextbook_author__base,
+        {
+          'Person': GBookFragmentData__asTextbook_author__asPerson,
+          'Company': GBookFragmentData__asTextbook_author__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentData__asTextbook_authorWhenExtension
+    on GBookFragmentData__asTextbook_author {
+  _T when<_T>({
+    required _T Function(GBookFragmentData__asTextbook_author__asPerson) person,
+    required _T Function(GBookFragmentData__asTextbook_author__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragmentData__asTextbook_author__asPerson));
+      case 'Company':
+        return company(
+            (this as GBookFragmentData__asTextbook_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData__asTextbook_author__asPerson)? person,
+    _T Function(GBookFragmentData__asTextbook_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragmentData__asTextbook_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragmentData__asTextbook_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__asTextbook_author__base
+    implements
+        Built<GBookFragmentData__asTextbook_author__base,
+            GBookFragmentData__asTextbook_author__baseBuilder>,
+        GBookFragmentData__asTextbook_author,
+        GAuthorFragment {
+  GBookFragmentData__asTextbook_author__base._();
+
+  factory GBookFragmentData__asTextbook_author__base(
+      [void Function(GBookFragmentData__asTextbook_author__baseBuilder b)
+          updates]) = _$GBookFragmentData__asTextbook_author__base;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asTextbook_author__base>
+      get serializer => _$gBookFragmentDataAsTextbookAuthorBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author__base.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asTextbook_author__asPerson
+    implements
+        Built<GBookFragmentData__asTextbook_author__asPerson,
+            GBookFragmentData__asTextbook_author__asPersonBuilder>,
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GBookFragment,
+        GBookFragment__asPerson,
+        GBookFragmentData_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragmentData__asTextbook_author {
+  GBookFragmentData__asTextbook_author__asPerson._();
+
+  factory GBookFragmentData__asTextbook_author__asPerson(
+      [void Function(GBookFragmentData__asTextbook_author__asPersonBuilder b)
+          updates]) = _$GBookFragmentData__asTextbook_author__asPerson;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GBookFragmentData__asTextbook_author__asPerson>
+      get serializer => _$gBookFragmentDataAsTextbookAuthorAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asTextbook_author__asCompany
+    implements
+        Built<GBookFragmentData__asTextbook_author__asCompany,
+            GBookFragmentData__asTextbook_author__asCompanyBuilder>,
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GBookFragment,
+        GBookFragment__asCompany,
+        GBookFragmentData_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragmentData__asTextbook_author {
+  GBookFragmentData__asTextbook_author__asCompany._();
+
+  factory GBookFragmentData__asTextbook_author__asCompany(
+      [void Function(GBookFragmentData__asTextbook_author__asCompanyBuilder b)
+          updates]) = _$GBookFragmentData__asTextbook_author__asCompany;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GBookFragmentData__asTextbook_author__asCompany>
+      get serializer => _$gBookFragmentDataAsTextbookAuthorAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asColoringBook
+    implements
+        Built<GBookFragmentData__asColoringBook,
+            GBookFragmentData__asColoringBookBuilder>,
+        GBookFragment,
+        GBookFragment__asColoringBook,
+        GBookFragmentData {
+  GBookFragmentData__asColoringBook._();
+
+  factory GBookFragmentData__asColoringBook(
+          [void Function(GBookFragmentData__asColoringBookBuilder b) updates]) =
+      _$GBookFragmentData__asColoringBook;
+
+  static void _initializeBuilder(GBookFragmentData__asColoringBookBuilder b) =>
+      b..G__typename = 'ColoringBook';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  GBookFragmentData__asColoringBook_author get author;
+  @override
+  String get title;
+  @override
+  BuiltList<String> get colors;
+  static Serializer<GBookFragmentData__asColoringBook> get serializer =>
+      _$gBookFragmentDataAsColoringBookSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asColoringBook_author
+    implements
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GBookFragmentData_author,
+        GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asColoringBook_author> get serializer =>
+      _i2.InlineFragmentSerializer<GBookFragmentData__asColoringBook_author>(
+        'GBookFragmentData__asColoringBook_author',
+        GBookFragmentData__asColoringBook_author__base,
+        {
+          'Person': GBookFragmentData__asColoringBook_author__asPerson,
+          'Company': GBookFragmentData__asColoringBook_author__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook_author.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentData__asColoringBook_authorWhenExtension
+    on GBookFragmentData__asColoringBook_author {
+  _T when<_T>({
+    required _T Function(GBookFragmentData__asColoringBook_author__asPerson)
+        person,
+    required _T Function(GBookFragmentData__asColoringBook_author__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person(
+            (this as GBookFragmentData__asColoringBook_author__asPerson));
+      case 'Company':
+        return company(
+            (this as GBookFragmentData__asColoringBook_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData__asColoringBook_author__asPerson)? person,
+    _T Function(GBookFragmentData__asColoringBook_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person(
+                (this as GBookFragmentData__asColoringBook_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company(
+                (this as GBookFragmentData__asColoringBook_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__asColoringBook_author__base
+    implements
+        Built<GBookFragmentData__asColoringBook_author__base,
+            GBookFragmentData__asColoringBook_author__baseBuilder>,
+        GBookFragmentData__asColoringBook_author,
+        GAuthorFragment {
+  GBookFragmentData__asColoringBook_author__base._();
+
+  factory GBookFragmentData__asColoringBook_author__base(
+      [void Function(GBookFragmentData__asColoringBook_author__baseBuilder b)
+          updates]) = _$GBookFragmentData__asColoringBook_author__base;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asColoringBook_author__base>
+      get serializer => _$gBookFragmentDataAsColoringBookAuthorBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook_author__base.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asColoringBook_author__asPerson
+    implements
+        Built<GBookFragmentData__asColoringBook_author__asPerson,
+            GBookFragmentData__asColoringBook_author__asPersonBuilder>,
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GBookFragment,
+        GBookFragment__asPerson,
+        GBookFragmentData_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragmentData__asColoringBook_author {
+  GBookFragmentData__asColoringBook_author__asPerson._();
+
+  factory GBookFragmentData__asColoringBook_author__asPerson(
+      [void Function(
+              GBookFragmentData__asColoringBook_author__asPersonBuilder b)
+          updates]) = _$GBookFragmentData__asColoringBook_author__asPerson;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GBookFragmentData__asColoringBook_author__asPerson>
+      get serializer =>
+          _$gBookFragmentDataAsColoringBookAuthorAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook_author__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asColoringBook_author__asCompany
+    implements
+        Built<GBookFragmentData__asColoringBook_author__asCompany,
+            GBookFragmentData__asColoringBook_author__asCompanyBuilder>,
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GBookFragment,
+        GBookFragment__asCompany,
+        GBookFragmentData_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragmentData__asColoringBook_author {
+  GBookFragmentData__asColoringBook_author__asCompany._();
+
+  factory GBookFragmentData__asColoringBook_author__asCompany(
+      [void Function(
+              GBookFragmentData__asColoringBook_author__asCompanyBuilder b)
+          updates]) = _$GBookFragmentData__asColoringBook_author__asCompany;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GBookFragmentData__asColoringBook_author__asCompany>
+      get serializer =>
+          _$gBookFragmentDataAsColoringBookAuthorAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData_author
+    implements GBookFragment_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragmentData_authorWhenExtension on GBookFragmentData_author {
+  _T when<_T>({
+    required _T Function(GBookFragmentData_author__asPerson) person,
+    required _T Function(GBookFragmentData_author__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GBookFragmentData_author__asPerson));
+      case 'Company':
+        return company((this as GBookFragmentData_author__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData_author__asPerson)? person,
+    _T Function(GBookFragmentData_author__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragmentData_author__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GBookFragmentData_author__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData_author__base
+    implements GBookFragmentData_author, GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragmentData_author__asPerson
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asPerson,
+        GAuthorFragment__asPerson,
+        GBookFragmentData_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragmentData_author__asCompany
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asCompany,
+        GAuthorFragment__asCompany,
+        GBookFragmentData_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.dart
@@ -158,6 +158,7 @@ abstract class GGetBooksData_books__base_author
         {
           'Person': GGetBooksData_books__base_author__asPerson,
           'Company': GGetBooksData_books__base_author__asCompany,
+          'Group': GGetBooksData_books__base_author__asGroup,
         },
       );
 
@@ -179,6 +180,7 @@ extension GGetBooksData_books__base_authorWhenExtension
   _T when<_T>({
     required _T Function(GGetBooksData_books__base_author__asPerson) person,
     required _T Function(GGetBooksData_books__base_author__asCompany) company,
+    required _T Function(GGetBooksData_books__base_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -186,6 +188,8 @@ extension GGetBooksData_books__base_authorWhenExtension
         return person((this as GGetBooksData_books__base_author__asPerson));
       case 'Company':
         return company((this as GGetBooksData_books__base_author__asCompany));
+      case 'Group':
+        return group((this as GGetBooksData_books__base_author__asGroup));
       default:
         return orElse();
     }
@@ -194,6 +198,7 @@ extension GGetBooksData_books__base_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GGetBooksData_books__base_author__asPerson)? person,
     _T Function(GGetBooksData_books__base_author__asCompany)? company,
+    _T Function(GGetBooksData_books__base_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -204,6 +209,10 @@ extension GGetBooksData_books__base_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GGetBooksData_books__base_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GGetBooksData_books__base_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -258,7 +267,8 @@ abstract class GGetBooksData_books__base_author__asPerson
         GGetBooksData_books_author__asPerson,
         GBookFragment_author__asPerson,
         GAuthorFragment__asPerson,
-        GGetBooksData_books__base_author {
+        GGetBooksData_books__base_author,
+        GAuthorPersonFragment {
   GGetBooksData_books__base_author__asPerson._();
 
   factory GGetBooksData_books__base_author__asPerson(
@@ -304,7 +314,8 @@ abstract class GGetBooksData_books__base_author__asCompany
         GGetBooksData_books_author__asCompany,
         GBookFragment_author__asCompany,
         GAuthorFragment__asCompany,
-        GGetBooksData_books__base_author {
+        GGetBooksData_books__base_author,
+        GAuthorCompanyFragment {
   GGetBooksData_books__base_author__asCompany._();
 
   factory GGetBooksData_books__base_author__asCompany(
@@ -334,6 +345,279 @@ abstract class GGetBooksData_books__base_author__asCompany
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
         GGetBooksData_books__base_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author__asGroup
+    implements
+        Built<GGetBooksData_books__base_author__asGroup,
+            GGetBooksData_books__base_author__asGroupBuilder>,
+        GGetBooksData_books_author,
+        GBookFragment_author,
+        GAuthorFragment,
+        GGetBooksData_books_author__asGroup,
+        GBookFragment_author__asGroup,
+        GAuthorFragment__asGroup,
+        GGetBooksData_books__base_author {
+  GGetBooksData_books__base_author__asGroup._();
+
+  factory GGetBooksData_books__base_author__asGroup(
+      [void Function(GGetBooksData_books__base_author__asGroupBuilder b)
+          updates]) = _$GGetBooksData_books__base_author__asGroup;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GGetBooksData_books__base_author__asGroup_members> get members;
+  static Serializer<GGetBooksData_books__base_author__asGroup> get serializer =>
+      _$gGetBooksDataBooksBaseAuthorAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asGroup? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author__asGroup_members
+    implements
+        GGetBooksData_books_author__asGroup_members,
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__base_author__asGroup_members>
+      get serializer => _i2.InlineFragmentSerializer<
+              GGetBooksData_books__base_author__asGroup_members>(
+            'GGetBooksData_books__base_author__asGroup_members',
+            GGetBooksData_books__base_author__asGroup_members__base,
+            {
+              'Person':
+                  GGetBooksData_books__base_author__asGroup_members__asPerson,
+              'Company':
+                  GGetBooksData_books__base_author__asGroup_members__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_books__base_author__asGroup_membersWhenExtension
+    on GGetBooksData_books__base_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GGetBooksData_books__base_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GGetBooksData_books__base_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GGetBooksData_books__base_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GGetBooksData_books__base_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GGetBooksData_books__base_author__asGroup_members__asPerson)?
+        person,
+    _T Function(GGetBooksData_books__base_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GGetBooksData_books__base_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GGetBooksData_books__base_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__base_author__asGroup_members__base
+    implements
+        Built<GGetBooksData_books__base_author__asGroup_members__base,
+            GGetBooksData_books__base_author__asGroup_members__baseBuilder>,
+        GGetBooksData_books__base_author__asGroup_members,
+        GAuthorGroupFragment {
+  GGetBooksData_books__base_author__asGroup_members__base._();
+
+  factory GGetBooksData_books__base_author__asGroup_members__base(
+      [void Function(
+              GGetBooksData_books__base_author__asGroup_members__baseBuilder b)
+          updates]) = _$GGetBooksData_books__base_author__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__asGroup_members__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__base_author__asGroup_members__base>
+      get serializer =>
+          _$gGetBooksDataBooksBaseAuthorAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asGroup_members__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asGroup_members__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asGroup_members__base.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author__asGroup_members__asPerson
+    implements
+        Built<GGetBooksData_books__base_author__asGroup_members__asPerson,
+            GGetBooksData_books__base_author__asGroup_members__asPersonBuilder>,
+        GGetBooksData_books_author__asGroup_members,
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GGetBooksData_books_author__asGroup_members__asPerson,
+        GBookFragment_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GGetBooksData_books__base_author__asGroup_members,
+        GAuthorPersonFragment {
+  GGetBooksData_books__base_author__asGroup_members__asPerson._();
+
+  factory GGetBooksData_books__base_author__asGroup_members__asPerson(
+      [void Function(
+              GGetBooksData_books__base_author__asGroup_members__asPersonBuilder
+                  b)
+          updates]) = _$GGetBooksData_books__base_author__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__asGroup_members__asPersonBuilder
+              b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GGetBooksData_books__base_author__asGroup_members__asPerson>
+      get serializer =>
+          _$gGetBooksDataBooksBaseAuthorAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asGroup_members__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asGroup_members__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asGroup_members__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__base_author__asGroup_members__asCompany
+    implements
+        Built<GGetBooksData_books__base_author__asGroup_members__asCompany,
+            GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder>,
+        GGetBooksData_books_author__asGroup_members,
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GGetBooksData_books_author__asGroup_members__asCompany,
+        GBookFragment_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GGetBooksData_books__base_author__asGroup_members,
+        GAuthorCompanyFragment {
+  GGetBooksData_books__base_author__asGroup_members__asCompany._();
+
+  factory GGetBooksData_books__base_author__asGroup_members__asCompany(
+          [void Function(
+                  GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__base_author__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder
+              b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<
+          GGetBooksData_books__base_author__asGroup_members__asCompany>
+      get serializer =>
+          _$gGetBooksDataBooksBaseAuthorAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__base_author__asGroup_members__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__base_author__asGroup_members__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__base_author__asGroup_members__asCompany.serializer,
         json,
       );
 }
@@ -396,6 +680,7 @@ abstract class GGetBooksData_books__asTextbook_author
         {
           'Person': GGetBooksData_books__asTextbook_author__asPerson,
           'Company': GGetBooksData_books__asTextbook_author__asCompany,
+          'Group': GGetBooksData_books__asTextbook_author__asGroup,
         },
       );
 
@@ -419,6 +704,7 @@ extension GGetBooksData_books__asTextbook_authorWhenExtension
         person,
     required _T Function(GGetBooksData_books__asTextbook_author__asCompany)
         company,
+    required _T Function(GGetBooksData_books__asTextbook_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -428,6 +714,8 @@ extension GGetBooksData_books__asTextbook_authorWhenExtension
       case 'Company':
         return company(
             (this as GGetBooksData_books__asTextbook_author__asCompany));
+      case 'Group':
+        return group((this as GGetBooksData_books__asTextbook_author__asGroup));
       default:
         return orElse();
     }
@@ -436,6 +724,7 @@ extension GGetBooksData_books__asTextbook_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GGetBooksData_books__asTextbook_author__asPerson)? person,
     _T Function(GGetBooksData_books__asTextbook_author__asCompany)? company,
+    _T Function(GGetBooksData_books__asTextbook_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -447,6 +736,10 @@ extension GGetBooksData_books__asTextbook_authorWhenExtension
         return company != null
             ? company(
                 (this as GGetBooksData_books__asTextbook_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GGetBooksData_books__asTextbook_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -503,7 +796,8 @@ abstract class GGetBooksData_books__asTextbook_author__asPerson
         GBookFragment__asTextbook_author__asPerson,
         GGetBooksData_books_author__asPerson,
         GAuthorFragment__asPerson,
-        GGetBooksData_books__asTextbook_author {
+        GGetBooksData_books__asTextbook_author,
+        GAuthorPersonFragment {
   GGetBooksData_books__asTextbook_author__asPerson._();
 
   factory GGetBooksData_books__asTextbook_author__asPerson(
@@ -551,7 +845,8 @@ abstract class GGetBooksData_books__asTextbook_author__asCompany
         GBookFragment__asTextbook_author__asCompany,
         GGetBooksData_books_author__asCompany,
         GAuthorFragment__asCompany,
-        GGetBooksData_books__asTextbook_author {
+        GGetBooksData_books__asTextbook_author,
+        GAuthorCompanyFragment {
   GGetBooksData_books__asTextbook_author__asCompany._();
 
   factory GGetBooksData_books__asTextbook_author__asCompany(
@@ -583,6 +878,299 @@ abstract class GGetBooksData_books__asTextbook_author__asCompany
         GGetBooksData_books__asTextbook_author__asCompany.serializer,
         json,
       );
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asGroup
+    implements
+        Built<GGetBooksData_books__asTextbook_author__asGroup,
+            GGetBooksData_books__asTextbook_author__asGroupBuilder>,
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GBookFragment__asTextbook_author__asGroup,
+        GGetBooksData_books_author__asGroup,
+        GAuthorFragment__asGroup,
+        GGetBooksData_books__asTextbook_author {
+  GGetBooksData_books__asTextbook_author__asGroup._();
+
+  factory GGetBooksData_books__asTextbook_author__asGroup(
+      [void Function(GGetBooksData_books__asTextbook_author__asGroupBuilder b)
+          updates]) = _$GGetBooksData_books__asTextbook_author__asGroup;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GGetBooksData_books__asTextbook_author__asGroup_members>
+      get members;
+  static Serializer<GGetBooksData_books__asTextbook_author__asGroup>
+      get serializer => _$gGetBooksDataBooksAsTextbookAuthorAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asGroup? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__asTextbook_author__asGroup_members>
+      get serializer => _i2.InlineFragmentSerializer<
+              GGetBooksData_books__asTextbook_author__asGroup_members>(
+            'GGetBooksData_books__asTextbook_author__asGroup_members',
+            GGetBooksData_books__asTextbook_author__asGroup_members__base,
+            {
+              'Person':
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asPerson,
+              'Company':
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_books__asTextbook_author__asGroup_membersWhenExtension
+    on GGetBooksData_books__asTextbook_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GGetBooksData_books__asTextbook_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GGetBooksData_books__asTextbook_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPerson)?
+        person,
+    _T Function(
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GGetBooksData_books__asTextbook_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GGetBooksData_books__asTextbook_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asGroup_members__base
+    implements
+        Built<GGetBooksData_books__asTextbook_author__asGroup_members__base,
+            GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder>,
+        GGetBooksData_books__asTextbook_author__asGroup_members,
+        GAuthorGroupFragment {
+  GGetBooksData_books__asTextbook_author__asGroup_members__base._();
+
+  factory GGetBooksData_books__asTextbook_author__asGroup_members__base(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__asTextbook_author__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder
+              b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<
+          GGetBooksData_books__asTextbook_author__asGroup_members__base>
+      get serializer =>
+          _$gGetBooksDataBooksAsTextbookAuthorAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup_members__base
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asGroup_members__base?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GGetBooksData_books__asTextbook_author__asGroup_members__base
+                .serializer,
+            json,
+          );
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+    implements
+        Built<GGetBooksData_books__asTextbook_author__asGroup_members__asPerson,
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GBookFragment__asTextbook_author__asGroup_members__asPerson,
+        GGetBooksData_books_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GGetBooksData_books__asTextbook_author__asGroup_members,
+        GAuthorPersonFragment {
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPerson._();
+
+  factory GGetBooksData_books__asTextbook_author__asGroup_members__asPerson(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder
+              b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<
+          GGetBooksData_books__asTextbook_author__asGroup_members__asPerson>
+      get serializer =>
+          _$gGetBooksDataBooksAsTextbookAuthorAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asGroup_members__asPerson?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+                .serializer,
+            json,
+          );
+}
+
+abstract class GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+    implements
+        Built<
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompany,
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GBookFragment__asTextbook_author__asGroup_members__asCompany,
+        GGetBooksData_books_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GGetBooksData_books__asTextbook_author__asGroup_members,
+        GAuthorCompanyFragment {
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompany._();
+
+  factory GGetBooksData_books__asTextbook_author__asGroup_members__asCompany(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder
+              b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<
+          GGetBooksData_books__asTextbook_author__asGroup_members__asCompany>
+      get serializer =>
+          _$gGetBooksDataBooksAsTextbookAuthorAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asTextbook_author__asGroup_members__asCompany?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+                .serializer,
+            json,
+          );
 }
 
 abstract class GGetBooksData_books__asColoringBook
@@ -646,6 +1234,7 @@ abstract class GGetBooksData_books__asColoringBook_author
             {
               'Person': GGetBooksData_books__asColoringBook_author__asPerson,
               'Company': GGetBooksData_books__asColoringBook_author__asCompany,
+              'Group': GGetBooksData_books__asColoringBook_author__asGroup,
             },
           );
 
@@ -669,6 +1258,8 @@ extension GGetBooksData_books__asColoringBook_authorWhenExtension
         person,
     required _T Function(GGetBooksData_books__asColoringBook_author__asCompany)
         company,
+    required _T Function(GGetBooksData_books__asColoringBook_author__asGroup)
+        group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -678,6 +1269,9 @@ extension GGetBooksData_books__asColoringBook_authorWhenExtension
       case 'Company':
         return company(
             (this as GGetBooksData_books__asColoringBook_author__asCompany));
+      case 'Group':
+        return group(
+            (this as GGetBooksData_books__asColoringBook_author__asGroup));
       default:
         return orElse();
     }
@@ -686,6 +1280,7 @@ extension GGetBooksData_books__asColoringBook_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GGetBooksData_books__asColoringBook_author__asPerson)? person,
     _T Function(GGetBooksData_books__asColoringBook_author__asCompany)? company,
+    _T Function(GGetBooksData_books__asColoringBook_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -698,6 +1293,11 @@ extension GGetBooksData_books__asColoringBook_authorWhenExtension
         return company != null
             ? company(
                 (this as GGetBooksData_books__asColoringBook_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group(
+                (this as GGetBooksData_books__asColoringBook_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -754,7 +1354,8 @@ abstract class GGetBooksData_books__asColoringBook_author__asPerson
         GBookFragment__asColoringBook_author__asPerson,
         GGetBooksData_books_author__asPerson,
         GAuthorFragment__asPerson,
-        GGetBooksData_books__asColoringBook_author {
+        GGetBooksData_books__asColoringBook_author,
+        GAuthorPersonFragment {
   GGetBooksData_books__asColoringBook_author__asPerson._();
 
   factory GGetBooksData_books__asColoringBook_author__asPerson(
@@ -804,7 +1405,8 @@ abstract class GGetBooksData_books__asColoringBook_author__asCompany
         GBookFragment__asColoringBook_author__asCompany,
         GGetBooksData_books_author__asCompany,
         GAuthorFragment__asCompany,
-        GGetBooksData_books__asColoringBook_author {
+        GGetBooksData_books__asColoringBook_author,
+        GAuthorCompanyFragment {
   GGetBooksData_books__asColoringBook_author__asCompany._();
 
   factory GGetBooksData_books__asColoringBook_author__asCompany(
@@ -840,6 +1442,302 @@ abstract class GGetBooksData_books__asColoringBook_author__asCompany
       );
 }
 
+abstract class GGetBooksData_books__asColoringBook_author__asGroup
+    implements
+        Built<GGetBooksData_books__asColoringBook_author__asGroup,
+            GGetBooksData_books__asColoringBook_author__asGroupBuilder>,
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GGetBooksData_books_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GBookFragment__asColoringBook_author__asGroup,
+        GGetBooksData_books_author__asGroup,
+        GAuthorFragment__asGroup,
+        GGetBooksData_books__asColoringBook_author {
+  GGetBooksData_books__asColoringBook_author__asGroup._();
+
+  factory GGetBooksData_books__asColoringBook_author__asGroup(
+      [void Function(
+              GGetBooksData_books__asColoringBook_author__asGroupBuilder b)
+          updates]) = _$GGetBooksData_books__asColoringBook_author__asGroup;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GGetBooksData_books__asColoringBook_author__asGroup_members>
+      get members;
+  static Serializer<GGetBooksData_books__asColoringBook_author__asGroup>
+      get serializer =>
+          _$gGetBooksDataBooksAsColoringBookAuthorAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asGroup? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GGetBooksData_books__asColoringBook_author__asGroup_members>
+      get serializer => _i2.InlineFragmentSerializer<
+              GGetBooksData_books__asColoringBook_author__asGroup_members>(
+            'GGetBooksData_books__asColoringBook_author__asGroup_members',
+            GGetBooksData_books__asColoringBook_author__asGroup_members__base,
+            {
+              'Person':
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson,
+              'Company':
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GGetBooksData_books__asColoringBook_author__asGroup_membersWhenExtension
+    on GGetBooksData_books__asColoringBook_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson)?
+        person,
+    _T Function(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__asGroup_members__base
+    implements
+        Built<GGetBooksData_books__asColoringBook_author__asGroup_members__base,
+            GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder>,
+        GGetBooksData_books__asColoringBook_author__asGroup_members,
+        GAuthorGroupFragment {
+  GGetBooksData_books__asColoringBook_author__asGroup_members__base._();
+
+  factory GGetBooksData_books__asColoringBook_author__asGroup_members__base(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__asColoringBook_author__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder
+              b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<
+          GGetBooksData_books__asColoringBook_author__asGroup_members__base>
+      get serializer =>
+          _$gGetBooksDataBooksAsColoringBookAuthorAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup_members__base
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asGroup_members__base?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__base
+                .serializer,
+            json,
+          );
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+    implements
+        Built<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson,
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GBookFragment__asColoringBook_author__asGroup_members__asPerson,
+        GGetBooksData_books_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GGetBooksData_books__asColoringBook_author__asGroup_members,
+        GAuthorPersonFragment {
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson._();
+
+  factory GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder
+              b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson>
+      get serializer =>
+          _$gGetBooksDataBooksAsColoringBookAuthorAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+                .serializer,
+            json,
+          );
+}
+
+abstract class GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+    implements
+        Built<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany,
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GBookFragment__asColoringBook_author__asGroup_members__asCompany,
+        GGetBooksData_books_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GGetBooksData_books__asColoringBook_author__asGroup_members,
+        GAuthorCompanyFragment {
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany._();
+
+  factory GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder
+                      b)
+              updates]) =
+      _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder
+              b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany>
+      get serializer =>
+          _$gGetBooksDataBooksAsColoringBookAuthorAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+                .serializer,
+            json,
+          );
+}
+
 abstract class GGetBooksData_books_author
     implements GBookFragment_author, GAuthorFragment {
   @override
@@ -853,6 +1751,7 @@ extension GGetBooksData_books_authorWhenExtension
   _T when<_T>({
     required _T Function(GGetBooksData_books_author__asPerson) person,
     required _T Function(GGetBooksData_books_author__asCompany) company,
+    required _T Function(GGetBooksData_books_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -860,6 +1759,8 @@ extension GGetBooksData_books_authorWhenExtension
         return person((this as GGetBooksData_books_author__asPerson));
       case 'Company':
         return company((this as GGetBooksData_books_author__asCompany));
+      case 'Group':
+        return group((this as GGetBooksData_books_author__asGroup));
       default:
         return orElse();
     }
@@ -868,6 +1769,7 @@ extension GGetBooksData_books_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GGetBooksData_books_author__asPerson)? person,
     _T Function(GGetBooksData_books_author__asCompany)? company,
+    _T Function(GGetBooksData_books_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -878,6 +1780,10 @@ extension GGetBooksData_books_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GGetBooksData_books_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GGetBooksData_books_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -899,7 +1805,8 @@ abstract class GGetBooksData_books_author__asPerson
         GAuthorFragment,
         GBookFragment_author__asPerson,
         GAuthorFragment__asPerson,
-        GGetBooksData_books_author {
+        GGetBooksData_books_author,
+        GAuthorPersonFragment {
   @override
   String get G__typename;
   @override
@@ -916,49 +1823,79 @@ abstract class GGetBooksData_books_author__asCompany
         GAuthorFragment,
         GBookFragment_author__asCompany,
         GAuthorFragment__asCompany,
+        GGetBooksData_books_author,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GGetBooksData_books_author__asGroup
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GAuthorFragment__asGroup,
         GGetBooksData_books_author {
   @override
   String get G__typename;
   @override
   String get displayName;
   @override
-  String get name;
+  BuiltList<GGetBooksData_books_author__asGroup_members> get members;
 }
 
-abstract class GAuthorFragment {
+abstract class GGetBooksData_books_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
   String get G__typename;
+  @override
   String get displayName;
 }
 
-extension GAuthorFragmentWhenExtension on GAuthorFragment {
+extension GGetBooksData_books_author__asGroup_membersWhenExtension
+    on GGetBooksData_books_author__asGroup_members {
   _T when<_T>({
-    required _T Function(GAuthorFragment__asPerson) person,
-    required _T Function(GAuthorFragment__asCompany) company,
+    required _T Function(GGetBooksData_books_author__asGroup_members__asPerson)
+        person,
+    required _T Function(GGetBooksData_books_author__asGroup_members__asCompany)
+        company,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
       case 'Person':
-        return person((this as GAuthorFragment__asPerson));
+        return person(
+            (this as GGetBooksData_books_author__asGroup_members__asPerson));
       case 'Company':
-        return company((this as GAuthorFragment__asCompany));
+        return company(
+            (this as GGetBooksData_books_author__asGroup_members__asCompany));
       default:
         return orElse();
     }
   }
 
   _T maybeWhen<_T>({
-    _T Function(GAuthorFragment__asPerson)? person,
-    _T Function(GAuthorFragment__asCompany)? company,
+    _T Function(GGetBooksData_books_author__asGroup_members__asPerson)? person,
+    _T Function(GGetBooksData_books_author__asGroup_members__asCompany)?
+        company,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
       case 'Person':
         return person != null
-            ? person((this as GAuthorFragment__asPerson))
+            ? person(
+                (this as GGetBooksData_books_author__asGroup_members__asPerson))
             : orElse();
       case 'Company':
         return company != null
-            ? company((this as GAuthorFragment__asCompany))
+            ? company((this
+                as GGetBooksData_books_author__asGroup_members__asCompany))
             : orElse();
       default:
         return orElse();
@@ -966,145 +1903,27 @@ extension GAuthorFragmentWhenExtension on GAuthorFragment {
   }
 }
 
-abstract class GAuthorFragment__base implements GAuthorFragment {
-  @override
-  String get G__typename;
-  @override
-  String get displayName;
-}
-
-abstract class GAuthorFragment__asPerson implements GAuthorFragment {
-  @override
-  String get G__typename;
-  @override
-  String get displayName;
-  String get firstName;
-  String get lastName;
-}
-
-abstract class GAuthorFragment__asCompany implements GAuthorFragment {
-  @override
-  String get G__typename;
-  @override
-  String get displayName;
-  String get name;
-}
-
-abstract class GAuthorFragmentData implements GAuthorFragment {
-  @override
-  @BuiltValueField(wireName: '__typename')
-  String get G__typename;
-  @override
-  String get displayName;
-  static Serializer<GAuthorFragmentData> get serializer =>
-      _i2.InlineFragmentSerializer<GAuthorFragmentData>(
-        'GAuthorFragmentData',
-        GAuthorFragmentData__base,
-        {
-          'Person': GAuthorFragmentData__asPerson,
-          'Company': GAuthorFragmentData__asCompany,
-        },
-      );
-
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GAuthorFragmentData.serializer,
-        this,
-      ) as Map<String, dynamic>);
-
-  static GAuthorFragmentData? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
-        GAuthorFragmentData.serializer,
-        json,
-      );
-}
-
-extension GAuthorFragmentDataWhenExtension on GAuthorFragmentData {
-  _T when<_T>({
-    required _T Function(GAuthorFragmentData__asPerson) person,
-    required _T Function(GAuthorFragmentData__asCompany) company,
-    required _T Function() orElse,
-  }) {
-    switch (G__typename) {
-      case 'Person':
-        return person((this as GAuthorFragmentData__asPerson));
-      case 'Company':
-        return company((this as GAuthorFragmentData__asCompany));
-      default:
-        return orElse();
-    }
-  }
-
-  _T maybeWhen<_T>({
-    _T Function(GAuthorFragmentData__asPerson)? person,
-    _T Function(GAuthorFragmentData__asCompany)? company,
-    required _T Function() orElse,
-  }) {
-    switch (G__typename) {
-      case 'Person':
-        return person != null
-            ? person((this as GAuthorFragmentData__asPerson))
-            : orElse();
-      case 'Company':
-        return company != null
-            ? company((this as GAuthorFragmentData__asCompany))
-            : orElse();
-      default:
-        return orElse();
-    }
-  }
-}
-
-abstract class GAuthorFragmentData__base
+abstract class GGetBooksData_books_author__asGroup_members__base
     implements
-        Built<GAuthorFragmentData__base, GAuthorFragmentData__baseBuilder>,
-        GAuthorFragmentData {
-  GAuthorFragmentData__base._();
-
-  factory GAuthorFragmentData__base(
-          [void Function(GAuthorFragmentData__baseBuilder b) updates]) =
-      _$GAuthorFragmentData__base;
-
-  static void _initializeBuilder(GAuthorFragmentData__baseBuilder b) =>
-      b..G__typename = 'Author';
-
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorGroupFragment {
   @override
-  @BuiltValueField(wireName: '__typename')
   String get G__typename;
   @override
   String get displayName;
-  static Serializer<GAuthorFragmentData__base> get serializer =>
-      _$gAuthorFragmentDataBaseSerializer;
-
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GAuthorFragmentData__base.serializer,
-        this,
-      ) as Map<String, dynamic>);
-
-  static GAuthorFragmentData__base? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
-        GAuthorFragmentData__base.serializer,
-        json,
-      );
 }
 
-abstract class GAuthorFragmentData__asPerson
+abstract class GGetBooksData_books_author__asGroup_members__asPerson
     implements
-        Built<GAuthorFragmentData__asPerson,
-            GAuthorFragmentData__asPersonBuilder>,
-        GAuthorFragment,
-        GAuthorFragment__asPerson,
-        GAuthorFragmentData {
-  GAuthorFragmentData__asPerson._();
-
-  factory GAuthorFragmentData__asPerson(
-          [void Function(GAuthorFragmentData__asPersonBuilder b) updates]) =
-      _$GAuthorFragmentData__asPerson;
-
-  static void _initializeBuilder(GAuthorFragmentData__asPersonBuilder b) =>
-      b..G__typename = 'Person';
-
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorPersonFragment {
   @override
-  @BuiltValueField(wireName: '__typename')
   String get G__typename;
   @override
   String get displayName;
@@ -1112,57 +1931,24 @@ abstract class GAuthorFragmentData__asPerson
   String get firstName;
   @override
   String get lastName;
-  static Serializer<GAuthorFragmentData__asPerson> get serializer =>
-      _$gAuthorFragmentDataAsPersonSerializer;
-
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GAuthorFragmentData__asPerson.serializer,
-        this,
-      ) as Map<String, dynamic>);
-
-  static GAuthorFragmentData__asPerson? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
-        GAuthorFragmentData__asPerson.serializer,
-        json,
-      );
 }
 
-abstract class GAuthorFragmentData__asCompany
+abstract class GGetBooksData_books_author__asGroup_members__asCompany
     implements
-        Built<GAuthorFragmentData__asCompany,
-            GAuthorFragmentData__asCompanyBuilder>,
-        GAuthorFragment,
-        GAuthorFragment__asCompany,
-        GAuthorFragmentData {
-  GAuthorFragmentData__asCompany._();
-
-  factory GAuthorFragmentData__asCompany(
-          [void Function(GAuthorFragmentData__asCompanyBuilder b) updates]) =
-      _$GAuthorFragmentData__asCompany;
-
-  static void _initializeBuilder(GAuthorFragmentData__asCompanyBuilder b) =>
-      b..G__typename = 'Company';
-
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GGetBooksData_books_author__asGroup_members,
+        GAuthorCompanyFragment {
   @override
-  @BuiltValueField(wireName: '__typename')
   String get G__typename;
   @override
   String get displayName;
   @override
   String get name;
-  static Serializer<GAuthorFragmentData__asCompany> get serializer =>
-      _$gAuthorFragmentDataAsCompanySerializer;
-
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GAuthorFragmentData__asCompany.serializer,
-        this,
-      ) as Map<String, dynamic>);
-
-  static GAuthorFragmentData__asCompany? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
-        GAuthorFragmentData__asCompany.serializer,
-        json,
-      );
 }
 
 abstract class GBookFragment {
@@ -1229,6 +2015,7 @@ extension GBookFragment__base_authorWhenExtension
   _T when<_T>({
     required _T Function(GBookFragment__base_author__asPerson) person,
     required _T Function(GBookFragment__base_author__asCompany) company,
+    required _T Function(GBookFragment__base_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1236,6 +2023,8 @@ extension GBookFragment__base_authorWhenExtension
         return person((this as GBookFragment__base_author__asPerson));
       case 'Company':
         return company((this as GBookFragment__base_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragment__base_author__asGroup));
       default:
         return orElse();
     }
@@ -1244,6 +2033,7 @@ extension GBookFragment__base_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GBookFragment__base_author__asPerson)? person,
     _T Function(GBookFragment__base_author__asCompany)? company,
+    _T Function(GBookFragment__base_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1254,6 +2044,10 @@ extension GBookFragment__base_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GBookFragment__base_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragment__base_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -1275,7 +2069,8 @@ abstract class GBookFragment__base_author__asPerson
         GAuthorFragment,
         GBookFragment_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragment__base_author {
+        GBookFragment__base_author,
+        GAuthorPersonFragment {
   @override
   String get G__typename;
   @override
@@ -1292,7 +2087,126 @@ abstract class GBookFragment__base_author__asCompany
         GAuthorFragment,
         GBookFragment_author__asCompany,
         GAuthorFragment__asCompany,
+        GBookFragment__base_author,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment__base_author__asGroup
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GAuthorFragment__asGroup,
         GBookFragment__base_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragment__base_author__asGroup_members> get members;
+}
+
+abstract class GBookFragment__base_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment__base_author__asGroup_membersWhenExtension
+    on GBookFragment__base_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(GBookFragment__base_author__asGroup_members__asPerson)
+        person,
+    required _T Function(GBookFragment__base_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person(
+            (this as GBookFragment__base_author__asGroup_members__asPerson));
+      case 'Company':
+        return company(
+            (this as GBookFragment__base_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment__base_author__asGroup_members__asPerson)? person,
+    _T Function(GBookFragment__base_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person(
+                (this as GBookFragment__base_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GBookFragment__base_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__base_author__asGroup_members__base
+    implements
+        GBookFragment__base_author__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment__base_author__asGroup_members__asPerson
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragment__base_author__asGroup_members,
+        GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment__base_author__asGroup_members__asCompany
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragment__base_author__asGroup_members,
+        GAuthorCompanyFragment {
   @override
   String get G__typename;
   @override
@@ -1324,6 +2238,7 @@ extension GBookFragment__asTextbook_authorWhenExtension
   _T when<_T>({
     required _T Function(GBookFragment__asTextbook_author__asPerson) person,
     required _T Function(GBookFragment__asTextbook_author__asCompany) company,
+    required _T Function(GBookFragment__asTextbook_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1331,6 +2246,8 @@ extension GBookFragment__asTextbook_authorWhenExtension
         return person((this as GBookFragment__asTextbook_author__asPerson));
       case 'Company':
         return company((this as GBookFragment__asTextbook_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragment__asTextbook_author__asGroup));
       default:
         return orElse();
     }
@@ -1339,6 +2256,7 @@ extension GBookFragment__asTextbook_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GBookFragment__asTextbook_author__asPerson)? person,
     _T Function(GBookFragment__asTextbook_author__asCompany)? company,
+    _T Function(GBookFragment__asTextbook_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1349,6 +2267,10 @@ extension GBookFragment__asTextbook_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GBookFragment__asTextbook_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragment__asTextbook_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -1370,7 +2292,8 @@ abstract class GBookFragment__asTextbook_author__asPerson
         GAuthorFragment,
         GBookFragment_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragment__asTextbook_author {
+        GBookFragment__asTextbook_author,
+        GAuthorPersonFragment {
   @override
   String get G__typename;
   @override
@@ -1387,7 +2310,129 @@ abstract class GBookFragment__asTextbook_author__asCompany
         GAuthorFragment,
         GBookFragment_author__asCompany,
         GAuthorFragment__asCompany,
+        GBookFragment__asTextbook_author,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment__asTextbook_author__asGroup
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GAuthorFragment__asGroup,
         GBookFragment__asTextbook_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragment__asTextbook_author__asGroup_members> get members;
+}
+
+abstract class GBookFragment__asTextbook_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment__asTextbook_author__asGroup_membersWhenExtension
+    on GBookFragment__asTextbook_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GBookFragment__asTextbook_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GBookFragment__asTextbook_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GBookFragment__asTextbook_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GBookFragment__asTextbook_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment__asTextbook_author__asGroup_members__asPerson)?
+        person,
+    _T Function(GBookFragment__asTextbook_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GBookFragment__asTextbook_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GBookFragment__asTextbook_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__asTextbook_author__asGroup_members__base
+    implements
+        GBookFragment__asTextbook_author__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment__asTextbook_author__asGroup_members__asPerson
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment__asTextbook_author__asGroup_members__asCompany
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GAuthorCompanyFragment {
   @override
   String get G__typename;
   @override
@@ -1420,6 +2465,7 @@ extension GBookFragment__asColoringBook_authorWhenExtension
     required _T Function(GBookFragment__asColoringBook_author__asPerson) person,
     required _T Function(GBookFragment__asColoringBook_author__asCompany)
         company,
+    required _T Function(GBookFragment__asColoringBook_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1428,6 +2474,8 @@ extension GBookFragment__asColoringBook_authorWhenExtension
       case 'Company':
         return company(
             (this as GBookFragment__asColoringBook_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragment__asColoringBook_author__asGroup));
       default:
         return orElse();
     }
@@ -1436,6 +2484,7 @@ extension GBookFragment__asColoringBook_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GBookFragment__asColoringBook_author__asPerson)? person,
     _T Function(GBookFragment__asColoringBook_author__asCompany)? company,
+    _T Function(GBookFragment__asColoringBook_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1446,6 +2495,10 @@ extension GBookFragment__asColoringBook_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GBookFragment__asColoringBook_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragment__asColoringBook_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -1467,7 +2520,8 @@ abstract class GBookFragment__asColoringBook_author__asPerson
         GAuthorFragment,
         GBookFragment_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragment__asColoringBook_author {
+        GBookFragment__asColoringBook_author,
+        GAuthorPersonFragment {
   @override
   String get G__typename;
   @override
@@ -1484,7 +2538,131 @@ abstract class GBookFragment__asColoringBook_author__asCompany
         GAuthorFragment,
         GBookFragment_author__asCompany,
         GAuthorFragment__asCompany,
+        GBookFragment__asColoringBook_author,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment__asColoringBook_author__asGroup
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GAuthorFragment__asGroup,
         GBookFragment__asColoringBook_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragment__asColoringBook_author__asGroup_members> get members;
+}
+
+abstract class GBookFragment__asColoringBook_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment__asColoringBook_author__asGroup_membersWhenExtension
+    on GBookFragment__asColoringBook_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GBookFragment__asColoringBook_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GBookFragment__asColoringBook_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GBookFragment__asColoringBook_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GBookFragment__asColoringBook_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            GBookFragment__asColoringBook_author__asGroup_members__asPerson)?
+        person,
+    _T Function(
+            GBookFragment__asColoringBook_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GBookFragment__asColoringBook_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GBookFragment__asColoringBook_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment__asColoringBook_author__asGroup_members__base
+    implements
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment__asColoringBook_author__asGroup_members__asPerson
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment__asColoringBook_author__asGroup_members__asCompany
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GAuthorCompanyFragment {
   @override
   String get G__typename;
   @override
@@ -1504,6 +2682,7 @@ extension GBookFragment_authorWhenExtension on GBookFragment_author {
   _T when<_T>({
     required _T Function(GBookFragment_author__asPerson) person,
     required _T Function(GBookFragment_author__asCompany) company,
+    required _T Function(GBookFragment_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1511,6 +2690,8 @@ extension GBookFragment_authorWhenExtension on GBookFragment_author {
         return person((this as GBookFragment_author__asPerson));
       case 'Company':
         return company((this as GBookFragment_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragment_author__asGroup));
       default:
         return orElse();
     }
@@ -1519,6 +2700,7 @@ extension GBookFragment_authorWhenExtension on GBookFragment_author {
   _T maybeWhen<_T>({
     _T Function(GBookFragment_author__asPerson)? person,
     _T Function(GBookFragment_author__asCompany)? company,
+    _T Function(GBookFragment_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1529,6 +2711,10 @@ extension GBookFragment_authorWhenExtension on GBookFragment_author {
       case 'Company':
         return company != null
             ? company((this as GBookFragment_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragment_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -1548,7 +2734,8 @@ abstract class GBookFragment_author__asPerson
     implements
         GAuthorFragment,
         GAuthorFragment__asPerson,
-        GBookFragment_author {
+        GBookFragment_author,
+        GAuthorPersonFragment {
   @override
   String get G__typename;
   @override
@@ -1563,7 +2750,110 @@ abstract class GBookFragment_author__asCompany
     implements
         GAuthorFragment,
         GAuthorFragment__asCompany,
-        GBookFragment_author {
+        GBookFragment_author,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GBookFragment_author__asGroup
+    implements GAuthorFragment, GAuthorFragment__asGroup, GBookFragment_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragment_author__asGroup_members> get members;
+}
+
+abstract class GBookFragment_author__asGroup_members
+    implements GAuthorFragment__asGroup_members, GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragment_author__asGroup_membersWhenExtension
+    on GBookFragment_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(GBookFragment_author__asGroup_members__asPerson)
+        person,
+    required _T Function(GBookFragment_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person(
+            (this as GBookFragment_author__asGroup_members__asPerson));
+      case 'Company':
+        return company(
+            (this as GBookFragment_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragment_author__asGroup_members__asPerson)? person,
+    _T Function(GBookFragment_author__asGroup_members__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GBookFragment_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company(
+                (this as GBookFragment_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragment_author__asGroup_members__base
+    implements GBookFragment_author__asGroup_members, GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragment_author__asGroup_members__asPerson
+    implements
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragment_author__asGroup_members,
+        GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragment_author__asGroup_members__asCompany
+    implements
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragment_author__asGroup_members,
+        GAuthorCompanyFragment {
   @override
   String get G__typename;
   @override
@@ -1687,6 +2977,7 @@ abstract class GBookFragmentData__base_author
         {
           'Person': GBookFragmentData__base_author__asPerson,
           'Company': GBookFragmentData__base_author__asCompany,
+          'Group': GBookFragmentData__base_author__asGroup,
         },
       );
 
@@ -1707,6 +2998,7 @@ extension GBookFragmentData__base_authorWhenExtension
   _T when<_T>({
     required _T Function(GBookFragmentData__base_author__asPerson) person,
     required _T Function(GBookFragmentData__base_author__asCompany) company,
+    required _T Function(GBookFragmentData__base_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1714,6 +3006,8 @@ extension GBookFragmentData__base_authorWhenExtension
         return person((this as GBookFragmentData__base_author__asPerson));
       case 'Company':
         return company((this as GBookFragmentData__base_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragmentData__base_author__asGroup));
       default:
         return orElse();
     }
@@ -1722,6 +3016,7 @@ extension GBookFragmentData__base_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GBookFragmentData__base_author__asPerson)? person,
     _T Function(GBookFragmentData__base_author__asCompany)? company,
+    _T Function(GBookFragmentData__base_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1732,6 +3027,10 @@ extension GBookFragmentData__base_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GBookFragmentData__base_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragmentData__base_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -1784,7 +3083,8 @@ abstract class GBookFragmentData__base_author__asPerson
         GAuthorFragment,
         GBookFragmentData_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragmentData__base_author {
+        GBookFragmentData__base_author,
+        GAuthorPersonFragment {
   GBookFragmentData__base_author__asPerson._();
 
   factory GBookFragmentData__base_author__asPerson(
@@ -1828,7 +3128,8 @@ abstract class GBookFragmentData__base_author__asCompany
         GAuthorFragment,
         GBookFragmentData_author__asCompany,
         GAuthorFragment__asCompany,
-        GBookFragmentData__base_author {
+        GBookFragmentData__base_author,
+        GAuthorCompanyFragment {
   GBookFragmentData__base_author__asCompany._();
 
   factory GBookFragmentData__base_author__asCompany(
@@ -1858,6 +3159,269 @@ abstract class GBookFragmentData__base_author__asCompany
           Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
         GBookFragmentData__base_author__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author__asGroup
+    implements
+        Built<GBookFragmentData__base_author__asGroup,
+            GBookFragmentData__base_author__asGroupBuilder>,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragmentData_author__asGroup,
+        GAuthorFragment__asGroup,
+        GBookFragmentData__base_author {
+  GBookFragmentData__base_author__asGroup._();
+
+  factory GBookFragmentData__base_author__asGroup(
+      [void Function(GBookFragmentData__base_author__asGroupBuilder b)
+          updates]) = _$GBookFragmentData__base_author__asGroup;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragmentData__base_author__asGroup_members> get members;
+  static Serializer<GBookFragmentData__base_author__asGroup> get serializer =>
+      _$gBookFragmentDataBaseAuthorAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asGroup? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author__asGroup_members
+    implements
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__base_author__asGroup_members>
+      get serializer => _i2.InlineFragmentSerializer<
+              GBookFragmentData__base_author__asGroup_members>(
+            'GBookFragmentData__base_author__asGroup_members',
+            GBookFragmentData__base_author__asGroup_members__base,
+            {
+              'Person':
+                  GBookFragmentData__base_author__asGroup_members__asPerson,
+              'Company':
+                  GBookFragmentData__base_author__asGroup_members__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentData__base_author__asGroup_membersWhenExtension
+    on GBookFragmentData__base_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GBookFragmentData__base_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GBookFragmentData__base_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GBookFragmentData__base_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GBookFragmentData__base_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData__base_author__asGroup_members__asPerson)?
+        person,
+    _T Function(GBookFragmentData__base_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GBookFragmentData__base_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GBookFragmentData__base_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__base_author__asGroup_members__base
+    implements
+        Built<GBookFragmentData__base_author__asGroup_members__base,
+            GBookFragmentData__base_author__asGroup_members__baseBuilder>,
+        GBookFragmentData__base_author__asGroup_members,
+        GAuthorGroupFragment {
+  GBookFragmentData__base_author__asGroup_members__base._();
+
+  factory GBookFragmentData__base_author__asGroup_members__base(
+      [void Function(
+              GBookFragmentData__base_author__asGroup_members__baseBuilder b)
+          updates]) = _$GBookFragmentData__base_author__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__asGroup_members__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__base_author__asGroup_members__base>
+      get serializer =>
+          _$gBookFragmentDataBaseAuthorAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asGroup_members__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asGroup_members__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asGroup_members__base.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author__asGroup_members__asPerson
+    implements
+        Built<GBookFragmentData__base_author__asGroup_members__asPerson,
+            GBookFragmentData__base_author__asGroup_members__asPersonBuilder>,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragmentData_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragmentData__base_author__asGroup_members,
+        GAuthorPersonFragment {
+  GBookFragmentData__base_author__asGroup_members__asPerson._();
+
+  factory GBookFragmentData__base_author__asGroup_members__asPerson(
+      [void Function(
+              GBookFragmentData__base_author__asGroup_members__asPersonBuilder
+                  b)
+          updates]) = _$GBookFragmentData__base_author__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__asGroup_members__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GBookFragmentData__base_author__asGroup_members__asPerson>
+      get serializer =>
+          _$gBookFragmentDataBaseAuthorAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asGroup_members__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asGroup_members__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asGroup_members__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__base_author__asGroup_members__asCompany
+    implements
+        Built<GBookFragmentData__base_author__asGroup_members__asCompany,
+            GBookFragmentData__base_author__asGroup_members__asCompanyBuilder>,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragmentData_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragmentData__base_author__asGroup_members,
+        GAuthorCompanyFragment {
+  GBookFragmentData__base_author__asGroup_members__asCompany._();
+
+  factory GBookFragmentData__base_author__asGroup_members__asCompany(
+      [void Function(
+              GBookFragmentData__base_author__asGroup_members__asCompanyBuilder
+                  b)
+          updates]) = _$GBookFragmentData__base_author__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GBookFragmentData__base_author__asGroup_members__asCompanyBuilder
+              b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GBookFragmentData__base_author__asGroup_members__asCompany>
+      get serializer =>
+          _$gBookFragmentDataBaseAuthorAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__base_author__asGroup_members__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__base_author__asGroup_members__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__base_author__asGroup_members__asCompany.serializer,
         json,
       );
 }
@@ -1920,6 +3484,7 @@ abstract class GBookFragmentData__asTextbook_author
         {
           'Person': GBookFragmentData__asTextbook_author__asPerson,
           'Company': GBookFragmentData__asTextbook_author__asCompany,
+          'Group': GBookFragmentData__asTextbook_author__asGroup,
         },
       );
 
@@ -1942,6 +3507,7 @@ extension GBookFragmentData__asTextbook_authorWhenExtension
     required _T Function(GBookFragmentData__asTextbook_author__asPerson) person,
     required _T Function(GBookFragmentData__asTextbook_author__asCompany)
         company,
+    required _T Function(GBookFragmentData__asTextbook_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1950,6 +3516,8 @@ extension GBookFragmentData__asTextbook_authorWhenExtension
       case 'Company':
         return company(
             (this as GBookFragmentData__asTextbook_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragmentData__asTextbook_author__asGroup));
       default:
         return orElse();
     }
@@ -1958,6 +3526,7 @@ extension GBookFragmentData__asTextbook_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GBookFragmentData__asTextbook_author__asPerson)? person,
     _T Function(GBookFragmentData__asTextbook_author__asCompany)? company,
+    _T Function(GBookFragmentData__asTextbook_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -1968,6 +3537,10 @@ extension GBookFragmentData__asTextbook_authorWhenExtension
       case 'Company':
         return company != null
             ? company((this as GBookFragmentData__asTextbook_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragmentData__asTextbook_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -2024,7 +3597,8 @@ abstract class GBookFragmentData__asTextbook_author__asPerson
         GBookFragment__asTextbook_author__asPerson,
         GBookFragmentData_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragmentData__asTextbook_author {
+        GBookFragmentData__asTextbook_author,
+        GAuthorPersonFragment {
   GBookFragmentData__asTextbook_author__asPerson._();
 
   factory GBookFragmentData__asTextbook_author__asPerson(
@@ -2072,7 +3646,8 @@ abstract class GBookFragmentData__asTextbook_author__asCompany
         GBookFragment__asTextbook_author__asCompany,
         GBookFragmentData_author__asCompany,
         GAuthorFragment__asCompany,
-        GBookFragmentData__asTextbook_author {
+        GBookFragmentData__asTextbook_author,
+        GAuthorCompanyFragment {
   GBookFragmentData__asTextbook_author__asCompany._();
 
   factory GBookFragmentData__asTextbook_author__asCompany(
@@ -2104,6 +3679,294 @@ abstract class GBookFragmentData__asTextbook_author__asCompany
         GBookFragmentData__asTextbook_author__asCompany.serializer,
         json,
       );
+}
+
+abstract class GBookFragmentData__asTextbook_author__asGroup
+    implements
+        Built<GBookFragmentData__asTextbook_author__asGroup,
+            GBookFragmentData__asTextbook_author__asGroupBuilder>,
+        GBookFragment_author,
+        GBookFragment__asTextbook_author,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GBookFragment__asTextbook_author__asGroup,
+        GBookFragmentData_author__asGroup,
+        GAuthorFragment__asGroup,
+        GBookFragmentData__asTextbook_author {
+  GBookFragmentData__asTextbook_author__asGroup._();
+
+  factory GBookFragmentData__asTextbook_author__asGroup(
+      [void Function(GBookFragmentData__asTextbook_author__asGroupBuilder b)
+          updates]) = _$GBookFragmentData__asTextbook_author__asGroup;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragmentData__asTextbook_author__asGroup_members> get members;
+  static Serializer<GBookFragmentData__asTextbook_author__asGroup>
+      get serializer => _$gBookFragmentDataAsTextbookAuthorAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asGroup? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asTextbook_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asTextbook_author__asGroup_members>
+      get serializer => _i2.InlineFragmentSerializer<
+              GBookFragmentData__asTextbook_author__asGroup_members>(
+            'GBookFragmentData__asTextbook_author__asGroup_members',
+            GBookFragmentData__asTextbook_author__asGroup_members__base,
+            {
+              'Person':
+                  GBookFragmentData__asTextbook_author__asGroup_members__asPerson,
+              'Company':
+                  GBookFragmentData__asTextbook_author__asGroup_members__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentData__asTextbook_author__asGroup_membersWhenExtension
+    on GBookFragmentData__asTextbook_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GBookFragmentData__asTextbook_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GBookFragmentData__asTextbook_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GBookFragmentData__asTextbook_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            GBookFragmentData__asTextbook_author__asGroup_members__asPerson)?
+        person,
+    _T Function(
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GBookFragmentData__asTextbook_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GBookFragmentData__asTextbook_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__asTextbook_author__asGroup_members__base
+    implements
+        Built<GBookFragmentData__asTextbook_author__asGroup_members__base,
+            GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder>,
+        GBookFragmentData__asTextbook_author__asGroup_members,
+        GAuthorGroupFragment {
+  GBookFragmentData__asTextbook_author__asGroup_members__base._();
+
+  factory GBookFragmentData__asTextbook_author__asGroup_members__base(
+      [void Function(
+              GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder
+                  b)
+          updates]) = _$GBookFragmentData__asTextbook_author__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder
+              b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asTextbook_author__asGroup_members__base>
+      get serializer =>
+          _$gBookFragmentDataAsTextbookAuthorAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asGroup_members__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asGroup_members__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asTextbook_author__asGroup_members__base.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+    implements
+        Built<GBookFragmentData__asTextbook_author__asGroup_members__asPerson,
+            GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GBookFragment__asTextbook_author__asGroup_members__asPerson,
+        GBookFragmentData_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragmentData__asTextbook_author__asGroup_members,
+        GAuthorPersonFragment {
+  GBookFragmentData__asTextbook_author__asGroup_members__asPerson._();
+
+  factory GBookFragmentData__asTextbook_author__asGroup_members__asPerson(
+          [void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder
+                      b)
+              updates]) =
+      _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder
+              b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<
+          GBookFragmentData__asTextbook_author__asGroup_members__asPerson>
+      get serializer =>
+          _$gBookFragmentDataAsTextbookAuthorAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asGroup_members__asPerson?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+                .serializer,
+            json,
+          );
+}
+
+abstract class GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+    implements
+        Built<GBookFragmentData__asTextbook_author__asGroup_members__asCompany,
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asTextbook_author__asGroup_members,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GBookFragment__asTextbook_author__asGroup_members__asCompany,
+        GBookFragmentData_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragmentData__asTextbook_author__asGroup_members,
+        GAuthorCompanyFragment {
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompany._();
+
+  factory GBookFragmentData__asTextbook_author__asGroup_members__asCompany(
+          [void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder
+                      b)
+              updates]) =
+      _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder
+              b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<
+          GBookFragmentData__asTextbook_author__asGroup_members__asCompany>
+      get serializer =>
+          _$gBookFragmentDataAsTextbookAuthorAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asTextbook_author__asGroup_members__asCompany?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+                .serializer,
+            json,
+          );
 }
 
 abstract class GBookFragmentData__asColoringBook
@@ -2165,6 +4028,7 @@ abstract class GBookFragmentData__asColoringBook_author
         {
           'Person': GBookFragmentData__asColoringBook_author__asPerson,
           'Company': GBookFragmentData__asColoringBook_author__asCompany,
+          'Group': GBookFragmentData__asColoringBook_author__asGroup,
         },
       );
 
@@ -2188,6 +4052,8 @@ extension GBookFragmentData__asColoringBook_authorWhenExtension
         person,
     required _T Function(GBookFragmentData__asColoringBook_author__asCompany)
         company,
+    required _T Function(GBookFragmentData__asColoringBook_author__asGroup)
+        group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -2197,6 +4063,9 @@ extension GBookFragmentData__asColoringBook_authorWhenExtension
       case 'Company':
         return company(
             (this as GBookFragmentData__asColoringBook_author__asCompany));
+      case 'Group':
+        return group(
+            (this as GBookFragmentData__asColoringBook_author__asGroup));
       default:
         return orElse();
     }
@@ -2205,6 +4074,7 @@ extension GBookFragmentData__asColoringBook_authorWhenExtension
   _T maybeWhen<_T>({
     _T Function(GBookFragmentData__asColoringBook_author__asPerson)? person,
     _T Function(GBookFragmentData__asColoringBook_author__asCompany)? company,
+    _T Function(GBookFragmentData__asColoringBook_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -2217,6 +4087,10 @@ extension GBookFragmentData__asColoringBook_authorWhenExtension
         return company != null
             ? company(
                 (this as GBookFragmentData__asColoringBook_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragmentData__asColoringBook_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -2273,7 +4147,8 @@ abstract class GBookFragmentData__asColoringBook_author__asPerson
         GBookFragment__asColoringBook_author__asPerson,
         GBookFragmentData_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragmentData__asColoringBook_author {
+        GBookFragmentData__asColoringBook_author,
+        GAuthorPersonFragment {
   GBookFragmentData__asColoringBook_author__asPerson._();
 
   factory GBookFragmentData__asColoringBook_author__asPerson(
@@ -2323,7 +4198,8 @@ abstract class GBookFragmentData__asColoringBook_author__asCompany
         GBookFragment__asColoringBook_author__asCompany,
         GBookFragmentData_author__asCompany,
         GAuthorFragment__asCompany,
-        GBookFragmentData__asColoringBook_author {
+        GBookFragmentData__asColoringBook_author,
+        GAuthorCompanyFragment {
   GBookFragmentData__asColoringBook_author__asCompany._();
 
   factory GBookFragmentData__asColoringBook_author__asCompany(
@@ -2359,6 +4235,301 @@ abstract class GBookFragmentData__asColoringBook_author__asCompany
       );
 }
 
+abstract class GBookFragmentData__asColoringBook_author__asGroup
+    implements
+        Built<GBookFragmentData__asColoringBook_author__asGroup,
+            GBookFragmentData__asColoringBook_author__asGroupBuilder>,
+        GBookFragment_author,
+        GBookFragment__asColoringBook_author,
+        GBookFragmentData_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GBookFragment__asColoringBook_author__asGroup,
+        GBookFragmentData_author__asGroup,
+        GAuthorFragment__asGroup,
+        GBookFragmentData__asColoringBook_author {
+  GBookFragmentData__asColoringBook_author__asGroup._();
+
+  factory GBookFragmentData__asColoringBook_author__asGroup(
+      [void Function(GBookFragmentData__asColoringBook_author__asGroupBuilder b)
+          updates]) = _$GBookFragmentData__asColoringBook_author__asGroup;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragmentData__asColoringBook_author__asGroup_members>
+      get members;
+  static Serializer<GBookFragmentData__asColoringBook_author__asGroup>
+      get serializer =>
+          _$gBookFragmentDataAsColoringBookAuthorAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asGroup? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentData__asColoringBook_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GBookFragmentData__asColoringBook_author__asGroup_members>
+      get serializer => _i2.InlineFragmentSerializer<
+              GBookFragmentData__asColoringBook_author__asGroup_members>(
+            'GBookFragmentData__asColoringBook_author__asGroup_members',
+            GBookFragmentData__asColoringBook_author__asGroup_members__base,
+            {
+              'Person':
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asPerson,
+              'Company':
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asCompany,
+            },
+          );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GBookFragmentData__asColoringBook_author__asGroup_membersWhenExtension
+    on GBookFragmentData__asColoringBook_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPerson)
+        person,
+    required _T Function(
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this
+            as GBookFragmentData__asColoringBook_author__asGroup_members__asPerson));
+      case 'Company':
+        return company((this
+            as GBookFragmentData__asColoringBook_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPerson)?
+        person,
+    _T Function(
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompany)?
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this
+                as GBookFragmentData__asColoringBook_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this
+                as GBookFragmentData__asColoringBook_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData__asColoringBook_author__asGroup_members__base
+    implements
+        Built<GBookFragmentData__asColoringBook_author__asGroup_members__base,
+            GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder>,
+        GBookFragmentData__asColoringBook_author__asGroup_members,
+        GAuthorGroupFragment {
+  GBookFragmentData__asColoringBook_author__asGroup_members__base._();
+
+  factory GBookFragmentData__asColoringBook_author__asGroup_members__base(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder
+                      b)
+              updates]) =
+      _$GBookFragmentData__asColoringBook_author__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder
+              b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<
+          GBookFragmentData__asColoringBook_author__asGroup_members__base>
+      get serializer =>
+          _$gBookFragmentDataAsColoringBookAuthorAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup_members__base
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asGroup_members__base?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GBookFragmentData__asColoringBook_author__asGroup_members__base
+                .serializer,
+            json,
+          );
+}
+
+abstract class GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+    implements
+        Built<
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPerson,
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GBookFragment__asColoringBook_author__asGroup_members__asPerson,
+        GBookFragmentData_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragmentData__asColoringBook_author__asGroup_members,
+        GAuthorPersonFragment {
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPerson._();
+
+  factory GBookFragmentData__asColoringBook_author__asGroup_members__asPerson(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder
+                      b)
+              updates]) =
+      _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder
+              b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<
+          GBookFragmentData__asColoringBook_author__asGroup_members__asPerson>
+      get serializer =>
+          _$gBookFragmentDataAsColoringBookAuthorAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asGroup_members__asPerson?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+                .serializer,
+            json,
+          );
+}
+
+abstract class GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+    implements
+        Built<
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompany,
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder>,
+        GBookFragment_author__asGroup_members,
+        GBookFragment__asColoringBook_author__asGroup_members,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GBookFragment__asColoringBook_author__asGroup_members__asCompany,
+        GBookFragmentData_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragmentData__asColoringBook_author__asGroup_members,
+        GAuthorCompanyFragment {
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompany._();
+
+  factory GBookFragmentData__asColoringBook_author__asGroup_members__asCompany(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder
+                      b)
+              updates]) =
+      _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder
+              b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<
+          GBookFragmentData__asColoringBook_author__asGroup_members__asCompany>
+      get serializer =>
+          _$gBookFragmentDataAsColoringBookAuthorAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+            .serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentData__asColoringBook_author__asGroup_members__asCompany?
+      fromJson(Map<String, dynamic> json) => _i1.serializers.deserializeWith(
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+                .serializer,
+            json,
+          );
+}
+
 abstract class GBookFragmentData_author
     implements GBookFragment_author, GAuthorFragment {
   @override
@@ -2371,6 +4542,7 @@ extension GBookFragmentData_authorWhenExtension on GBookFragmentData_author {
   _T when<_T>({
     required _T Function(GBookFragmentData_author__asPerson) person,
     required _T Function(GBookFragmentData_author__asCompany) company,
+    required _T Function(GBookFragmentData_author__asGroup) group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -2378,6 +4550,8 @@ extension GBookFragmentData_authorWhenExtension on GBookFragmentData_author {
         return person((this as GBookFragmentData_author__asPerson));
       case 'Company':
         return company((this as GBookFragmentData_author__asCompany));
+      case 'Group':
+        return group((this as GBookFragmentData_author__asGroup));
       default:
         return orElse();
     }
@@ -2386,6 +4560,7 @@ extension GBookFragmentData_authorWhenExtension on GBookFragmentData_author {
   _T maybeWhen<_T>({
     _T Function(GBookFragmentData_author__asPerson)? person,
     _T Function(GBookFragmentData_author__asCompany)? company,
+    _T Function(GBookFragmentData_author__asGroup)? group,
     required _T Function() orElse,
   }) {
     switch (G__typename) {
@@ -2396,6 +4571,10 @@ extension GBookFragmentData_authorWhenExtension on GBookFragmentData_author {
       case 'Company':
         return company != null
             ? company((this as GBookFragmentData_author__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GBookFragmentData_author__asGroup))
             : orElse();
       default:
         return orElse();
@@ -2417,7 +4596,8 @@ abstract class GBookFragmentData_author__asPerson
         GAuthorFragment,
         GBookFragment_author__asPerson,
         GAuthorFragment__asPerson,
-        GBookFragmentData_author {
+        GBookFragmentData_author,
+        GAuthorPersonFragment {
   @override
   String get G__typename;
   @override
@@ -2434,11 +4614,1044 @@ abstract class GBookFragmentData_author__asCompany
         GAuthorFragment,
         GBookFragment_author__asCompany,
         GAuthorFragment__asCompany,
-        GBookFragmentData_author {
+        GBookFragmentData_author,
+        GAuthorCompanyFragment {
   @override
   String get G__typename;
   @override
   String get displayName;
   @override
   String get name;
+}
+
+abstract class GBookFragmentData_author__asGroup
+    implements
+        GBookFragment_author,
+        GAuthorFragment,
+        GBookFragment_author__asGroup,
+        GAuthorFragment__asGroup,
+        GBookFragmentData_author {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GBookFragmentData_author__asGroup_members> get members;
+}
+
+abstract class GBookFragmentData_author__asGroup_members
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GBookFragmentData_author__asGroup_membersWhenExtension
+    on GBookFragmentData_author__asGroup_members {
+  _T when<_T>({
+    required _T Function(GBookFragmentData_author__asGroup_members__asPerson)
+        person,
+    required _T Function(GBookFragmentData_author__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person(
+            (this as GBookFragmentData_author__asGroup_members__asPerson));
+      case 'Company':
+        return company(
+            (this as GBookFragmentData_author__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GBookFragmentData_author__asGroup_members__asPerson)? person,
+    _T Function(GBookFragmentData_author__asGroup_members__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person(
+                (this as GBookFragmentData_author__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company(
+                (this as GBookFragmentData_author__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GBookFragmentData_author__asGroup_members__base
+    implements GBookFragmentData_author__asGroup_members, GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GBookFragmentData_author__asGroup_members__asPerson
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asPerson,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GBookFragmentData_author__asGroup_members__asCompany
+    implements
+        GBookFragment_author__asGroup_members,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GBookFragment_author__asGroup_members__asCompany,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GBookFragmentData_author__asGroup_members,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GAuthorFragment {
+  String get G__typename;
+  String get displayName;
+}
+
+extension GAuthorFragmentWhenExtension on GAuthorFragment {
+  _T when<_T>({
+    required _T Function(GAuthorFragment__asPerson) person,
+    required _T Function(GAuthorFragment__asCompany) company,
+    required _T Function(GAuthorFragment__asGroup) group,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorFragment__asPerson));
+      case 'Company':
+        return company((this as GAuthorFragment__asCompany));
+      case 'Group':
+        return group((this as GAuthorFragment__asGroup));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorFragment__asPerson)? person,
+    _T Function(GAuthorFragment__asCompany)? company,
+    _T Function(GAuthorFragment__asGroup)? group,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorFragment__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorFragment__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GAuthorFragment__asGroup))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorFragment__base implements GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GAuthorFragment__asPerson
+    implements GAuthorFragment, GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GAuthorFragment__asCompany
+    implements GAuthorFragment, GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GAuthorFragment__asGroup implements GAuthorFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  BuiltList<GAuthorFragment__asGroup_members> get members;
+}
+
+abstract class GAuthorFragment__asGroup_members
+    implements GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+extension GAuthorFragment__asGroup_membersWhenExtension
+    on GAuthorFragment__asGroup_members {
+  _T when<_T>({
+    required _T Function(GAuthorFragment__asGroup_members__asPerson) person,
+    required _T Function(GAuthorFragment__asGroup_members__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorFragment__asGroup_members__asPerson));
+      case 'Company':
+        return company((this as GAuthorFragment__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorFragment__asGroup_members__asPerson)? person,
+    _T Function(GAuthorFragment__asGroup_members__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorFragment__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorFragment__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorFragment__asGroup_members__base
+    implements GAuthorFragment__asGroup_members, GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GAuthorFragment__asGroup_members__asPerson
+    implements
+        GAuthorGroupFragment,
+        GAuthorGroupFragment__asPerson,
+        GAuthorFragment__asGroup_members,
+        GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GAuthorFragment__asGroup_members__asCompany
+    implements
+        GAuthorGroupFragment,
+        GAuthorGroupFragment__asCompany,
+        GAuthorFragment__asGroup_members,
+        GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GAuthorFragmentData implements GAuthorFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorFragmentData> get serializer =>
+      _i2.InlineFragmentSerializer<GAuthorFragmentData>(
+        'GAuthorFragmentData',
+        GAuthorFragmentData__base,
+        {
+          'Person': GAuthorFragmentData__asPerson,
+          'Company': GAuthorFragmentData__asCompany,
+          'Group': GAuthorFragmentData__asGroup,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData.serializer,
+        json,
+      );
+}
+
+extension GAuthorFragmentDataWhenExtension on GAuthorFragmentData {
+  _T when<_T>({
+    required _T Function(GAuthorFragmentData__asPerson) person,
+    required _T Function(GAuthorFragmentData__asCompany) company,
+    required _T Function(GAuthorFragmentData__asGroup) group,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorFragmentData__asPerson));
+      case 'Company':
+        return company((this as GAuthorFragmentData__asCompany));
+      case 'Group':
+        return group((this as GAuthorFragmentData__asGroup));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorFragmentData__asPerson)? person,
+    _T Function(GAuthorFragmentData__asCompany)? company,
+    _T Function(GAuthorFragmentData__asGroup)? group,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorFragmentData__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorFragmentData__asCompany))
+            : orElse();
+      case 'Group':
+        return group != null
+            ? group((this as GAuthorFragmentData__asGroup))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorFragmentData__base
+    implements
+        Built<GAuthorFragmentData__base, GAuthorFragmentData__baseBuilder>,
+        GAuthorFragmentData {
+  GAuthorFragmentData__base._();
+
+  factory GAuthorFragmentData__base(
+          [void Function(GAuthorFragmentData__baseBuilder b) updates]) =
+      _$GAuthorFragmentData__base;
+
+  static void _initializeBuilder(GAuthorFragmentData__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorFragmentData__base> get serializer =>
+      _$gAuthorFragmentDataBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__base? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__base.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asPerson
+    implements
+        Built<GAuthorFragmentData__asPerson,
+            GAuthorFragmentData__asPersonBuilder>,
+        GAuthorFragment,
+        GAuthorFragment__asPerson,
+        GAuthorFragmentData,
+        GAuthorPersonFragment {
+  GAuthorFragmentData__asPerson._();
+
+  factory GAuthorFragmentData__asPerson(
+          [void Function(GAuthorFragmentData__asPersonBuilder b) updates]) =
+      _$GAuthorFragmentData__asPerson;
+
+  static void _initializeBuilder(GAuthorFragmentData__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GAuthorFragmentData__asPerson> get serializer =>
+      _$gAuthorFragmentDataAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asPerson? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asCompany
+    implements
+        Built<GAuthorFragmentData__asCompany,
+            GAuthorFragmentData__asCompanyBuilder>,
+        GAuthorFragment,
+        GAuthorFragment__asCompany,
+        GAuthorFragmentData,
+        GAuthorCompanyFragment {
+  GAuthorFragmentData__asCompany._();
+
+  factory GAuthorFragmentData__asCompany(
+          [void Function(GAuthorFragmentData__asCompanyBuilder b) updates]) =
+      _$GAuthorFragmentData__asCompany;
+
+  static void _initializeBuilder(GAuthorFragmentData__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GAuthorFragmentData__asCompany> get serializer =>
+      _$gAuthorFragmentDataAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asCompany? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asGroup
+    implements
+        Built<GAuthorFragmentData__asGroup,
+            GAuthorFragmentData__asGroupBuilder>,
+        GAuthorFragment,
+        GAuthorFragment__asGroup,
+        GAuthorFragmentData {
+  GAuthorFragmentData__asGroup._();
+
+  factory GAuthorFragmentData__asGroup(
+          [void Function(GAuthorFragmentData__asGroupBuilder b) updates]) =
+      _$GAuthorFragmentData__asGroup;
+
+  static void _initializeBuilder(GAuthorFragmentData__asGroupBuilder b) =>
+      b..G__typename = 'Group';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  BuiltList<GAuthorFragmentData__asGroup_members> get members;
+  static Serializer<GAuthorFragmentData__asGroup> get serializer =>
+      _$gAuthorFragmentDataAsGroupSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asGroup.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asGroup? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asGroup.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asGroup_members
+    implements GAuthorFragment__asGroup_members, GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorFragmentData__asGroup_members> get serializer =>
+      _i2.InlineFragmentSerializer<GAuthorFragmentData__asGroup_members>(
+        'GAuthorFragmentData__asGroup_members',
+        GAuthorFragmentData__asGroup_members__base,
+        {
+          'Person': GAuthorFragmentData__asGroup_members__asPerson,
+          'Company': GAuthorFragmentData__asGroup_members__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asGroup_members.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asGroup_members? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asGroup_members.serializer,
+        json,
+      );
+}
+
+extension GAuthorFragmentData__asGroup_membersWhenExtension
+    on GAuthorFragmentData__asGroup_members {
+  _T when<_T>({
+    required _T Function(GAuthorFragmentData__asGroup_members__asPerson) person,
+    required _T Function(GAuthorFragmentData__asGroup_members__asCompany)
+        company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorFragmentData__asGroup_members__asPerson));
+      case 'Company':
+        return company(
+            (this as GAuthorFragmentData__asGroup_members__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorFragmentData__asGroup_members__asPerson)? person,
+    _T Function(GAuthorFragmentData__asGroup_members__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorFragmentData__asGroup_members__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorFragmentData__asGroup_members__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorFragmentData__asGroup_members__base
+    implements
+        Built<GAuthorFragmentData__asGroup_members__base,
+            GAuthorFragmentData__asGroup_members__baseBuilder>,
+        GAuthorFragmentData__asGroup_members,
+        GAuthorGroupFragment {
+  GAuthorFragmentData__asGroup_members__base._();
+
+  factory GAuthorFragmentData__asGroup_members__base(
+      [void Function(GAuthorFragmentData__asGroup_members__baseBuilder b)
+          updates]) = _$GAuthorFragmentData__asGroup_members__base;
+
+  static void _initializeBuilder(
+          GAuthorFragmentData__asGroup_members__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorFragmentData__asGroup_members__base>
+      get serializer => _$gAuthorFragmentDataAsGroupMembersBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asGroup_members__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asGroup_members__base? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asGroup_members__base.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asGroup_members__asPerson
+    implements
+        Built<GAuthorFragmentData__asGroup_members__asPerson,
+            GAuthorFragmentData__asGroup_members__asPersonBuilder>,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GAuthorFragment__asGroup_members__asPerson,
+        GAuthorGroupFragment__asPerson,
+        GAuthorFragmentData__asGroup_members,
+        GAuthorPersonFragment {
+  GAuthorFragmentData__asGroup_members__asPerson._();
+
+  factory GAuthorFragmentData__asGroup_members__asPerson(
+      [void Function(GAuthorFragmentData__asGroup_members__asPersonBuilder b)
+          updates]) = _$GAuthorFragmentData__asGroup_members__asPerson;
+
+  static void _initializeBuilder(
+          GAuthorFragmentData__asGroup_members__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GAuthorFragmentData__asGroup_members__asPerson>
+      get serializer => _$gAuthorFragmentDataAsGroupMembersAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asGroup_members__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asGroup_members__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asGroup_members__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentData__asGroup_members__asCompany
+    implements
+        Built<GAuthorFragmentData__asGroup_members__asCompany,
+            GAuthorFragmentData__asGroup_members__asCompanyBuilder>,
+        GAuthorFragment__asGroup_members,
+        GAuthorGroupFragment,
+        GAuthorFragment__asGroup_members__asCompany,
+        GAuthorGroupFragment__asCompany,
+        GAuthorFragmentData__asGroup_members,
+        GAuthorCompanyFragment {
+  GAuthorFragmentData__asGroup_members__asCompany._();
+
+  factory GAuthorFragmentData__asGroup_members__asCompany(
+      [void Function(GAuthorFragmentData__asGroup_members__asCompanyBuilder b)
+          updates]) = _$GAuthorFragmentData__asGroup_members__asCompany;
+
+  static void _initializeBuilder(
+          GAuthorFragmentData__asGroup_members__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GAuthorFragmentData__asGroup_members__asCompany>
+      get serializer => _$gAuthorFragmentDataAsGroupMembersAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentData__asGroup_members__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentData__asGroup_members__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentData__asGroup_members__asCompany.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorPersonFragment {
+  String get G__typename;
+  String get firstName;
+  String get lastName;
+}
+
+abstract class GAuthorPersonFragmentData
+    implements
+        Built<GAuthorPersonFragmentData, GAuthorPersonFragmentDataBuilder>,
+        GAuthorPersonFragment {
+  GAuthorPersonFragmentData._();
+
+  factory GAuthorPersonFragmentData(
+          [void Function(GAuthorPersonFragmentDataBuilder b) updates]) =
+      _$GAuthorPersonFragmentData;
+
+  static void _initializeBuilder(GAuthorPersonFragmentDataBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GAuthorPersonFragmentData> get serializer =>
+      _$gAuthorPersonFragmentDataSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorPersonFragmentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorPersonFragmentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorPersonFragmentData.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorCompanyFragment {
+  String get G__typename;
+  String get name;
+}
+
+abstract class GAuthorCompanyFragmentData
+    implements
+        Built<GAuthorCompanyFragmentData, GAuthorCompanyFragmentDataBuilder>,
+        GAuthorCompanyFragment {
+  GAuthorCompanyFragmentData._();
+
+  factory GAuthorCompanyFragmentData(
+          [void Function(GAuthorCompanyFragmentDataBuilder b) updates]) =
+      _$GAuthorCompanyFragmentData;
+
+  static void _initializeBuilder(GAuthorCompanyFragmentDataBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get name;
+  static Serializer<GAuthorCompanyFragmentData> get serializer =>
+      _$gAuthorCompanyFragmentDataSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorCompanyFragmentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorCompanyFragmentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorCompanyFragmentData.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorGroupFragment {
+  String get G__typename;
+  String get displayName;
+}
+
+extension GAuthorGroupFragmentWhenExtension on GAuthorGroupFragment {
+  _T when<_T>({
+    required _T Function(GAuthorGroupFragment__asPerson) person,
+    required _T Function(GAuthorGroupFragment__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorGroupFragment__asPerson));
+      case 'Company':
+        return company((this as GAuthorGroupFragment__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorGroupFragment__asPerson)? person,
+    _T Function(GAuthorGroupFragment__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorGroupFragment__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorGroupFragment__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorGroupFragment__base implements GAuthorGroupFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+}
+
+abstract class GAuthorGroupFragment__asPerson
+    implements GAuthorGroupFragment, GAuthorPersonFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+}
+
+abstract class GAuthorGroupFragment__asCompany
+    implements GAuthorGroupFragment, GAuthorCompanyFragment {
+  @override
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+}
+
+abstract class GAuthorGroupFragmentData implements GAuthorGroupFragment {
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorGroupFragmentData> get serializer =>
+      _i2.InlineFragmentSerializer<GAuthorGroupFragmentData>(
+        'GAuthorGroupFragmentData',
+        GAuthorGroupFragmentData__base,
+        {
+          'Person': GAuthorGroupFragmentData__asPerson,
+          'Company': GAuthorGroupFragmentData__asCompany,
+        },
+      );
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorGroupFragmentData.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorGroupFragmentData? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorGroupFragmentData.serializer,
+        json,
+      );
+}
+
+extension GAuthorGroupFragmentDataWhenExtension on GAuthorGroupFragmentData {
+  _T when<_T>({
+    required _T Function(GAuthorGroupFragmentData__asPerson) person,
+    required _T Function(GAuthorGroupFragmentData__asCompany) company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person((this as GAuthorGroupFragmentData__asPerson));
+      case 'Company':
+        return company((this as GAuthorGroupFragmentData__asCompany));
+      default:
+        return orElse();
+    }
+  }
+
+  _T maybeWhen<_T>({
+    _T Function(GAuthorGroupFragmentData__asPerson)? person,
+    _T Function(GAuthorGroupFragmentData__asCompany)? company,
+    required _T Function() orElse,
+  }) {
+    switch (G__typename) {
+      case 'Person':
+        return person != null
+            ? person((this as GAuthorGroupFragmentData__asPerson))
+            : orElse();
+      case 'Company':
+        return company != null
+            ? company((this as GAuthorGroupFragmentData__asCompany))
+            : orElse();
+      default:
+        return orElse();
+    }
+  }
+}
+
+abstract class GAuthorGroupFragmentData__base
+    implements
+        Built<GAuthorGroupFragmentData__base,
+            GAuthorGroupFragmentData__baseBuilder>,
+        GAuthorGroupFragmentData {
+  GAuthorGroupFragmentData__base._();
+
+  factory GAuthorGroupFragmentData__base(
+          [void Function(GAuthorGroupFragmentData__baseBuilder b) updates]) =
+      _$GAuthorGroupFragmentData__base;
+
+  static void _initializeBuilder(GAuthorGroupFragmentData__baseBuilder b) =>
+      b..G__typename = 'Author';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  static Serializer<GAuthorGroupFragmentData__base> get serializer =>
+      _$gAuthorGroupFragmentDataBaseSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorGroupFragmentData__base.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorGroupFragmentData__base? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorGroupFragmentData__base.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorGroupFragmentData__asPerson
+    implements
+        Built<GAuthorGroupFragmentData__asPerson,
+            GAuthorGroupFragmentData__asPersonBuilder>,
+        GAuthorGroupFragment,
+        GAuthorGroupFragment__asPerson,
+        GAuthorGroupFragmentData,
+        GAuthorPersonFragment {
+  GAuthorGroupFragmentData__asPerson._();
+
+  factory GAuthorGroupFragmentData__asPerson(
+      [void Function(GAuthorGroupFragmentData__asPersonBuilder b)
+          updates]) = _$GAuthorGroupFragmentData__asPerson;
+
+  static void _initializeBuilder(GAuthorGroupFragmentData__asPersonBuilder b) =>
+      b..G__typename = 'Person';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get firstName;
+  @override
+  String get lastName;
+  static Serializer<GAuthorGroupFragmentData__asPerson> get serializer =>
+      _$gAuthorGroupFragmentDataAsPersonSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorGroupFragmentData__asPerson.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorGroupFragmentData__asPerson? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorGroupFragmentData__asPerson.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorGroupFragmentData__asCompany
+    implements
+        Built<GAuthorGroupFragmentData__asCompany,
+            GAuthorGroupFragmentData__asCompanyBuilder>,
+        GAuthorGroupFragment,
+        GAuthorGroupFragment__asCompany,
+        GAuthorGroupFragmentData,
+        GAuthorCompanyFragment {
+  GAuthorGroupFragmentData__asCompany._();
+
+  factory GAuthorGroupFragmentData__asCompany(
+      [void Function(GAuthorGroupFragmentData__asCompanyBuilder b)
+          updates]) = _$GAuthorGroupFragmentData__asCompany;
+
+  static void _initializeBuilder(
+          GAuthorGroupFragmentData__asCompanyBuilder b) =>
+      b..G__typename = 'Company';
+
+  @override
+  @BuiltValueField(wireName: '__typename')
+  String get G__typename;
+  @override
+  String get displayName;
+  @override
+  String get name;
+  static Serializer<GAuthorGroupFragmentData__asCompany> get serializer =>
+      _$gAuthorGroupFragmentDataAsCompanySerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorGroupFragmentData__asCompany.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorGroupFragmentData__asCompany? fromJson(
+          Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorGroupFragmentData__asCompany.serializer,
+        json,
+      );
 }

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.g.dart
@@ -536,12 +536,6 @@ class _$GGetBooksData_books__asTextbook_author__asPersonSerializer
       'lastName',
       serializers.serialize(object.lastName,
           specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -573,15 +567,6 @@ class _$GGetBooksData_books__asTextbook_author__asPersonSerializer
           break;
         case 'lastName':
           result.lastName = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -616,12 +601,6 @@ class _$GGetBooksData_books__asTextbook_author__asCompanySerializer
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -649,15 +628,6 @@ class _$GGetBooksData_books__asTextbook_author__asCompanySerializer
           break;
         case 'name':
           result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -824,12 +794,6 @@ class _$GGetBooksData_books__asColoringBook_author__asPersonSerializer
       'lastName',
       serializers.serialize(object.lastName,
           specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -862,15 +826,6 @@ class _$GGetBooksData_books__asColoringBook_author__asPersonSerializer
           break;
         case 'lastName':
           result.lastName = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -906,12 +861,6 @@ class _$GGetBooksData_books__asColoringBook_author__asCompanySerializer
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -940,15 +889,6 @@ class _$GGetBooksData_books__asColoringBook_author__asCompanySerializer
           break;
         case 'name':
           result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -1532,12 +1472,6 @@ class _$GBookFragmentData__asTextbook_author__asPersonSerializer
       'lastName',
       serializers.serialize(object.lastName,
           specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -1571,15 +1505,6 @@ class _$GBookFragmentData__asTextbook_author__asPersonSerializer
           result.lastName = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
       }
     }
 
@@ -1611,12 +1536,6 @@ class _$GBookFragmentData__asTextbook_author__asCompanySerializer
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -1644,15 +1563,6 @@ class _$GBookFragmentData__asTextbook_author__asCompanySerializer
           break;
         case 'name':
           result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -1818,12 +1728,6 @@ class _$GBookFragmentData__asColoringBook_author__asPersonSerializer
       'lastName',
       serializers.serialize(object.lastName,
           specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -1855,15 +1759,6 @@ class _$GBookFragmentData__asColoringBook_author__asPersonSerializer
           break;
         case 'lastName':
           result.lastName = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -1898,12 +1793,6 @@ class _$GBookFragmentData__asColoringBook_author__asCompanySerializer
           specifiedType: const FullType(String)),
       'name',
       serializers.serialize(object.name, specifiedType: const FullType(String)),
-      'author',
-      serializers.serialize(object.author,
-          specifiedType: const FullType(GBookFragment_author)),
-      'title',
-      serializers.serialize(object.title,
-          specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -1931,15 +1820,6 @@ class _$GBookFragmentData__asColoringBook_author__asCompanySerializer
           break;
         case 'name':
           result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'author':
-          result.author = serializers.deserialize(value,
-                  specifiedType: const FullType(GBookFragment_author))!
-              as GBookFragment_author;
-          break;
-        case 'title':
-          result.title = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
       }
@@ -2801,10 +2681,6 @@ class _$GGetBooksData_books__asTextbook_author__asPerson
   final String firstName;
   @override
   final String lastName;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GGetBooksData_books__asTextbook_author__asPerson(
           [void Function(
@@ -2818,9 +2694,7 @@ class _$GGetBooksData_books__asTextbook_author__asPerson
       {required this.G__typename,
       required this.displayName,
       required this.firstName,
-      required this.lastName,
-      required this.author,
-      required this.title})
+      required this.lastName})
       : super._();
   @override
   GGetBooksData_books__asTextbook_author__asPerson rebuild(
@@ -2839,9 +2713,7 @@ class _$GGetBooksData_books__asTextbook_author__asPerson
         G__typename == other.G__typename &&
         displayName == other.displayName &&
         firstName == other.firstName &&
-        lastName == other.lastName &&
-        author == other.author &&
-        title == other.title;
+        lastName == other.lastName;
   }
 
   @override
@@ -2851,8 +2723,6 @@ class _$GGetBooksData_books__asTextbook_author__asPerson
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, firstName.hashCode);
     _$hash = $jc(_$hash, lastName.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -2864,9 +2734,7 @@ class _$GGetBooksData_books__asTextbook_author__asPerson
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
           ..add('firstName', firstName)
-          ..add('lastName', lastName)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('lastName', lastName))
         .toString();
   }
 }
@@ -2893,14 +2761,6 @@ class GGetBooksData_books__asTextbook_author__asPersonBuilder
   String? get lastName => _$this._lastName;
   set lastName(String? lastName) => _$this._lastName = lastName;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GGetBooksData_books__asTextbook_author__asPersonBuilder() {
     GGetBooksData_books__asTextbook_author__asPerson._initializeBuilder(this);
   }
@@ -2912,8 +2772,6 @@ class GGetBooksData_books__asTextbook_author__asPersonBuilder
       _displayName = $v.displayName;
       _firstName = $v.firstName;
       _lastName = $v.lastName;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -2949,10 +2807,6 @@ class GGetBooksData_books__asTextbook_author__asPersonBuilder
               r'GGetBooksData_books__asTextbook_author__asPerson', 'firstName'),
           lastName: BuiltValueNullFieldError.checkNotNull(lastName,
               r'GGetBooksData_books__asTextbook_author__asPerson', 'lastName'),
-          author: BuiltValueNullFieldError.checkNotNull(author,
-              r'GGetBooksData_books__asTextbook_author__asPerson', 'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GGetBooksData_books__asTextbook_author__asPerson', 'title'),
         );
     replace(_$result);
     return _$result;
@@ -2967,10 +2821,6 @@ class _$GGetBooksData_books__asTextbook_author__asCompany
   final String displayName;
   @override
   final String name;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GGetBooksData_books__asTextbook_author__asCompany(
           [void Function(
@@ -2983,9 +2833,7 @@ class _$GGetBooksData_books__asTextbook_author__asCompany
   _$GGetBooksData_books__asTextbook_author__asCompany._(
       {required this.G__typename,
       required this.displayName,
-      required this.name,
-      required this.author,
-      required this.title})
+      required this.name})
       : super._();
   @override
   GGetBooksData_books__asTextbook_author__asCompany rebuild(
@@ -3004,9 +2852,7 @@ class _$GGetBooksData_books__asTextbook_author__asCompany
     return other is GGetBooksData_books__asTextbook_author__asCompany &&
         G__typename == other.G__typename &&
         displayName == other.displayName &&
-        name == other.name &&
-        author == other.author &&
-        title == other.title;
+        name == other.name;
   }
 
   @override
@@ -3015,8 +2861,6 @@ class _$GGetBooksData_books__asTextbook_author__asCompany
     _$hash = $jc(_$hash, G__typename.hashCode);
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -3027,9 +2871,7 @@ class _$GGetBooksData_books__asTextbook_author__asCompany
             r'GGetBooksData_books__asTextbook_author__asCompany')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
-          ..add('name', name)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('name', name))
         .toString();
   }
 }
@@ -3052,14 +2894,6 @@ class GGetBooksData_books__asTextbook_author__asCompanyBuilder
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GGetBooksData_books__asTextbook_author__asCompanyBuilder() {
     GGetBooksData_books__asTextbook_author__asCompany._initializeBuilder(this);
   }
@@ -3070,8 +2904,6 @@ class GGetBooksData_books__asTextbook_author__asCompanyBuilder
       _G__typename = $v.G__typename;
       _displayName = $v.displayName;
       _name = $v.name;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -3105,10 +2937,6 @@ class GGetBooksData_books__asTextbook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(name,
               r'GGetBooksData_books__asTextbook_author__asCompany', 'name'),
-          author: BuiltValueNullFieldError.checkNotNull(author,
-              r'GGetBooksData_books__asTextbook_author__asCompany', 'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GGetBooksData_books__asTextbook_author__asCompany', 'title'),
         );
     replace(_$result);
     return _$result;
@@ -3385,10 +3213,6 @@ class _$GGetBooksData_books__asColoringBook_author__asPerson
   final String firstName;
   @override
   final String lastName;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GGetBooksData_books__asColoringBook_author__asPerson(
           [void Function(
@@ -3402,9 +3226,7 @@ class _$GGetBooksData_books__asColoringBook_author__asPerson
       {required this.G__typename,
       required this.displayName,
       required this.firstName,
-      required this.lastName,
-      required this.author,
-      required this.title})
+      required this.lastName})
       : super._();
   @override
   GGetBooksData_books__asColoringBook_author__asPerson rebuild(
@@ -3425,9 +3247,7 @@ class _$GGetBooksData_books__asColoringBook_author__asPerson
         G__typename == other.G__typename &&
         displayName == other.displayName &&
         firstName == other.firstName &&
-        lastName == other.lastName &&
-        author == other.author &&
-        title == other.title;
+        lastName == other.lastName;
   }
 
   @override
@@ -3437,8 +3257,6 @@ class _$GGetBooksData_books__asColoringBook_author__asPerson
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, firstName.hashCode);
     _$hash = $jc(_$hash, lastName.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -3450,9 +3268,7 @@ class _$GGetBooksData_books__asColoringBook_author__asPerson
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
           ..add('firstName', firstName)
-          ..add('lastName', lastName)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('lastName', lastName))
         .toString();
   }
 }
@@ -3479,14 +3295,6 @@ class GGetBooksData_books__asColoringBook_author__asPersonBuilder
   String? get lastName => _$this._lastName;
   set lastName(String? lastName) => _$this._lastName = lastName;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GGetBooksData_books__asColoringBook_author__asPersonBuilder() {
     GGetBooksData_books__asColoringBook_author__asPerson._initializeBuilder(
         this);
@@ -3499,8 +3307,6 @@ class GGetBooksData_books__asColoringBook_author__asPersonBuilder
       _displayName = $v.displayName;
       _firstName = $v.firstName;
       _lastName = $v.lastName;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -3541,12 +3347,6 @@ class GGetBooksData_books__asColoringBook_author__asPersonBuilder
               lastName,
               r'GGetBooksData_books__asColoringBook_author__asPerson',
               'lastName'),
-          author: BuiltValueNullFieldError.checkNotNull(
-              author,
-              r'GGetBooksData_books__asColoringBook_author__asPerson',
-              'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GGetBooksData_books__asColoringBook_author__asPerson', 'title'),
         );
     replace(_$result);
     return _$result;
@@ -3561,10 +3361,6 @@ class _$GGetBooksData_books__asColoringBook_author__asCompany
   final String displayName;
   @override
   final String name;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GGetBooksData_books__asColoringBook_author__asCompany(
           [void Function(
@@ -3577,9 +3373,7 @@ class _$GGetBooksData_books__asColoringBook_author__asCompany
   _$GGetBooksData_books__asColoringBook_author__asCompany._(
       {required this.G__typename,
       required this.displayName,
-      required this.name,
-      required this.author,
-      required this.title})
+      required this.name})
       : super._();
   @override
   GGetBooksData_books__asColoringBook_author__asCompany rebuild(
@@ -3599,9 +3393,7 @@ class _$GGetBooksData_books__asColoringBook_author__asCompany
     return other is GGetBooksData_books__asColoringBook_author__asCompany &&
         G__typename == other.G__typename &&
         displayName == other.displayName &&
-        name == other.name &&
-        author == other.author &&
-        title == other.title;
+        name == other.name;
   }
 
   @override
@@ -3610,8 +3402,6 @@ class _$GGetBooksData_books__asColoringBook_author__asCompany
     _$hash = $jc(_$hash, G__typename.hashCode);
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -3622,9 +3412,7 @@ class _$GGetBooksData_books__asColoringBook_author__asCompany
             r'GGetBooksData_books__asColoringBook_author__asCompany')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
-          ..add('name', name)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('name', name))
         .toString();
   }
 }
@@ -3647,14 +3435,6 @@ class GGetBooksData_books__asColoringBook_author__asCompanyBuilder
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GGetBooksData_books__asColoringBook_author__asCompanyBuilder() {
     GGetBooksData_books__asColoringBook_author__asCompany._initializeBuilder(
         this);
@@ -3666,8 +3446,6 @@ class GGetBooksData_books__asColoringBook_author__asCompanyBuilder
       _G__typename = $v.G__typename;
       _displayName = $v.displayName;
       _name = $v.name;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -3702,14 +3480,6 @@ class GGetBooksData_books__asColoringBook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(name,
               r'GGetBooksData_books__asColoringBook_author__asCompany', 'name'),
-          author: BuiltValueNullFieldError.checkNotNull(
-              author,
-              r'GGetBooksData_books__asColoringBook_author__asCompany',
-              'author'),
-          title: BuiltValueNullFieldError.checkNotNull(
-              title,
-              r'GGetBooksData_books__asColoringBook_author__asCompany',
-              'title'),
         );
     replace(_$result);
     return _$result;
@@ -4799,10 +4569,6 @@ class _$GBookFragmentData__asTextbook_author__asPerson
   final String firstName;
   @override
   final String lastName;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GBookFragmentData__asTextbook_author__asPerson(
           [void Function(GBookFragmentData__asTextbook_author__asPersonBuilder)?
@@ -4814,9 +4580,7 @@ class _$GBookFragmentData__asTextbook_author__asPerson
       {required this.G__typename,
       required this.displayName,
       required this.firstName,
-      required this.lastName,
-      required this.author,
-      required this.title})
+      required this.lastName})
       : super._();
   @override
   GBookFragmentData__asTextbook_author__asPerson rebuild(
@@ -4835,9 +4599,7 @@ class _$GBookFragmentData__asTextbook_author__asPerson
         G__typename == other.G__typename &&
         displayName == other.displayName &&
         firstName == other.firstName &&
-        lastName == other.lastName &&
-        author == other.author &&
-        title == other.title;
+        lastName == other.lastName;
   }
 
   @override
@@ -4847,8 +4609,6 @@ class _$GBookFragmentData__asTextbook_author__asPerson
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, firstName.hashCode);
     _$hash = $jc(_$hash, lastName.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -4860,9 +4620,7 @@ class _$GBookFragmentData__asTextbook_author__asPerson
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
           ..add('firstName', firstName)
-          ..add('lastName', lastName)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('lastName', lastName))
         .toString();
   }
 }
@@ -4889,14 +4647,6 @@ class GBookFragmentData__asTextbook_author__asPersonBuilder
   String? get lastName => _$this._lastName;
   set lastName(String? lastName) => _$this._lastName = lastName;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GBookFragmentData__asTextbook_author__asPersonBuilder() {
     GBookFragmentData__asTextbook_author__asPerson._initializeBuilder(this);
   }
@@ -4908,8 +4658,6 @@ class GBookFragmentData__asTextbook_author__asPersonBuilder
       _displayName = $v.displayName;
       _firstName = $v.firstName;
       _lastName = $v.lastName;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -4941,10 +4689,6 @@ class GBookFragmentData__asTextbook_author__asPersonBuilder
               r'GBookFragmentData__asTextbook_author__asPerson', 'firstName'),
           lastName: BuiltValueNullFieldError.checkNotNull(lastName,
               r'GBookFragmentData__asTextbook_author__asPerson', 'lastName'),
-          author: BuiltValueNullFieldError.checkNotNull(author,
-              r'GBookFragmentData__asTextbook_author__asPerson', 'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GBookFragmentData__asTextbook_author__asPerson', 'title'),
         );
     replace(_$result);
     return _$result;
@@ -4959,10 +4703,6 @@ class _$GBookFragmentData__asTextbook_author__asCompany
   final String displayName;
   @override
   final String name;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GBookFragmentData__asTextbook_author__asCompany(
           [void Function(
@@ -4975,9 +4715,7 @@ class _$GBookFragmentData__asTextbook_author__asCompany
   _$GBookFragmentData__asTextbook_author__asCompany._(
       {required this.G__typename,
       required this.displayName,
-      required this.name,
-      required this.author,
-      required this.title})
+      required this.name})
       : super._();
   @override
   GBookFragmentData__asTextbook_author__asCompany rebuild(
@@ -4995,9 +4733,7 @@ class _$GBookFragmentData__asTextbook_author__asCompany
     return other is GBookFragmentData__asTextbook_author__asCompany &&
         G__typename == other.G__typename &&
         displayName == other.displayName &&
-        name == other.name &&
-        author == other.author &&
-        title == other.title;
+        name == other.name;
   }
 
   @override
@@ -5006,8 +4742,6 @@ class _$GBookFragmentData__asTextbook_author__asCompany
     _$hash = $jc(_$hash, G__typename.hashCode);
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -5018,9 +4752,7 @@ class _$GBookFragmentData__asTextbook_author__asCompany
             r'GBookFragmentData__asTextbook_author__asCompany')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
-          ..add('name', name)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('name', name))
         .toString();
   }
 }
@@ -5043,14 +4775,6 @@ class GBookFragmentData__asTextbook_author__asCompanyBuilder
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GBookFragmentData__asTextbook_author__asCompanyBuilder() {
     GBookFragmentData__asTextbook_author__asCompany._initializeBuilder(this);
   }
@@ -5061,8 +4785,6 @@ class GBookFragmentData__asTextbook_author__asCompanyBuilder
       _G__typename = $v.G__typename;
       _displayName = $v.displayName;
       _name = $v.name;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -5096,10 +4818,6 @@ class GBookFragmentData__asTextbook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(
               name, r'GBookFragmentData__asTextbook_author__asCompany', 'name'),
-          author: BuiltValueNullFieldError.checkNotNull(author,
-              r'GBookFragmentData__asTextbook_author__asCompany', 'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GBookFragmentData__asTextbook_author__asCompany', 'title'),
         );
     replace(_$result);
     return _$result;
@@ -5369,10 +5087,6 @@ class _$GBookFragmentData__asColoringBook_author__asPerson
   final String firstName;
   @override
   final String lastName;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GBookFragmentData__asColoringBook_author__asPerson(
           [void Function(
@@ -5386,9 +5100,7 @@ class _$GBookFragmentData__asColoringBook_author__asPerson
       {required this.G__typename,
       required this.displayName,
       required this.firstName,
-      required this.lastName,
-      required this.author,
-      required this.title})
+      required this.lastName})
       : super._();
   @override
   GBookFragmentData__asColoringBook_author__asPerson rebuild(
@@ -5409,9 +5121,7 @@ class _$GBookFragmentData__asColoringBook_author__asPerson
         G__typename == other.G__typename &&
         displayName == other.displayName &&
         firstName == other.firstName &&
-        lastName == other.lastName &&
-        author == other.author &&
-        title == other.title;
+        lastName == other.lastName;
   }
 
   @override
@@ -5421,8 +5131,6 @@ class _$GBookFragmentData__asColoringBook_author__asPerson
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, firstName.hashCode);
     _$hash = $jc(_$hash, lastName.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -5434,9 +5142,7 @@ class _$GBookFragmentData__asColoringBook_author__asPerson
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
           ..add('firstName', firstName)
-          ..add('lastName', lastName)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('lastName', lastName))
         .toString();
   }
 }
@@ -5463,14 +5169,6 @@ class GBookFragmentData__asColoringBook_author__asPersonBuilder
   String? get lastName => _$this._lastName;
   set lastName(String? lastName) => _$this._lastName = lastName;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GBookFragmentData__asColoringBook_author__asPersonBuilder() {
     GBookFragmentData__asColoringBook_author__asPerson._initializeBuilder(this);
   }
@@ -5482,8 +5180,6 @@ class GBookFragmentData__asColoringBook_author__asPersonBuilder
       _displayName = $v.displayName;
       _firstName = $v.firstName;
       _lastName = $v.lastName;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -5523,10 +5219,6 @@ class GBookFragmentData__asColoringBook_author__asPersonBuilder
               lastName,
               r'GBookFragmentData__asColoringBook_author__asPerson',
               'lastName'),
-          author: BuiltValueNullFieldError.checkNotNull(author,
-              r'GBookFragmentData__asColoringBook_author__asPerson', 'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GBookFragmentData__asColoringBook_author__asPerson', 'title'),
         );
     replace(_$result);
     return _$result;
@@ -5541,10 +5233,6 @@ class _$GBookFragmentData__asColoringBook_author__asCompany
   final String displayName;
   @override
   final String name;
-  @override
-  final GBookFragment_author author;
-  @override
-  final String title;
 
   factory _$GBookFragmentData__asColoringBook_author__asCompany(
           [void Function(
@@ -5557,9 +5245,7 @@ class _$GBookFragmentData__asColoringBook_author__asCompany
   _$GBookFragmentData__asColoringBook_author__asCompany._(
       {required this.G__typename,
       required this.displayName,
-      required this.name,
-      required this.author,
-      required this.title})
+      required this.name})
       : super._();
   @override
   GBookFragmentData__asColoringBook_author__asCompany rebuild(
@@ -5579,9 +5265,7 @@ class _$GBookFragmentData__asColoringBook_author__asCompany
     return other is GBookFragmentData__asColoringBook_author__asCompany &&
         G__typename == other.G__typename &&
         displayName == other.displayName &&
-        name == other.name &&
-        author == other.author &&
-        title == other.title;
+        name == other.name;
   }
 
   @override
@@ -5590,8 +5274,6 @@ class _$GBookFragmentData__asColoringBook_author__asCompany
     _$hash = $jc(_$hash, G__typename.hashCode);
     _$hash = $jc(_$hash, displayName.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
-    _$hash = $jc(_$hash, author.hashCode);
-    _$hash = $jc(_$hash, title.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -5602,9 +5284,7 @@ class _$GBookFragmentData__asColoringBook_author__asCompany
             r'GBookFragmentData__asColoringBook_author__asCompany')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
-          ..add('name', name)
-          ..add('author', author)
-          ..add('title', title))
+          ..add('name', name))
         .toString();
   }
 }
@@ -5627,14 +5307,6 @@ class GBookFragmentData__asColoringBook_author__asCompanyBuilder
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
 
-  GBookFragment_author? _author;
-  GBookFragment_author? get author => _$this._author;
-  set author(GBookFragment_author? author) => _$this._author = author;
-
-  String? _title;
-  String? get title => _$this._title;
-  set title(String? title) => _$this._title = title;
-
   GBookFragmentData__asColoringBook_author__asCompanyBuilder() {
     GBookFragmentData__asColoringBook_author__asCompany._initializeBuilder(
         this);
@@ -5646,8 +5318,6 @@ class GBookFragmentData__asColoringBook_author__asCompanyBuilder
       _G__typename = $v.G__typename;
       _displayName = $v.displayName;
       _name = $v.name;
-      _author = $v.author;
-      _title = $v.title;
       _$v = null;
     }
     return this;
@@ -5681,10 +5351,6 @@ class GBookFragmentData__asColoringBook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(name,
               r'GBookFragmentData__asColoringBook_author__asCompany', 'name'),
-          author: BuiltValueNullFieldError.checkNotNull(author,
-              r'GBookFragmentData__asColoringBook_author__asCompany', 'author'),
-          title: BuiltValueNullFieldError.checkNotNull(title,
-              r'GBookFragmentData__asColoringBook_author__asCompany', 'title'),
         );
     replace(_$result);
     return _$result;

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.g.dart
@@ -1,0 +1,5694 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nested_fragments_on_interface.data.gql.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GGetBooksData> _$gGetBooksDataSerializer =
+    _$GGetBooksDataSerializer();
+Serializer<GGetBooksData_books__base> _$gGetBooksDataBooksBaseSerializer =
+    _$GGetBooksData_books__baseSerializer();
+Serializer<GGetBooksData_books__base_author__base>
+    _$gGetBooksDataBooksBaseAuthorBaseSerializer =
+    _$GGetBooksData_books__base_author__baseSerializer();
+Serializer<GGetBooksData_books__base_author__asPerson>
+    _$gGetBooksDataBooksBaseAuthorAsPersonSerializer =
+    _$GGetBooksData_books__base_author__asPersonSerializer();
+Serializer<GGetBooksData_books__base_author__asCompany>
+    _$gGetBooksDataBooksBaseAuthorAsCompanySerializer =
+    _$GGetBooksData_books__base_author__asCompanySerializer();
+Serializer<GGetBooksData_books__asTextbook>
+    _$gGetBooksDataBooksAsTextbookSerializer =
+    _$GGetBooksData_books__asTextbookSerializer();
+Serializer<GGetBooksData_books__asTextbook_author__base>
+    _$gGetBooksDataBooksAsTextbookAuthorBaseSerializer =
+    _$GGetBooksData_books__asTextbook_author__baseSerializer();
+Serializer<GGetBooksData_books__asTextbook_author__asPerson>
+    _$gGetBooksDataBooksAsTextbookAuthorAsPersonSerializer =
+    _$GGetBooksData_books__asTextbook_author__asPersonSerializer();
+Serializer<GGetBooksData_books__asTextbook_author__asCompany>
+    _$gGetBooksDataBooksAsTextbookAuthorAsCompanySerializer =
+    _$GGetBooksData_books__asTextbook_author__asCompanySerializer();
+Serializer<GGetBooksData_books__asColoringBook>
+    _$gGetBooksDataBooksAsColoringBookSerializer =
+    _$GGetBooksData_books__asColoringBookSerializer();
+Serializer<GGetBooksData_books__asColoringBook_author__base>
+    _$gGetBooksDataBooksAsColoringBookAuthorBaseSerializer =
+    _$GGetBooksData_books__asColoringBook_author__baseSerializer();
+Serializer<GGetBooksData_books__asColoringBook_author__asPerson>
+    _$gGetBooksDataBooksAsColoringBookAuthorAsPersonSerializer =
+    _$GGetBooksData_books__asColoringBook_author__asPersonSerializer();
+Serializer<GGetBooksData_books__asColoringBook_author__asCompany>
+    _$gGetBooksDataBooksAsColoringBookAuthorAsCompanySerializer =
+    _$GGetBooksData_books__asColoringBook_author__asCompanySerializer();
+Serializer<GAuthorFragmentData__base> _$gAuthorFragmentDataBaseSerializer =
+    _$GAuthorFragmentData__baseSerializer();
+Serializer<GAuthorFragmentData__asPerson>
+    _$gAuthorFragmentDataAsPersonSerializer =
+    _$GAuthorFragmentData__asPersonSerializer();
+Serializer<GAuthorFragmentData__asCompany>
+    _$gAuthorFragmentDataAsCompanySerializer =
+    _$GAuthorFragmentData__asCompanySerializer();
+Serializer<GBookFragmentData__base> _$gBookFragmentDataBaseSerializer =
+    _$GBookFragmentData__baseSerializer();
+Serializer<GBookFragmentData__base_author__base>
+    _$gBookFragmentDataBaseAuthorBaseSerializer =
+    _$GBookFragmentData__base_author__baseSerializer();
+Serializer<GBookFragmentData__base_author__asPerson>
+    _$gBookFragmentDataBaseAuthorAsPersonSerializer =
+    _$GBookFragmentData__base_author__asPersonSerializer();
+Serializer<GBookFragmentData__base_author__asCompany>
+    _$gBookFragmentDataBaseAuthorAsCompanySerializer =
+    _$GBookFragmentData__base_author__asCompanySerializer();
+Serializer<GBookFragmentData__asTextbook>
+    _$gBookFragmentDataAsTextbookSerializer =
+    _$GBookFragmentData__asTextbookSerializer();
+Serializer<GBookFragmentData__asTextbook_author__base>
+    _$gBookFragmentDataAsTextbookAuthorBaseSerializer =
+    _$GBookFragmentData__asTextbook_author__baseSerializer();
+Serializer<GBookFragmentData__asTextbook_author__asPerson>
+    _$gBookFragmentDataAsTextbookAuthorAsPersonSerializer =
+    _$GBookFragmentData__asTextbook_author__asPersonSerializer();
+Serializer<GBookFragmentData__asTextbook_author__asCompany>
+    _$gBookFragmentDataAsTextbookAuthorAsCompanySerializer =
+    _$GBookFragmentData__asTextbook_author__asCompanySerializer();
+Serializer<GBookFragmentData__asColoringBook>
+    _$gBookFragmentDataAsColoringBookSerializer =
+    _$GBookFragmentData__asColoringBookSerializer();
+Serializer<GBookFragmentData__asColoringBook_author__base>
+    _$gBookFragmentDataAsColoringBookAuthorBaseSerializer =
+    _$GBookFragmentData__asColoringBook_author__baseSerializer();
+Serializer<GBookFragmentData__asColoringBook_author__asPerson>
+    _$gBookFragmentDataAsColoringBookAuthorAsPersonSerializer =
+    _$GBookFragmentData__asColoringBook_author__asPersonSerializer();
+Serializer<GBookFragmentData__asColoringBook_author__asCompany>
+    _$gBookFragmentDataAsColoringBookAuthorAsCompanySerializer =
+    _$GBookFragmentData__asColoringBook_author__asCompanySerializer();
+
+class _$GGetBooksDataSerializer implements StructuredSerializer<GGetBooksData> {
+  @override
+  final Iterable<Type> types = const [GGetBooksData, _$GGetBooksData];
+  @override
+  final String wireName = 'GGetBooksData';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GGetBooksData object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'books',
+      serializers.serialize(object.books,
+          specifiedType: const FullType(
+              BuiltList, const [const FullType(GGetBooksData_books)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksDataBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'books':
+          result.books.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(GGetBooksData_books)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__baseSerializer
+    implements StructuredSerializer<GGetBooksData_books__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base,
+    _$GGetBooksData_books__base
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GGetBooksData_books__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GGetBooksData_books__base_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GGetBooksData_books__base_author))!
+              as GGetBooksData_books__base_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__base_author__baseSerializer
+    implements StructuredSerializer<GGetBooksData_books__base_author__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__base,
+    _$GGetBooksData_books__base_author__base
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__base_author__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GGetBooksData_books__base_author__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__base_author__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__base_author__asPersonSerializer
+    implements
+        StructuredSerializer<GGetBooksData_books__base_author__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__asPerson,
+    _$GGetBooksData_books__base_author__asPerson
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__base_author__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__base_author__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__base_author__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__base_author__asCompanySerializer
+    implements
+        StructuredSerializer<GGetBooksData_books__base_author__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__asCompany,
+    _$GGetBooksData_books__base_author__asCompany
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__base_author__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__base_author__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__base_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbookSerializer
+    implements StructuredSerializer<GGetBooksData_books__asTextbook> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook,
+    _$GGetBooksData_books__asTextbook
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asTextbook';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GGetBooksData_books__asTextbook object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType:
+              const FullType(GGetBooksData_books__asTextbook_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+      'courses',
+      serializers.serialize(object.courses,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asTextbookBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GGetBooksData_books__asTextbook_author))!
+              as GGetBooksData_books__asTextbook_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'courses':
+          result.courses.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__baseSerializer
+    implements
+        StructuredSerializer<GGetBooksData_books__asTextbook_author__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__base,
+    _$GGetBooksData_books__asTextbook_author__base
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asTextbook_author__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asTextbook_author__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asPersonSerializer
+    implements
+        StructuredSerializer<GGetBooksData_books__asTextbook_author__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__asPerson,
+    _$GGetBooksData_books__asTextbook_author__asPerson
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asTextbook_author__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asTextbook_author__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asTextbook_author__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__asCompany,
+    _$GGetBooksData_books__asTextbook_author__asCompany
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asTextbook_author__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asTextbook_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asColoringBookSerializer
+    implements StructuredSerializer<GGetBooksData_books__asColoringBook> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asColoringBook,
+    _$GGetBooksData_books__asColoringBook
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asColoringBook';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GGetBooksData_books__asColoringBook object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType:
+              const FullType(GGetBooksData_books__asColoringBook_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+      'colors',
+      serializers.serialize(object.colors,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asColoringBookBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      GGetBooksData_books__asColoringBook_author))!
+              as GGetBooksData_books__asColoringBook_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'colors':
+          result.colors.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__baseSerializer
+    implements
+        StructuredSerializer<GGetBooksData_books__asColoringBook_author__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asColoringBook_author__base,
+    _$GGetBooksData_books__asColoringBook_author__base
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asColoringBook_author__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asColoringBook_author__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asColoringBook_author__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asColoringBook_author__asPerson,
+    _$GGetBooksData_books__asColoringBook_author__asPerson
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__asColoringBook_author__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asColoringBook_author__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asColoringBook_author__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asColoringBook_author__asCompany,
+    _$GGetBooksData_books__asColoringBook_author__asCompany
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__asColoringBook_author__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asColoringBook_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__baseSerializer
+    implements StructuredSerializer<GAuthorFragmentData__base> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__base,
+    _$GAuthorFragmentData__base
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asPersonSerializer
+    implements StructuredSerializer<GAuthorFragmentData__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asPerson,
+    _$GAuthorFragmentData__asPerson
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asPerson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asCompanySerializer
+    implements StructuredSerializer<GAuthorFragmentData__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asCompany,
+    _$GAuthorFragmentData__asCompany
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asCompany';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__baseSerializer
+    implements StructuredSerializer<GBookFragmentData__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base,
+    _$GBookFragmentData__base
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragmentData__base_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GBookFragmentData__base_author))!
+              as GBookFragmentData__base_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__baseSerializer
+    implements StructuredSerializer<GBookFragmentData__base_author__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__base,
+    _$GBookFragmentData__base_author__base
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__base_author__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__base_author__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__base_author__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__asPersonSerializer
+    implements StructuredSerializer<GBookFragmentData__base_author__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__asPerson,
+    _$GBookFragmentData__base_author__asPerson
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__base_author__asPerson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__base_author__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__base_author__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__asCompanySerializer
+    implements StructuredSerializer<GBookFragmentData__base_author__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__asCompany,
+    _$GBookFragmentData__base_author__asCompany
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__base_author__asCompany';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__base_author__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__base_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbookSerializer
+    implements StructuredSerializer<GBookFragmentData__asTextbook> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook,
+    _$GBookFragmentData__asTextbook
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asTextbook';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__asTextbook object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragmentData__asTextbook_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+      'courses',
+      serializers.serialize(object.courses,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asTextbookBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GBookFragmentData__asTextbook_author))!
+              as GBookFragmentData__asTextbook_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'courses':
+          result.courses.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__baseSerializer
+    implements
+        StructuredSerializer<GBookFragmentData__asTextbook_author__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__base,
+    _$GBookFragmentData__asTextbook_author__base
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asTextbook_author__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asTextbook_author__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asPersonSerializer
+    implements
+        StructuredSerializer<GBookFragmentData__asTextbook_author__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__asPerson,
+    _$GBookFragmentData__asTextbook_author__asPerson
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asTextbook_author__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asTextbook_author__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asCompanySerializer
+    implements
+        StructuredSerializer<GBookFragmentData__asTextbook_author__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__asCompany,
+    _$GBookFragmentData__asTextbook_author__asCompany
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asTextbook_author__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asTextbook_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBookSerializer
+    implements StructuredSerializer<GBookFragmentData__asColoringBook> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook,
+    _$GBookFragmentData__asColoringBook
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asColoringBook';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__asColoringBook object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType:
+              const FullType(GBookFragmentData__asColoringBook_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+      'colors',
+      serializers.serialize(object.colors,
+          specifiedType:
+              const FullType(BuiltList, const [const FullType(String)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asColoringBookBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(GBookFragmentData__asColoringBook_author))!
+              as GBookFragmentData__asColoringBook_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'colors':
+          result.colors.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(
+                      BuiltList, const [const FullType(String)]))!
+              as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__baseSerializer
+    implements
+        StructuredSerializer<GBookFragmentData__asColoringBook_author__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__base,
+    _$GBookFragmentData__asColoringBook_author__base
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asColoringBook_author__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asColoringBook_author__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asColoringBook_author__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asColoringBook_author__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__asPerson,
+    _$GBookFragmentData__asColoringBook_author__asPerson
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asColoringBook_author__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asColoringBook_author__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asColoringBook_author__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asColoringBook_author__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__asCompany,
+    _$GBookFragmentData__asColoringBook_author__asCompany
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asColoringBook_author__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asColoringBook_author__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+      'author',
+      serializers.serialize(object.author,
+          specifiedType: const FullType(GBookFragment_author)),
+      'title',
+      serializers.serialize(object.title,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asColoringBook_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'author':
+          result.author = serializers.deserialize(value,
+                  specifiedType: const FullType(GBookFragment_author))!
+              as GBookFragment_author;
+          break;
+        case 'title':
+          result.title = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData extends GGetBooksData {
+  @override
+  final String G__typename;
+  @override
+  final BuiltList<GGetBooksData_books> books;
+
+  factory _$GGetBooksData([void Function(GGetBooksDataBuilder)? updates]) =>
+      (GGetBooksDataBuilder()..update(updates))._build();
+
+  _$GGetBooksData._({required this.G__typename, required this.books})
+      : super._();
+  @override
+  GGetBooksData rebuild(void Function(GGetBooksDataBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksDataBuilder toBuilder() => GGetBooksDataBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData &&
+        G__typename == other.G__typename &&
+        books == other.books;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, books.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GGetBooksData')
+          ..add('G__typename', G__typename)
+          ..add('books', books))
+        .toString();
+  }
+}
+
+class GGetBooksDataBuilder
+    implements Builder<GGetBooksData, GGetBooksDataBuilder> {
+  _$GGetBooksData? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  ListBuilder<GGetBooksData_books>? _books;
+  ListBuilder<GGetBooksData_books> get books =>
+      _$this._books ??= ListBuilder<GGetBooksData_books>();
+  set books(ListBuilder<GGetBooksData_books>? books) => _$this._books = books;
+
+  GGetBooksDataBuilder() {
+    GGetBooksData._initializeBuilder(this);
+  }
+
+  GGetBooksDataBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _books = $v.books.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData other) {
+    _$v = other as _$GGetBooksData;
+  }
+
+  @override
+  void update(void Function(GGetBooksDataBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData build() => _build();
+
+  _$GGetBooksData _build() {
+    _$GGetBooksData _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooksData._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, r'GGetBooksData', 'G__typename'),
+            books: books.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'books';
+        books.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GGetBooksData', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base extends GGetBooksData_books__base {
+  @override
+  final String G__typename;
+  @override
+  final GGetBooksData_books__base_author author;
+  @override
+  final String title;
+
+  factory _$GGetBooksData_books__base(
+          [void Function(GGetBooksData_books__baseBuilder)? updates]) =>
+      (GGetBooksData_books__baseBuilder()..update(updates))._build();
+
+  _$GGetBooksData_books__base._(
+      {required this.G__typename, required this.author, required this.title})
+      : super._();
+  @override
+  GGetBooksData_books__base rebuild(
+          void Function(GGetBooksData_books__baseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__baseBuilder toBuilder() =>
+      GGetBooksData_books__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__base &&
+        G__typename == other.G__typename &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GGetBooksData_books__base')
+          ..add('G__typename', G__typename)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__baseBuilder
+    implements
+        Builder<GGetBooksData_books__base, GGetBooksData_books__baseBuilder> {
+  _$GGetBooksData_books__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  GGetBooksData_books__base_author? _author;
+  GGetBooksData_books__base_author? get author => _$this._author;
+  set author(GGetBooksData_books__base_author? author) =>
+      _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GGetBooksData_books__baseBuilder() {
+    GGetBooksData_books__base._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__base other) {
+    _$v = other as _$GGetBooksData_books__base;
+  }
+
+  @override
+  void update(void Function(GGetBooksData_books__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base build() => _build();
+
+  _$GGetBooksData_books__base _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GGetBooksData_books__base', 'G__typename'),
+          author: BuiltValueNullFieldError.checkNotNull(
+              author, r'GGetBooksData_books__base', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(
+              title, r'GGetBooksData_books__base', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base_author__base
+    extends GGetBooksData_books__base_author__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GGetBooksData_books__base_author__base(
+          [void Function(GGetBooksData_books__base_author__baseBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__baseBuilder()..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__base rebuild(
+          void Function(GGetBooksData_books__base_author__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__baseBuilder toBuilder() =>
+      GGetBooksData_books__base_author__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__base_author__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__baseBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__base,
+            GGetBooksData_books__base_author__baseBuilder> {
+  _$GGetBooksData_books__base_author__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GGetBooksData_books__base_author__baseBuilder() {
+    GGetBooksData_books__base_author__base._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__base_author__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__base_author__base other) {
+    _$v = other as _$GGetBooksData_books__base_author__base;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__base_author__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__base build() => _build();
+
+  _$GGetBooksData_books__base_author__base _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base_author__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GGetBooksData_books__base_author__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GGetBooksData_books__base_author__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base_author__asPerson
+    extends GGetBooksData_books__base_author__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GGetBooksData_books__base_author__asPerson(
+          [void Function(GGetBooksData_books__base_author__asPersonBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__asPersonBuilder()..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__asPerson rebuild(
+          void Function(GGetBooksData_books__base_author__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__asPersonBuilder toBuilder() =>
+      GGetBooksData_books__base_author__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__base_author__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__asPersonBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__asPerson,
+            GGetBooksData_books__base_author__asPersonBuilder> {
+  _$GGetBooksData_books__base_author__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GGetBooksData_books__base_author__asPersonBuilder() {
+    GGetBooksData_books__base_author__asPerson._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__base_author__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__base_author__asPerson other) {
+    _$v = other as _$GGetBooksData_books__base_author__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__base_author__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__asPerson build() => _build();
+
+  _$GGetBooksData_books__base_author__asPerson _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base_author__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GGetBooksData_books__base_author__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GGetBooksData_books__base_author__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(firstName,
+              r'GGetBooksData_books__base_author__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(lastName,
+              r'GGetBooksData_books__base_author__asPerson', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base_author__asCompany
+    extends GGetBooksData_books__base_author__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GGetBooksData_books__base_author__asCompany(
+          [void Function(GGetBooksData_books__base_author__asCompanyBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__asCompanyBuilder()..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__asCompany rebuild(
+          void Function(GGetBooksData_books__base_author__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__asCompanyBuilder toBuilder() =>
+      GGetBooksData_books__base_author__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__base_author__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__asCompanyBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__asCompany,
+            GGetBooksData_books__base_author__asCompanyBuilder> {
+  _$GGetBooksData_books__base_author__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GGetBooksData_books__base_author__asCompanyBuilder() {
+    GGetBooksData_books__base_author__asCompany._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__base_author__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__base_author__asCompany other) {
+    _$v = other as _$GGetBooksData_books__base_author__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__base_author__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__asCompany build() => _build();
+
+  _$GGetBooksData_books__base_author__asCompany _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base_author__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GGetBooksData_books__base_author__asCompany', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GGetBooksData_books__base_author__asCompany', 'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GGetBooksData_books__base_author__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook
+    extends GGetBooksData_books__asTextbook {
+  @override
+  final String G__typename;
+  @override
+  final GGetBooksData_books__asTextbook_author author;
+  @override
+  final String title;
+  @override
+  final BuiltList<String> courses;
+
+  factory _$GGetBooksData_books__asTextbook(
+          [void Function(GGetBooksData_books__asTextbookBuilder)? updates]) =>
+      (GGetBooksData_books__asTextbookBuilder()..update(updates))._build();
+
+  _$GGetBooksData_books__asTextbook._(
+      {required this.G__typename,
+      required this.author,
+      required this.title,
+      required this.courses})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook rebuild(
+          void Function(GGetBooksData_books__asTextbookBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbookBuilder toBuilder() =>
+      GGetBooksData_books__asTextbookBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asTextbook &&
+        G__typename == other.G__typename &&
+        author == other.author &&
+        title == other.title &&
+        courses == other.courses;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, courses.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GGetBooksData_books__asTextbook')
+          ..add('G__typename', G__typename)
+          ..add('author', author)
+          ..add('title', title)
+          ..add('courses', courses))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbookBuilder
+    implements
+        Builder<GGetBooksData_books__asTextbook,
+            GGetBooksData_books__asTextbookBuilder> {
+  _$GGetBooksData_books__asTextbook? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  GGetBooksData_books__asTextbook_author? _author;
+  GGetBooksData_books__asTextbook_author? get author => _$this._author;
+  set author(GGetBooksData_books__asTextbook_author? author) =>
+      _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  ListBuilder<String>? _courses;
+  ListBuilder<String> get courses => _$this._courses ??= ListBuilder<String>();
+  set courses(ListBuilder<String>? courses) => _$this._courses = courses;
+
+  GGetBooksData_books__asTextbookBuilder() {
+    GGetBooksData_books__asTextbook._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbookBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _author = $v.author;
+      _title = $v.title;
+      _courses = $v.courses.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asTextbook other) {
+    _$v = other as _$GGetBooksData_books__asTextbook;
+  }
+
+  @override
+  void update(void Function(GGetBooksData_books__asTextbookBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook build() => _build();
+
+  _$GGetBooksData_books__asTextbook _build() {
+    _$GGetBooksData_books__asTextbook _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooksData_books__asTextbook._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, r'GGetBooksData_books__asTextbook', 'G__typename'),
+            author: BuiltValueNullFieldError.checkNotNull(
+                author, r'GGetBooksData_books__asTextbook', 'author'),
+            title: BuiltValueNullFieldError.checkNotNull(
+                title, r'GGetBooksData_books__asTextbook', 'title'),
+            courses: courses.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'courses';
+        courses.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GGetBooksData_books__asTextbook', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__base
+    extends GGetBooksData_books__asTextbook_author__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GGetBooksData_books__asTextbook_author__base(
+          [void Function(GGetBooksData_books__asTextbook_author__baseBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__baseBuilder()..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__base rebuild(
+          void Function(GGetBooksData_books__asTextbook_author__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__baseBuilder toBuilder() =>
+      GGetBooksData_books__asTextbook_author__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asTextbook_author__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__baseBuilder
+    implements
+        Builder<GGetBooksData_books__asTextbook_author__base,
+            GGetBooksData_books__asTextbook_author__baseBuilder> {
+  _$GGetBooksData_books__asTextbook_author__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GGetBooksData_books__asTextbook_author__baseBuilder() {
+    GGetBooksData_books__asTextbook_author__base._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asTextbook_author__base other) {
+    _$v = other as _$GGetBooksData_books__asTextbook_author__base;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asTextbook_author__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__base build() => _build();
+
+  _$GGetBooksData_books__asTextbook_author__base _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asTextbook_author__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GGetBooksData_books__asTextbook_author__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GGetBooksData_books__asTextbook_author__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asPerson
+    extends GGetBooksData_books__asTextbook_author__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GGetBooksData_books__asTextbook_author__asPerson(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asPersonBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__asPerson rebuild(
+          void Function(GGetBooksData_books__asTextbook_author__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__asPersonBuilder toBuilder() =>
+      GGetBooksData_books__asTextbook_author__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asTextbook_author__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__asPersonBuilder
+    implements
+        Builder<GGetBooksData_books__asTextbook_author__asPerson,
+            GGetBooksData_books__asTextbook_author__asPersonBuilder> {
+  _$GGetBooksData_books__asTextbook_author__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GGetBooksData_books__asTextbook_author__asPersonBuilder() {
+    GGetBooksData_books__asTextbook_author__asPerson._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asTextbook_author__asPerson other) {
+    _$v = other as _$GGetBooksData_books__asTextbook_author__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asTextbook_author__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asPerson build() => _build();
+
+  _$GGetBooksData_books__asTextbook_author__asPerson _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asTextbook_author__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asTextbook_author__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asTextbook_author__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(firstName,
+              r'GGetBooksData_books__asTextbook_author__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(lastName,
+              r'GGetBooksData_books__asTextbook_author__asPerson', 'lastName'),
+          author: BuiltValueNullFieldError.checkNotNull(author,
+              r'GGetBooksData_books__asTextbook_author__asPerson', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GGetBooksData_books__asTextbook_author__asPerson', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asCompany
+    extends GGetBooksData_books__asTextbook_author__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GGetBooksData_books__asTextbook_author__asCompany(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asCompanyBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__asCompany rebuild(
+          void Function(
+                  GGetBooksData_books__asTextbook_author__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__asCompanyBuilder toBuilder() =>
+      GGetBooksData_books__asTextbook_author__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asTextbook_author__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__asCompanyBuilder
+    implements
+        Builder<GGetBooksData_books__asTextbook_author__asCompany,
+            GGetBooksData_books__asTextbook_author__asCompanyBuilder> {
+  _$GGetBooksData_books__asTextbook_author__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GGetBooksData_books__asTextbook_author__asCompanyBuilder() {
+    GGetBooksData_books__asTextbook_author__asCompany._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asTextbook_author__asCompany other) {
+    _$v = other as _$GGetBooksData_books__asTextbook_author__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asTextbook_author__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asCompany build() => _build();
+
+  _$GGetBooksData_books__asTextbook_author__asCompany _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asTextbook_author__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asTextbook_author__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asTextbook_author__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(name,
+              r'GGetBooksData_books__asTextbook_author__asCompany', 'name'),
+          author: BuiltValueNullFieldError.checkNotNull(author,
+              r'GGetBooksData_books__asTextbook_author__asCompany', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GGetBooksData_books__asTextbook_author__asCompany', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook
+    extends GGetBooksData_books__asColoringBook {
+  @override
+  final String G__typename;
+  @override
+  final GGetBooksData_books__asColoringBook_author author;
+  @override
+  final String title;
+  @override
+  final BuiltList<String> colors;
+
+  factory _$GGetBooksData_books__asColoringBook(
+          [void Function(GGetBooksData_books__asColoringBookBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBookBuilder()..update(updates))._build();
+
+  _$GGetBooksData_books__asColoringBook._(
+      {required this.G__typename,
+      required this.author,
+      required this.title,
+      required this.colors})
+      : super._();
+  @override
+  GGetBooksData_books__asColoringBook rebuild(
+          void Function(GGetBooksData_books__asColoringBookBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asColoringBookBuilder toBuilder() =>
+      GGetBooksData_books__asColoringBookBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asColoringBook &&
+        G__typename == other.G__typename &&
+        author == other.author &&
+        title == other.title &&
+        colors == other.colors;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, colors.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GGetBooksData_books__asColoringBook')
+          ..add('G__typename', G__typename)
+          ..add('author', author)
+          ..add('title', title)
+          ..add('colors', colors))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asColoringBookBuilder
+    implements
+        Builder<GGetBooksData_books__asColoringBook,
+            GGetBooksData_books__asColoringBookBuilder> {
+  _$GGetBooksData_books__asColoringBook? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  GGetBooksData_books__asColoringBook_author? _author;
+  GGetBooksData_books__asColoringBook_author? get author => _$this._author;
+  set author(GGetBooksData_books__asColoringBook_author? author) =>
+      _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  ListBuilder<String>? _colors;
+  ListBuilder<String> get colors => _$this._colors ??= ListBuilder<String>();
+  set colors(ListBuilder<String>? colors) => _$this._colors = colors;
+
+  GGetBooksData_books__asColoringBookBuilder() {
+    GGetBooksData_books__asColoringBook._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asColoringBookBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _author = $v.author;
+      _title = $v.title;
+      _colors = $v.colors.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asColoringBook other) {
+    _$v = other as _$GGetBooksData_books__asColoringBook;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asColoringBookBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook build() => _build();
+
+  _$GGetBooksData_books__asColoringBook _build() {
+    _$GGetBooksData_books__asColoringBook _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooksData_books__asColoringBook._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                r'GGetBooksData_books__asColoringBook', 'G__typename'),
+            author: BuiltValueNullFieldError.checkNotNull(
+                author, r'GGetBooksData_books__asColoringBook', 'author'),
+            title: BuiltValueNullFieldError.checkNotNull(
+                title, r'GGetBooksData_books__asColoringBook', 'title'),
+            colors: colors.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'colors';
+        colors.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(r'GGetBooksData_books__asColoringBook',
+            _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__base
+    extends GGetBooksData_books__asColoringBook_author__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GGetBooksData_books__asColoringBook_author__base(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__baseBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__baseBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asColoringBook_author__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GGetBooksData_books__asColoringBook_author__base rebuild(
+          void Function(GGetBooksData_books__asColoringBook_author__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asColoringBook_author__baseBuilder toBuilder() =>
+      GGetBooksData_books__asColoringBook_author__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asColoringBook_author__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asColoringBook_author__baseBuilder
+    implements
+        Builder<GGetBooksData_books__asColoringBook_author__base,
+            GGetBooksData_books__asColoringBook_author__baseBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GGetBooksData_books__asColoringBook_author__baseBuilder() {
+    GGetBooksData_books__asColoringBook_author__base._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asColoringBook_author__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asColoringBook_author__base other) {
+    _$v = other as _$GGetBooksData_books__asColoringBook_author__base;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asColoringBook_author__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__base build() => _build();
+
+  _$GGetBooksData_books__asColoringBook_author__base _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asColoringBook_author__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asColoringBook_author__base',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asColoringBook_author__base',
+              'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__asPerson
+    extends GGetBooksData_books__asColoringBook_author__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GGetBooksData_books__asColoringBook_author__asPerson(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asPersonBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asColoringBook_author__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GGetBooksData_books__asColoringBook_author__asPerson rebuild(
+          void Function(
+                  GGetBooksData_books__asColoringBook_author__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asPersonBuilder toBuilder() =>
+      GGetBooksData_books__asColoringBook_author__asPersonBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asColoringBook_author__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asColoringBook_author__asPersonBuilder
+    implements
+        Builder<GGetBooksData_books__asColoringBook_author__asPerson,
+            GGetBooksData_books__asColoringBook_author__asPersonBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GGetBooksData_books__asColoringBook_author__asPersonBuilder() {
+    GGetBooksData_books__asColoringBook_author__asPerson._initializeBuilder(
+        this);
+  }
+
+  GGetBooksData_books__asColoringBook_author__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asColoringBook_author__asPerson other) {
+    _$v = other as _$GGetBooksData_books__asColoringBook_author__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__asColoringBook_author__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asPerson build() => _build();
+
+  _$GGetBooksData_books__asColoringBook_author__asPerson _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asColoringBook_author__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asColoringBook_author__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asColoringBook_author__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GGetBooksData_books__asColoringBook_author__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GGetBooksData_books__asColoringBook_author__asPerson',
+              'lastName'),
+          author: BuiltValueNullFieldError.checkNotNull(
+              author,
+              r'GGetBooksData_books__asColoringBook_author__asPerson',
+              'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GGetBooksData_books__asColoringBook_author__asPerson', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__asCompany
+    extends GGetBooksData_books__asColoringBook_author__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GGetBooksData_books__asColoringBook_author__asCompany(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asCompanyBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asColoringBook_author__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GGetBooksData_books__asColoringBook_author__asCompany rebuild(
+          void Function(
+                  GGetBooksData_books__asColoringBook_author__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asCompanyBuilder toBuilder() =>
+      GGetBooksData_books__asColoringBook_author__asCompanyBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asColoringBook_author__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asColoringBook_author__asCompanyBuilder
+    implements
+        Builder<GGetBooksData_books__asColoringBook_author__asCompany,
+            GGetBooksData_books__asColoringBook_author__asCompanyBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GGetBooksData_books__asColoringBook_author__asCompanyBuilder() {
+    GGetBooksData_books__asColoringBook_author__asCompany._initializeBuilder(
+        this);
+  }
+
+  GGetBooksData_books__asColoringBook_author__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asColoringBook_author__asCompany other) {
+    _$v = other as _$GGetBooksData_books__asColoringBook_author__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__asColoringBook_author__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asCompany build() => _build();
+
+  _$GGetBooksData_books__asColoringBook_author__asCompany _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asColoringBook_author__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asColoringBook_author__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asColoringBook_author__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(name,
+              r'GGetBooksData_books__asColoringBook_author__asCompany', 'name'),
+          author: BuiltValueNullFieldError.checkNotNull(
+              author,
+              r'GGetBooksData_books__asColoringBook_author__asCompany',
+              'author'),
+          title: BuiltValueNullFieldError.checkNotNull(
+              title,
+              r'GGetBooksData_books__asColoringBook_author__asCompany',
+              'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__base extends GAuthorFragmentData__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GAuthorFragmentData__base(
+          [void Function(GAuthorFragmentData__baseBuilder)? updates]) =>
+      (GAuthorFragmentData__baseBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GAuthorFragmentData__base rebuild(
+          void Function(GAuthorFragmentData__baseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__baseBuilder toBuilder() =>
+      GAuthorFragmentData__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__baseBuilder
+    implements
+        Builder<GAuthorFragmentData__base, GAuthorFragmentData__baseBuilder> {
+  _$GAuthorFragmentData__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GAuthorFragmentData__baseBuilder() {
+    GAuthorFragmentData__base._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__base other) {
+    _$v = other as _$GAuthorFragmentData__base;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__base build() => _build();
+
+  _$GAuthorFragmentData__base _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorFragmentData__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorFragmentData__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asPerson extends GAuthorFragmentData__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GAuthorFragmentData__asPerson(
+          [void Function(GAuthorFragmentData__asPersonBuilder)? updates]) =>
+      (GAuthorFragmentData__asPersonBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GAuthorFragmentData__asPerson rebuild(
+          void Function(GAuthorFragmentData__asPersonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asPersonBuilder toBuilder() =>
+      GAuthorFragmentData__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asPersonBuilder
+    implements
+        Builder<GAuthorFragmentData__asPerson,
+            GAuthorFragmentData__asPersonBuilder> {
+  _$GAuthorFragmentData__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GAuthorFragmentData__asPersonBuilder() {
+    GAuthorFragmentData__asPerson._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asPerson other) {
+    _$v = other as _$GAuthorFragmentData__asPerson;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__asPersonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asPerson build() => _build();
+
+  _$GAuthorFragmentData__asPerson _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorFragmentData__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorFragmentData__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName, r'GAuthorFragmentData__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName, r'GAuthorFragmentData__asPerson', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asCompany extends GAuthorFragmentData__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GAuthorFragmentData__asCompany(
+          [void Function(GAuthorFragmentData__asCompanyBuilder)? updates]) =>
+      (GAuthorFragmentData__asCompanyBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GAuthorFragmentData__asCompany rebuild(
+          void Function(GAuthorFragmentData__asCompanyBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asCompanyBuilder toBuilder() =>
+      GAuthorFragmentData__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asCompanyBuilder
+    implements
+        Builder<GAuthorFragmentData__asCompany,
+            GAuthorFragmentData__asCompanyBuilder> {
+  _$GAuthorFragmentData__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GAuthorFragmentData__asCompanyBuilder() {
+    GAuthorFragmentData__asCompany._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asCompany other) {
+    _$v = other as _$GAuthorFragmentData__asCompany;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__asCompanyBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asCompany build() => _build();
+
+  _$GAuthorFragmentData__asCompany _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorFragmentData__asCompany', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorFragmentData__asCompany', 'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GAuthorFragmentData__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base extends GBookFragmentData__base {
+  @override
+  final String G__typename;
+  @override
+  final GBookFragmentData__base_author author;
+  @override
+  final String title;
+
+  factory _$GBookFragmentData__base(
+          [void Function(GBookFragmentData__baseBuilder)? updates]) =>
+      (GBookFragmentData__baseBuilder()..update(updates))._build();
+
+  _$GBookFragmentData__base._(
+      {required this.G__typename, required this.author, required this.title})
+      : super._();
+  @override
+  GBookFragmentData__base rebuild(
+          void Function(GBookFragmentData__baseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__baseBuilder toBuilder() =>
+      GBookFragmentData__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base &&
+        G__typename == other.G__typename &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GBookFragmentData__base')
+          ..add('G__typename', G__typename)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GBookFragmentData__baseBuilder
+    implements
+        Builder<GBookFragmentData__base, GBookFragmentData__baseBuilder> {
+  _$GBookFragmentData__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  GBookFragmentData__base_author? _author;
+  GBookFragmentData__base_author? get author => _$this._author;
+  set author(GBookFragmentData__base_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GBookFragmentData__baseBuilder() {
+    GBookFragmentData__base._initializeBuilder(this);
+  }
+
+  GBookFragmentData__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__base other) {
+    _$v = other as _$GBookFragmentData__base;
+  }
+
+  @override
+  void update(void Function(GBookFragmentData__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base build() => _build();
+
+  _$GBookFragmentData__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GBookFragmentData__base', 'G__typename'),
+          author: BuiltValueNullFieldError.checkNotNull(
+              author, r'GBookFragmentData__base', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(
+              title, r'GBookFragmentData__base', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__base
+    extends GBookFragmentData__base_author__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GBookFragmentData__base_author__base(
+          [void Function(GBookFragmentData__base_author__baseBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__baseBuilder()..update(updates))._build();
+
+  _$GBookFragmentData__base_author__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GBookFragmentData__base_author__base rebuild(
+          void Function(GBookFragmentData__base_author__baseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__baseBuilder toBuilder() =>
+      GBookFragmentData__base_author__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base_author__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GBookFragmentData__base_author__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__baseBuilder
+    implements
+        Builder<GBookFragmentData__base_author__base,
+            GBookFragmentData__base_author__baseBuilder> {
+  _$GBookFragmentData__base_author__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GBookFragmentData__base_author__baseBuilder() {
+    GBookFragmentData__base_author__base._initializeBuilder(this);
+  }
+
+  GBookFragmentData__base_author__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__base_author__base other) {
+    _$v = other as _$GBookFragmentData__base_author__base;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__base_author__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__base build() => _build();
+
+  _$GBookFragmentData__base_author__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base_author__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GBookFragmentData__base_author__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GBookFragmentData__base_author__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__asPerson
+    extends GBookFragmentData__base_author__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GBookFragmentData__base_author__asPerson(
+          [void Function(GBookFragmentData__base_author__asPersonBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__asPersonBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__base_author__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GBookFragmentData__base_author__asPerson rebuild(
+          void Function(GBookFragmentData__base_author__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__asPersonBuilder toBuilder() =>
+      GBookFragmentData__base_author__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base_author__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__base_author__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__asPersonBuilder
+    implements
+        Builder<GBookFragmentData__base_author__asPerson,
+            GBookFragmentData__base_author__asPersonBuilder> {
+  _$GBookFragmentData__base_author__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragmentData__base_author__asPersonBuilder() {
+    GBookFragmentData__base_author__asPerson._initializeBuilder(this);
+  }
+
+  GBookFragmentData__base_author__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__base_author__asPerson other) {
+    _$v = other as _$GBookFragmentData__base_author__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__base_author__asPersonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__asPerson build() => _build();
+
+  _$GBookFragmentData__base_author__asPerson _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base_author__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GBookFragmentData__base_author__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GBookFragmentData__base_author__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(firstName,
+              r'GBookFragmentData__base_author__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(lastName,
+              r'GBookFragmentData__base_author__asPerson', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__asCompany
+    extends GBookFragmentData__base_author__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GBookFragmentData__base_author__asCompany(
+          [void Function(GBookFragmentData__base_author__asCompanyBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__asCompanyBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__base_author__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GBookFragmentData__base_author__asCompany rebuild(
+          void Function(GBookFragmentData__base_author__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__asCompanyBuilder toBuilder() =>
+      GBookFragmentData__base_author__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base_author__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__base_author__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__asCompanyBuilder
+    implements
+        Builder<GBookFragmentData__base_author__asCompany,
+            GBookFragmentData__base_author__asCompanyBuilder> {
+  _$GBookFragmentData__base_author__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragmentData__base_author__asCompanyBuilder() {
+    GBookFragmentData__base_author__asCompany._initializeBuilder(this);
+  }
+
+  GBookFragmentData__base_author__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__base_author__asCompany other) {
+    _$v = other as _$GBookFragmentData__base_author__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__base_author__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__asCompany build() => _build();
+
+  _$GBookFragmentData__base_author__asCompany _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base_author__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GBookFragmentData__base_author__asCompany', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GBookFragmentData__base_author__asCompany', 'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GBookFragmentData__base_author__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook extends GBookFragmentData__asTextbook {
+  @override
+  final String G__typename;
+  @override
+  final GBookFragmentData__asTextbook_author author;
+  @override
+  final String title;
+  @override
+  final BuiltList<String> courses;
+
+  factory _$GBookFragmentData__asTextbook(
+          [void Function(GBookFragmentData__asTextbookBuilder)? updates]) =>
+      (GBookFragmentData__asTextbookBuilder()..update(updates))._build();
+
+  _$GBookFragmentData__asTextbook._(
+      {required this.G__typename,
+      required this.author,
+      required this.title,
+      required this.courses})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook rebuild(
+          void Function(GBookFragmentData__asTextbookBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbookBuilder toBuilder() =>
+      GBookFragmentData__asTextbookBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asTextbook &&
+        G__typename == other.G__typename &&
+        author == other.author &&
+        title == other.title &&
+        courses == other.courses;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, courses.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GBookFragmentData__asTextbook')
+          ..add('G__typename', G__typename)
+          ..add('author', author)
+          ..add('title', title)
+          ..add('courses', courses))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbookBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook,
+            GBookFragmentData__asTextbookBuilder> {
+  _$GBookFragmentData__asTextbook? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  GBookFragmentData__asTextbook_author? _author;
+  GBookFragmentData__asTextbook_author? get author => _$this._author;
+  set author(GBookFragmentData__asTextbook_author? author) =>
+      _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  ListBuilder<String>? _courses;
+  ListBuilder<String> get courses => _$this._courses ??= ListBuilder<String>();
+  set courses(ListBuilder<String>? courses) => _$this._courses = courses;
+
+  GBookFragmentData__asTextbookBuilder() {
+    GBookFragmentData__asTextbook._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbookBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _author = $v.author;
+      _title = $v.title;
+      _courses = $v.courses.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asTextbook other) {
+    _$v = other as _$GBookFragmentData__asTextbook;
+  }
+
+  @override
+  void update(void Function(GBookFragmentData__asTextbookBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook build() => _build();
+
+  _$GBookFragmentData__asTextbook _build() {
+    _$GBookFragmentData__asTextbook _$result;
+    try {
+      _$result = _$v ??
+          _$GBookFragmentData__asTextbook._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, r'GBookFragmentData__asTextbook', 'G__typename'),
+            author: BuiltValueNullFieldError.checkNotNull(
+                author, r'GBookFragmentData__asTextbook', 'author'),
+            title: BuiltValueNullFieldError.checkNotNull(
+                title, r'GBookFragmentData__asTextbook', 'title'),
+            courses: courses.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'courses';
+        courses.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GBookFragmentData__asTextbook', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__base
+    extends GBookFragmentData__asTextbook_author__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GBookFragmentData__asTextbook_author__base(
+          [void Function(GBookFragmentData__asTextbook_author__baseBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__baseBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__base rebuild(
+          void Function(GBookFragmentData__asTextbook_author__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__baseBuilder toBuilder() =>
+      GBookFragmentData__asTextbook_author__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asTextbook_author__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__baseBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook_author__base,
+            GBookFragmentData__asTextbook_author__baseBuilder> {
+  _$GBookFragmentData__asTextbook_author__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GBookFragmentData__asTextbook_author__baseBuilder() {
+    GBookFragmentData__asTextbook_author__base._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asTextbook_author__base other) {
+    _$v = other as _$GBookFragmentData__asTextbook_author__base;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asTextbook_author__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__base build() => _build();
+
+  _$GBookFragmentData__asTextbook_author__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asTextbook_author__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GBookFragmentData__asTextbook_author__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GBookFragmentData__asTextbook_author__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asPerson
+    extends GBookFragmentData__asTextbook_author__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GBookFragmentData__asTextbook_author__asPerson(
+          [void Function(GBookFragmentData__asTextbook_author__asPersonBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__asPersonBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__asPerson rebuild(
+          void Function(GBookFragmentData__asTextbook_author__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__asPersonBuilder toBuilder() =>
+      GBookFragmentData__asTextbook_author__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asTextbook_author__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__asPersonBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook_author__asPerson,
+            GBookFragmentData__asTextbook_author__asPersonBuilder> {
+  _$GBookFragmentData__asTextbook_author__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GBookFragmentData__asTextbook_author__asPersonBuilder() {
+    GBookFragmentData__asTextbook_author__asPerson._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asTextbook_author__asPerson other) {
+    _$v = other as _$GBookFragmentData__asTextbook_author__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asTextbook_author__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asPerson build() => _build();
+
+  _$GBookFragmentData__asTextbook_author__asPerson _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asTextbook_author__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GBookFragmentData__asTextbook_author__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GBookFragmentData__asTextbook_author__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(firstName,
+              r'GBookFragmentData__asTextbook_author__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(lastName,
+              r'GBookFragmentData__asTextbook_author__asPerson', 'lastName'),
+          author: BuiltValueNullFieldError.checkNotNull(author,
+              r'GBookFragmentData__asTextbook_author__asPerson', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GBookFragmentData__asTextbook_author__asPerson', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asCompany
+    extends GBookFragmentData__asTextbook_author__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GBookFragmentData__asTextbook_author__asCompany(
+          [void Function(
+                  GBookFragmentData__asTextbook_author__asCompanyBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__asCompany rebuild(
+          void Function(GBookFragmentData__asTextbook_author__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__asCompanyBuilder toBuilder() =>
+      GBookFragmentData__asTextbook_author__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asTextbook_author__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__asCompanyBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook_author__asCompany,
+            GBookFragmentData__asTextbook_author__asCompanyBuilder> {
+  _$GBookFragmentData__asTextbook_author__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GBookFragmentData__asTextbook_author__asCompanyBuilder() {
+    GBookFragmentData__asTextbook_author__asCompany._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asTextbook_author__asCompany other) {
+    _$v = other as _$GBookFragmentData__asTextbook_author__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asTextbook_author__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asCompany build() => _build();
+
+  _$GBookFragmentData__asTextbook_author__asCompany _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asTextbook_author__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asTextbook_author__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asTextbook_author__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GBookFragmentData__asTextbook_author__asCompany', 'name'),
+          author: BuiltValueNullFieldError.checkNotNull(author,
+              r'GBookFragmentData__asTextbook_author__asCompany', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GBookFragmentData__asTextbook_author__asCompany', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook
+    extends GBookFragmentData__asColoringBook {
+  @override
+  final String G__typename;
+  @override
+  final GBookFragmentData__asColoringBook_author author;
+  @override
+  final String title;
+  @override
+  final BuiltList<String> colors;
+
+  factory _$GBookFragmentData__asColoringBook(
+          [void Function(GBookFragmentData__asColoringBookBuilder)? updates]) =>
+      (GBookFragmentData__asColoringBookBuilder()..update(updates))._build();
+
+  _$GBookFragmentData__asColoringBook._(
+      {required this.G__typename,
+      required this.author,
+      required this.title,
+      required this.colors})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook rebuild(
+          void Function(GBookFragmentData__asColoringBookBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBookBuilder toBuilder() =>
+      GBookFragmentData__asColoringBookBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asColoringBook &&
+        G__typename == other.G__typename &&
+        author == other.author &&
+        title == other.title &&
+        colors == other.colors;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jc(_$hash, colors.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GBookFragmentData__asColoringBook')
+          ..add('G__typename', G__typename)
+          ..add('author', author)
+          ..add('title', title)
+          ..add('colors', colors))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBookBuilder
+    implements
+        Builder<GBookFragmentData__asColoringBook,
+            GBookFragmentData__asColoringBookBuilder> {
+  _$GBookFragmentData__asColoringBook? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  GBookFragmentData__asColoringBook_author? _author;
+  GBookFragmentData__asColoringBook_author? get author => _$this._author;
+  set author(GBookFragmentData__asColoringBook_author? author) =>
+      _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  ListBuilder<String>? _colors;
+  ListBuilder<String> get colors => _$this._colors ??= ListBuilder<String>();
+  set colors(ListBuilder<String>? colors) => _$this._colors = colors;
+
+  GBookFragmentData__asColoringBookBuilder() {
+    GBookFragmentData__asColoringBook._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBookBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _author = $v.author;
+      _title = $v.title;
+      _colors = $v.colors.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asColoringBook other) {
+    _$v = other as _$GBookFragmentData__asColoringBook;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asColoringBookBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook build() => _build();
+
+  _$GBookFragmentData__asColoringBook _build() {
+    _$GBookFragmentData__asColoringBook _$result;
+    try {
+      _$result = _$v ??
+          _$GBookFragmentData__asColoringBook._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                r'GBookFragmentData__asColoringBook', 'G__typename'),
+            author: BuiltValueNullFieldError.checkNotNull(
+                author, r'GBookFragmentData__asColoringBook', 'author'),
+            title: BuiltValueNullFieldError.checkNotNull(
+                title, r'GBookFragmentData__asColoringBook', 'title'),
+            colors: colors.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'colors';
+        colors.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GBookFragmentData__asColoringBook', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__base
+    extends GBookFragmentData__asColoringBook_author__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GBookFragmentData__asColoringBook_author__base(
+          [void Function(GBookFragmentData__asColoringBook_author__baseBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__baseBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__base rebuild(
+          void Function(GBookFragmentData__asColoringBook_author__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__baseBuilder toBuilder() =>
+      GBookFragmentData__asColoringBook_author__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asColoringBook_author__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__baseBuilder
+    implements
+        Builder<GBookFragmentData__asColoringBook_author__base,
+            GBookFragmentData__asColoringBook_author__baseBuilder> {
+  _$GBookFragmentData__asColoringBook_author__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GBookFragmentData__asColoringBook_author__baseBuilder() {
+    GBookFragmentData__asColoringBook_author__base._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBook_author__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asColoringBook_author__base other) {
+    _$v = other as _$GBookFragmentData__asColoringBook_author__base;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asColoringBook_author__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__base build() => _build();
+
+  _$GBookFragmentData__asColoringBook_author__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asColoringBook_author__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GBookFragmentData__asColoringBook_author__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GBookFragmentData__asColoringBook_author__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asPerson
+    extends GBookFragmentData__asColoringBook_author__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GBookFragmentData__asColoringBook_author__asPerson(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asPersonBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__asPerson rebuild(
+          void Function(
+                  GBookFragmentData__asColoringBook_author__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__asPersonBuilder toBuilder() =>
+      GBookFragmentData__asColoringBook_author__asPersonBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asColoringBook_author__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__asPersonBuilder
+    implements
+        Builder<GBookFragmentData__asColoringBook_author__asPerson,
+            GBookFragmentData__asColoringBook_author__asPersonBuilder> {
+  _$GBookFragmentData__asColoringBook_author__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GBookFragmentData__asColoringBook_author__asPersonBuilder() {
+    GBookFragmentData__asColoringBook_author__asPerson._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBook_author__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asColoringBook_author__asPerson other) {
+    _$v = other as _$GBookFragmentData__asColoringBook_author__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asColoringBook_author__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asPerson build() => _build();
+
+  _$GBookFragmentData__asColoringBook_author__asPerson _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asColoringBook_author__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asColoringBook_author__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asColoringBook_author__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GBookFragmentData__asColoringBook_author__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GBookFragmentData__asColoringBook_author__asPerson',
+              'lastName'),
+          author: BuiltValueNullFieldError.checkNotNull(author,
+              r'GBookFragmentData__asColoringBook_author__asPerson', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GBookFragmentData__asColoringBook_author__asPerson', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asCompany
+    extends GBookFragmentData__asColoringBook_author__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+  @override
+  final GBookFragment_author author;
+  @override
+  final String title;
+
+  factory _$GBookFragmentData__asColoringBook_author__asCompany(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asCompanyBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name,
+      required this.author,
+      required this.title})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__asCompany rebuild(
+          void Function(
+                  GBookFragmentData__asColoringBook_author__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__asCompanyBuilder toBuilder() =>
+      GBookFragmentData__asColoringBook_author__asCompanyBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asColoringBook_author__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name &&
+        author == other.author &&
+        title == other.title;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, author.hashCode);
+    _$hash = $jc(_$hash, title.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name)
+          ..add('author', author)
+          ..add('title', title))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__asCompanyBuilder
+    implements
+        Builder<GBookFragmentData__asColoringBook_author__asCompany,
+            GBookFragmentData__asColoringBook_author__asCompanyBuilder> {
+  _$GBookFragmentData__asColoringBook_author__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragment_author? _author;
+  GBookFragment_author? get author => _$this._author;
+  set author(GBookFragment_author? author) => _$this._author = author;
+
+  String? _title;
+  String? get title => _$this._title;
+  set title(String? title) => _$this._title = title;
+
+  GBookFragmentData__asColoringBook_author__asCompanyBuilder() {
+    GBookFragmentData__asColoringBook_author__asCompany._initializeBuilder(
+        this);
+  }
+
+  GBookFragmentData__asColoringBook_author__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _author = $v.author;
+      _title = $v.title;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asColoringBook_author__asCompany other) {
+    _$v = other as _$GBookFragmentData__asColoringBook_author__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asColoringBook_author__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asCompany build() => _build();
+
+  _$GBookFragmentData__asColoringBook_author__asCompany _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asColoringBook_author__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asColoringBook_author__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asColoringBook_author__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(name,
+              r'GBookFragmentData__asColoringBook_author__asCompany', 'name'),
+          author: BuiltValueNullFieldError.checkNotNull(author,
+              r'GBookFragmentData__asColoringBook_author__asCompany', 'author'),
+          title: BuiltValueNullFieldError.checkNotNull(title,
+              r'GBookFragmentData__asColoringBook_author__asCompany', 'title'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.data.gql.g.dart
@@ -19,6 +19,18 @@ Serializer<GGetBooksData_books__base_author__asPerson>
 Serializer<GGetBooksData_books__base_author__asCompany>
     _$gGetBooksDataBooksBaseAuthorAsCompanySerializer =
     _$GGetBooksData_books__base_author__asCompanySerializer();
+Serializer<GGetBooksData_books__base_author__asGroup>
+    _$gGetBooksDataBooksBaseAuthorAsGroupSerializer =
+    _$GGetBooksData_books__base_author__asGroupSerializer();
+Serializer<GGetBooksData_books__base_author__asGroup_members__base>
+    _$gGetBooksDataBooksBaseAuthorAsGroupMembersBaseSerializer =
+    _$GGetBooksData_books__base_author__asGroup_members__baseSerializer();
+Serializer<GGetBooksData_books__base_author__asGroup_members__asPerson>
+    _$gGetBooksDataBooksBaseAuthorAsGroupMembersAsPersonSerializer =
+    _$GGetBooksData_books__base_author__asGroup_members__asPersonSerializer();
+Serializer<GGetBooksData_books__base_author__asGroup_members__asCompany>
+    _$gGetBooksDataBooksBaseAuthorAsGroupMembersAsCompanySerializer =
+    _$GGetBooksData_books__base_author__asGroup_members__asCompanySerializer();
 Serializer<GGetBooksData_books__asTextbook>
     _$gGetBooksDataBooksAsTextbookSerializer =
     _$GGetBooksData_books__asTextbookSerializer();
@@ -31,6 +43,18 @@ Serializer<GGetBooksData_books__asTextbook_author__asPerson>
 Serializer<GGetBooksData_books__asTextbook_author__asCompany>
     _$gGetBooksDataBooksAsTextbookAuthorAsCompanySerializer =
     _$GGetBooksData_books__asTextbook_author__asCompanySerializer();
+Serializer<GGetBooksData_books__asTextbook_author__asGroup>
+    _$gGetBooksDataBooksAsTextbookAuthorAsGroupSerializer =
+    _$GGetBooksData_books__asTextbook_author__asGroupSerializer();
+Serializer<GGetBooksData_books__asTextbook_author__asGroup_members__base>
+    _$gGetBooksDataBooksAsTextbookAuthorAsGroupMembersBaseSerializer =
+    _$GGetBooksData_books__asTextbook_author__asGroup_members__baseSerializer();
+Serializer<GGetBooksData_books__asTextbook_author__asGroup_members__asPerson>
+    _$gGetBooksDataBooksAsTextbookAuthorAsGroupMembersAsPersonSerializer =
+    _$GGetBooksData_books__asTextbook_author__asGroup_members__asPersonSerializer();
+Serializer<GGetBooksData_books__asTextbook_author__asGroup_members__asCompany>
+    _$gGetBooksDataBooksAsTextbookAuthorAsGroupMembersAsCompanySerializer =
+    _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompanySerializer();
 Serializer<GGetBooksData_books__asColoringBook>
     _$gGetBooksDataBooksAsColoringBookSerializer =
     _$GGetBooksData_books__asColoringBookSerializer();
@@ -43,14 +67,20 @@ Serializer<GGetBooksData_books__asColoringBook_author__asPerson>
 Serializer<GGetBooksData_books__asColoringBook_author__asCompany>
     _$gGetBooksDataBooksAsColoringBookAuthorAsCompanySerializer =
     _$GGetBooksData_books__asColoringBook_author__asCompanySerializer();
-Serializer<GAuthorFragmentData__base> _$gAuthorFragmentDataBaseSerializer =
-    _$GAuthorFragmentData__baseSerializer();
-Serializer<GAuthorFragmentData__asPerson>
-    _$gAuthorFragmentDataAsPersonSerializer =
-    _$GAuthorFragmentData__asPersonSerializer();
-Serializer<GAuthorFragmentData__asCompany>
-    _$gAuthorFragmentDataAsCompanySerializer =
-    _$GAuthorFragmentData__asCompanySerializer();
+Serializer<GGetBooksData_books__asColoringBook_author__asGroup>
+    _$gGetBooksDataBooksAsColoringBookAuthorAsGroupSerializer =
+    _$GGetBooksData_books__asColoringBook_author__asGroupSerializer();
+Serializer<GGetBooksData_books__asColoringBook_author__asGroup_members__base>
+    _$gGetBooksDataBooksAsColoringBookAuthorAsGroupMembersBaseSerializer =
+    _$GGetBooksData_books__asColoringBook_author__asGroup_members__baseSerializer();
+Serializer<
+        GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson>
+    _$gGetBooksDataBooksAsColoringBookAuthorAsGroupMembersAsPersonSerializer =
+    _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonSerializer();
+Serializer<
+        GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany>
+    _$gGetBooksDataBooksAsColoringBookAuthorAsGroupMembersAsCompanySerializer =
+    _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanySerializer();
 Serializer<GBookFragmentData__base> _$gBookFragmentDataBaseSerializer =
     _$GBookFragmentData__baseSerializer();
 Serializer<GBookFragmentData__base_author__base>
@@ -62,6 +92,18 @@ Serializer<GBookFragmentData__base_author__asPerson>
 Serializer<GBookFragmentData__base_author__asCompany>
     _$gBookFragmentDataBaseAuthorAsCompanySerializer =
     _$GBookFragmentData__base_author__asCompanySerializer();
+Serializer<GBookFragmentData__base_author__asGroup>
+    _$gBookFragmentDataBaseAuthorAsGroupSerializer =
+    _$GBookFragmentData__base_author__asGroupSerializer();
+Serializer<GBookFragmentData__base_author__asGroup_members__base>
+    _$gBookFragmentDataBaseAuthorAsGroupMembersBaseSerializer =
+    _$GBookFragmentData__base_author__asGroup_members__baseSerializer();
+Serializer<GBookFragmentData__base_author__asGroup_members__asPerson>
+    _$gBookFragmentDataBaseAuthorAsGroupMembersAsPersonSerializer =
+    _$GBookFragmentData__base_author__asGroup_members__asPersonSerializer();
+Serializer<GBookFragmentData__base_author__asGroup_members__asCompany>
+    _$gBookFragmentDataBaseAuthorAsGroupMembersAsCompanySerializer =
+    _$GBookFragmentData__base_author__asGroup_members__asCompanySerializer();
 Serializer<GBookFragmentData__asTextbook>
     _$gBookFragmentDataAsTextbookSerializer =
     _$GBookFragmentData__asTextbookSerializer();
@@ -74,6 +116,18 @@ Serializer<GBookFragmentData__asTextbook_author__asPerson>
 Serializer<GBookFragmentData__asTextbook_author__asCompany>
     _$gBookFragmentDataAsTextbookAuthorAsCompanySerializer =
     _$GBookFragmentData__asTextbook_author__asCompanySerializer();
+Serializer<GBookFragmentData__asTextbook_author__asGroup>
+    _$gBookFragmentDataAsTextbookAuthorAsGroupSerializer =
+    _$GBookFragmentData__asTextbook_author__asGroupSerializer();
+Serializer<GBookFragmentData__asTextbook_author__asGroup_members__base>
+    _$gBookFragmentDataAsTextbookAuthorAsGroupMembersBaseSerializer =
+    _$GBookFragmentData__asTextbook_author__asGroup_members__baseSerializer();
+Serializer<GBookFragmentData__asTextbook_author__asGroup_members__asPerson>
+    _$gBookFragmentDataAsTextbookAuthorAsGroupMembersAsPersonSerializer =
+    _$GBookFragmentData__asTextbook_author__asGroup_members__asPersonSerializer();
+Serializer<GBookFragmentData__asTextbook_author__asGroup_members__asCompany>
+    _$gBookFragmentDataAsTextbookAuthorAsGroupMembersAsCompanySerializer =
+    _$GBookFragmentData__asTextbook_author__asGroup_members__asCompanySerializer();
 Serializer<GBookFragmentData__asColoringBook>
     _$gBookFragmentDataAsColoringBookSerializer =
     _$GBookFragmentData__asColoringBookSerializer();
@@ -86,6 +140,51 @@ Serializer<GBookFragmentData__asColoringBook_author__asPerson>
 Serializer<GBookFragmentData__asColoringBook_author__asCompany>
     _$gBookFragmentDataAsColoringBookAuthorAsCompanySerializer =
     _$GBookFragmentData__asColoringBook_author__asCompanySerializer();
+Serializer<GBookFragmentData__asColoringBook_author__asGroup>
+    _$gBookFragmentDataAsColoringBookAuthorAsGroupSerializer =
+    _$GBookFragmentData__asColoringBook_author__asGroupSerializer();
+Serializer<GBookFragmentData__asColoringBook_author__asGroup_members__base>
+    _$gBookFragmentDataAsColoringBookAuthorAsGroupMembersBaseSerializer =
+    _$GBookFragmentData__asColoringBook_author__asGroup_members__baseSerializer();
+Serializer<GBookFragmentData__asColoringBook_author__asGroup_members__asPerson>
+    _$gBookFragmentDataAsColoringBookAuthorAsGroupMembersAsPersonSerializer =
+    _$GBookFragmentData__asColoringBook_author__asGroup_members__asPersonSerializer();
+Serializer<GBookFragmentData__asColoringBook_author__asGroup_members__asCompany>
+    _$gBookFragmentDataAsColoringBookAuthorAsGroupMembersAsCompanySerializer =
+    _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompanySerializer();
+Serializer<GAuthorFragmentData__base> _$gAuthorFragmentDataBaseSerializer =
+    _$GAuthorFragmentData__baseSerializer();
+Serializer<GAuthorFragmentData__asPerson>
+    _$gAuthorFragmentDataAsPersonSerializer =
+    _$GAuthorFragmentData__asPersonSerializer();
+Serializer<GAuthorFragmentData__asCompany>
+    _$gAuthorFragmentDataAsCompanySerializer =
+    _$GAuthorFragmentData__asCompanySerializer();
+Serializer<GAuthorFragmentData__asGroup>
+    _$gAuthorFragmentDataAsGroupSerializer =
+    _$GAuthorFragmentData__asGroupSerializer();
+Serializer<GAuthorFragmentData__asGroup_members__base>
+    _$gAuthorFragmentDataAsGroupMembersBaseSerializer =
+    _$GAuthorFragmentData__asGroup_members__baseSerializer();
+Serializer<GAuthorFragmentData__asGroup_members__asPerson>
+    _$gAuthorFragmentDataAsGroupMembersAsPersonSerializer =
+    _$GAuthorFragmentData__asGroup_members__asPersonSerializer();
+Serializer<GAuthorFragmentData__asGroup_members__asCompany>
+    _$gAuthorFragmentDataAsGroupMembersAsCompanySerializer =
+    _$GAuthorFragmentData__asGroup_members__asCompanySerializer();
+Serializer<GAuthorPersonFragmentData> _$gAuthorPersonFragmentDataSerializer =
+    _$GAuthorPersonFragmentDataSerializer();
+Serializer<GAuthorCompanyFragmentData> _$gAuthorCompanyFragmentDataSerializer =
+    _$GAuthorCompanyFragmentDataSerializer();
+Serializer<GAuthorGroupFragmentData__base>
+    _$gAuthorGroupFragmentDataBaseSerializer =
+    _$GAuthorGroupFragmentData__baseSerializer();
+Serializer<GAuthorGroupFragmentData__asPerson>
+    _$gAuthorGroupFragmentDataAsPersonSerializer =
+    _$GAuthorGroupFragmentData__asPersonSerializer();
+Serializer<GAuthorGroupFragmentData__asCompany>
+    _$gAuthorGroupFragmentDataAsCompanySerializer =
+    _$GAuthorGroupFragmentData__asCompanySerializer();
 
 class _$GGetBooksDataSerializer implements StructuredSerializer<GGetBooksData> {
   @override
@@ -381,6 +480,262 @@ class _$GGetBooksData_books__base_author__asCompanySerializer
   }
 }
 
+class _$GGetBooksData_books__base_author__asGroupSerializer
+    implements StructuredSerializer<GGetBooksData_books__base_author__asGroup> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__asGroup,
+    _$GGetBooksData_books__base_author__asGroup
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__base_author__asGroup';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GGetBooksData_books__base_author__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(GGetBooksData_books__base_author__asGroup_members)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__base_author__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(
+                    GGetBooksData_books__base_author__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__base_author__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__base_author__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__asGroup_members__base,
+    _$GGetBooksData_books__base_author__asGroup_members__base
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__base_author__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__base_author__asGroup_members__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__base_author__asGroup_members__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__base_author__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__base_author__asGroup_members__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__asGroup_members__asPerson,
+    _$GGetBooksData_books__base_author__asGroup_members__asPerson
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__base_author__asGroup_members__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__base_author__asGroup_members__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__base_author__asGroup_members__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__base_author__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__base_author__asGroup_members__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__base_author__asGroup_members__asCompany,
+    _$GGetBooksData_books__base_author__asGroup_members__asCompany
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__base_author__asGroup_members__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__base_author__asGroup_members__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$GGetBooksData_books__asTextbookSerializer
     implements StructuredSerializer<GGetBooksData_books__asTextbook> {
   @override
@@ -611,6 +966,264 @@ class _$GGetBooksData_books__asTextbook_author__asCompanySerializer
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = GGetBooksData_books__asTextbook_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroupSerializer
+    implements
+        StructuredSerializer<GGetBooksData_books__asTextbook_author__asGroup> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__asGroup,
+    _$GGetBooksData_books__asTextbook_author__asGroup
+  ];
+  @override
+  final String wireName = 'GGetBooksData_books__asTextbook_author__asGroup';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(
+                GGetBooksData_books__asTextbook_author__asGroup_members)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asTextbook_author__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(
+                    GGetBooksData_books__asTextbook_author__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asTextbook_author__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__asGroup_members__base,
+    _$GGetBooksData_books__asTextbook_author__asGroup_members__base
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__asTextbook_author__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__asGroup_members__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__asGroup_members__asPerson,
+    _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__asTextbook_author__asGroup_members__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__asGroup_members__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asTextbook_author__asGroup_members__asCompany,
+    _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__asTextbook_author__asGroup_members__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asTextbook_author__asGroup_members__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+      deserialize(Serializers serializers, Iterable<Object?> serialized,
+          {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -898,19 +1511,90 @@ class _$GGetBooksData_books__asColoringBook_author__asCompanySerializer
   }
 }
 
-class _$GAuthorFragmentData__baseSerializer
-    implements StructuredSerializer<GAuthorFragmentData__base> {
+class _$GGetBooksData_books__asColoringBook_author__asGroupSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asColoringBook_author__asGroup> {
   @override
   final Iterable<Type> types = const [
-    GAuthorFragmentData__base,
-    _$GAuthorFragmentData__base
+    GGetBooksData_books__asColoringBook_author__asGroup,
+    _$GGetBooksData_books__asColoringBook_author__asGroup
   ];
   @override
-  final String wireName = 'GAuthorFragmentData__base';
+  final String wireName = 'GGetBooksData_books__asColoringBook_author__asGroup';
 
   @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GAuthorFragmentData__base object,
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(
+                GGetBooksData_books__asColoringBook_author__asGroup_members)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksData_books__asColoringBook_author__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(
+                    GGetBooksData_books__asColoringBook_author__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GGetBooksData_books__asColoringBook_author__asGroup_members__base,
+    _$GGetBooksData_books__asColoringBook_author__asGroup_members__base
+  ];
+  @override
+  final String wireName =
+      'GGetBooksData_books__asColoringBook_author__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__asGroup_members__base object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
@@ -925,10 +1609,11 @@ class _$GAuthorFragmentData__baseSerializer
   }
 
   @override
-  GAuthorFragmentData__base deserialize(
+  GGetBooksData_books__asColoringBook_author__asGroup_members__base deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    final result = GAuthorFragmentData__baseBuilder();
+    final result =
+        GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -951,19 +1636,24 @@ class _$GAuthorFragmentData__baseSerializer
   }
 }
 
-class _$GAuthorFragmentData__asPersonSerializer
-    implements StructuredSerializer<GAuthorFragmentData__asPerson> {
+class _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson> {
   @override
   final Iterable<Type> types = const [
-    GAuthorFragmentData__asPerson,
-    _$GAuthorFragmentData__asPerson
+    GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson,
+    _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
   ];
   @override
-  final String wireName = 'GAuthorFragmentData__asPerson';
+  final String wireName =
+      'GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson';
 
   @override
   Iterable<Object?> serialize(
-      Serializers serializers, GAuthorFragmentData__asPerson object,
+      Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+          object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
@@ -984,10 +1674,11 @@ class _$GAuthorFragmentData__asPersonSerializer
   }
 
   @override
-  GAuthorFragmentData__asPerson deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = GAuthorFragmentData__asPersonBuilder();
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+      deserialize(Serializers serializers, Iterable<Object?> serialized,
+          {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -1018,19 +1709,24 @@ class _$GAuthorFragmentData__asPersonSerializer
   }
 }
 
-class _$GAuthorFragmentData__asCompanySerializer
-    implements StructuredSerializer<GAuthorFragmentData__asCompany> {
+class _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany> {
   @override
   final Iterable<Type> types = const [
-    GAuthorFragmentData__asCompany,
-    _$GAuthorFragmentData__asCompany
+    GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany,
+    _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
   ];
   @override
-  final String wireName = 'GAuthorFragmentData__asCompany';
+  final String wireName =
+      'GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany';
 
   @override
   Iterable<Object?> serialize(
-      Serializers serializers, GAuthorFragmentData__asCompany object,
+      Serializers serializers,
+      GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+          object,
       {FullType specifiedType = FullType.unspecified}) {
     final result = <Object?>[
       '__typename',
@@ -1047,10 +1743,11 @@ class _$GAuthorFragmentData__asCompanySerializer
   }
 
   @override
-  GAuthorFragmentData__asCompany deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = GAuthorFragmentData__asCompanyBuilder();
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+      deserialize(Serializers serializers, Iterable<Object?> serialized,
+          {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -1292,6 +1989,261 @@ class _$GBookFragmentData__base_author__asCompanySerializer
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = GBookFragmentData__base_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroupSerializer
+    implements StructuredSerializer<GBookFragmentData__base_author__asGroup> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__asGroup,
+    _$GBookFragmentData__base_author__asGroup
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__base_author__asGroup';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GBookFragmentData__base_author__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(GBookFragmentData__base_author__asGroup_members)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__base_author__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GBookFragmentData__base_author__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__base_author__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__asGroup_members__base,
+    _$GBookFragmentData__base_author__asGroup_members__base
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__base_author__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__base_author__asGroup_members__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__base_author__asGroup_members__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__base_author__asGroup_members__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__asGroup_members__asPerson,
+    _$GBookFragmentData__base_author__asGroup_members__asPerson
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__base_author__asGroup_members__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__base_author__asGroup_members__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__base_author__asGroup_members__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__base_author__asGroup_members__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__base_author__asGroup_members__asCompany,
+    _$GBookFragmentData__base_author__asGroup_members__asCompany
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__base_author__asGroup_members__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__base_author__asGroup_members__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__base_author__asGroup_members__asCompanyBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -1572,6 +2524,264 @@ class _$GBookFragmentData__asTextbook_author__asCompanySerializer
   }
 }
 
+class _$GBookFragmentData__asTextbook_author__asGroupSerializer
+    implements
+        StructuredSerializer<GBookFragmentData__asTextbook_author__asGroup> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__asGroup,
+    _$GBookFragmentData__asTextbook_author__asGroup
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asTextbook_author__asGroup';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(
+                GBookFragmentData__asTextbook_author__asGroup_members)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asTextbook_author__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(
+                    GBookFragmentData__asTextbook_author__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asTextbook_author__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__asGroup_members__base,
+    _$GBookFragmentData__asTextbook_author__asGroup_members__base
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__asTextbook_author__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__asGroup_members__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asTextbook_author__asGroup_members__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__asGroup_members__asPerson,
+    _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__asTextbook_author__asGroup_members__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__asGroup_members__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asTextbook_author__asGroup_members__asCompany,
+    _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__asTextbook_author__asGroup_members__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asTextbook_author__asGroup_members__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
 class _$GBookFragmentData__asColoringBookSerializer
     implements StructuredSerializer<GBookFragmentData__asColoringBook> {
   @override
@@ -1803,6 +3013,984 @@ class _$GBookFragmentData__asColoringBook_author__asCompanySerializer
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     final result = GBookFragmentData__asColoringBook_author__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroupSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asColoringBook_author__asGroup> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__asGroup,
+    _$GBookFragmentData__asColoringBook_author__asGroup
+  ];
+  @override
+  final String wireName = 'GBookFragmentData__asColoringBook_author__asGroup';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asColoringBook_author__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList, const [
+            const FullType(
+                GBookFragmentData__asColoringBook_author__asGroup_members)
+          ])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GBookFragmentData__asColoringBook_author__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(
+                    GBookFragmentData__asColoringBook_author__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asColoringBook_author__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__asGroup_members__base,
+    _$GBookFragmentData__asColoringBook_author__asGroup_members__base
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__asColoringBook_author__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GBookFragmentData__asColoringBook_author__asGroup_members__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__asGroup_members__asPerson,
+    _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__asColoringBook_author__asGroup_members__asPerson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers,
+      GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+          object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+      deserialize(Serializers serializers, Iterable<Object?> serialized,
+          {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GBookFragmentData__asColoringBook_author__asGroup_members__asCompany,
+    _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+  ];
+  @override
+  final String wireName =
+      'GBookFragmentData__asColoringBook_author__asGroup_members__asCompany';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers,
+      GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+          object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+      deserialize(Serializers serializers, Iterable<Object?> serialized,
+          {FullType specifiedType = FullType.unspecified}) {
+    final result =
+        GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__baseSerializer
+    implements StructuredSerializer<GAuthorFragmentData__base> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__base,
+    _$GAuthorFragmentData__base
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asPersonSerializer
+    implements StructuredSerializer<GAuthorFragmentData__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asPerson,
+    _$GAuthorFragmentData__asPerson
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asPerson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asCompanySerializer
+    implements StructuredSerializer<GAuthorFragmentData__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asCompany,
+    _$GAuthorFragmentData__asCompany
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asCompany';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asGroupSerializer
+    implements StructuredSerializer<GAuthorFragmentData__asGroup> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asGroup,
+    _$GAuthorFragmentData__asGroup
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asGroup';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentData__asGroup object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'members',
+      serializers.serialize(object.members,
+          specifiedType: const FullType(BuiltList,
+              const [const FullType(GAuthorFragmentData__asGroup_members)])),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asGroup deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asGroupBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'members':
+          result.members.replace(serializers.deserialize(value,
+              specifiedType: const FullType(BuiltList, const [
+                const FullType(GAuthorFragmentData__asGroup_members)
+              ]))! as BuiltList<Object?>);
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asGroup_members__baseSerializer
+    implements
+        StructuredSerializer<GAuthorFragmentData__asGroup_members__base> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asGroup_members__base,
+    _$GAuthorFragmentData__asGroup_members__base
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asGroup_members__base';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GAuthorFragmentData__asGroup_members__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asGroup_members__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asGroup_members__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asGroup_members__asPersonSerializer
+    implements
+        StructuredSerializer<GAuthorFragmentData__asGroup_members__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asGroup_members__asPerson,
+    _$GAuthorFragmentData__asGroup_members__asPerson
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asGroup_members__asPerson';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GAuthorFragmentData__asGroup_members__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asGroup_members__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asGroup_members__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorFragmentData__asGroup_members__asCompanySerializer
+    implements
+        StructuredSerializer<GAuthorFragmentData__asGroup_members__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentData__asGroup_members__asCompany,
+    _$GAuthorFragmentData__asGroup_members__asCompany
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentData__asGroup_members__asCompany';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers,
+      GAuthorFragmentData__asGroup_members__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorFragmentData__asGroup_members__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorFragmentData__asGroup_members__asCompanyBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorPersonFragmentDataSerializer
+    implements StructuredSerializer<GAuthorPersonFragmentData> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorPersonFragmentData,
+    _$GAuthorPersonFragmentData
+  ];
+  @override
+  final String wireName = 'GAuthorPersonFragmentData';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorPersonFragmentData object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorPersonFragmentData deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorPersonFragmentDataBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorCompanyFragmentDataSerializer
+    implements StructuredSerializer<GAuthorCompanyFragmentData> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorCompanyFragmentData,
+    _$GAuthorCompanyFragmentData
+  ];
+  @override
+  final String wireName = 'GAuthorCompanyFragmentData';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorCompanyFragmentData object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorCompanyFragmentData deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorCompanyFragmentDataBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorGroupFragmentData__baseSerializer
+    implements StructuredSerializer<GAuthorGroupFragmentData__base> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorGroupFragmentData__base,
+    _$GAuthorGroupFragmentData__base
+  ];
+  @override
+  final String wireName = 'GAuthorGroupFragmentData__base';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorGroupFragmentData__base object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorGroupFragmentData__base deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorGroupFragmentData__baseBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorGroupFragmentData__asPersonSerializer
+    implements StructuredSerializer<GAuthorGroupFragmentData__asPerson> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorGroupFragmentData__asPerson,
+    _$GAuthorGroupFragmentData__asPerson
+  ];
+  @override
+  final String wireName = 'GAuthorGroupFragmentData__asPerson';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorGroupFragmentData__asPerson object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'firstName',
+      serializers.serialize(object.firstName,
+          specifiedType: const FullType(String)),
+      'lastName',
+      serializers.serialize(object.lastName,
+          specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorGroupFragmentData__asPerson deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorGroupFragmentData__asPersonBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case '__typename':
+          result.G__typename = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'displayName':
+          result.displayName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'firstName':
+          result.firstName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'lastName':
+          result.lastName = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GAuthorGroupFragmentData__asCompanySerializer
+    implements StructuredSerializer<GAuthorGroupFragmentData__asCompany> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorGroupFragmentData__asCompany,
+    _$GAuthorGroupFragmentData__asCompany
+  ];
+  @override
+  final String wireName = 'GAuthorGroupFragmentData__asCompany';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorGroupFragmentData__asCompany object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      '__typename',
+      serializers.serialize(object.G__typename,
+          specifiedType: const FullType(String)),
+      'displayName',
+      serializers.serialize(object.displayName,
+          specifiedType: const FullType(String)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GAuthorGroupFragmentData__asCompany deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GAuthorGroupFragmentData__asCompanyBuilder();
 
     final iterator = serialized.iterator;
     while (iterator.moveNext()) {
@@ -2419,6 +4607,564 @@ class GGetBooksData_books__base_author__asCompanyBuilder
   }
 }
 
+class _$GGetBooksData_books__base_author__asGroup
+    extends GGetBooksData_books__base_author__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GGetBooksData_books__base_author__asGroup_members> members;
+
+  factory _$GGetBooksData_books__base_author__asGroup(
+          [void Function(GGetBooksData_books__base_author__asGroupBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__asGroupBuilder()..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__asGroup rebuild(
+          void Function(GGetBooksData_books__base_author__asGroupBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__asGroupBuilder toBuilder() =>
+      GGetBooksData_books__base_author__asGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__base_author__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__asGroupBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__asGroup,
+            GGetBooksData_books__base_author__asGroupBuilder> {
+  _$GGetBooksData_books__base_author__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GGetBooksData_books__base_author__asGroup_members>? _members;
+  ListBuilder<GGetBooksData_books__base_author__asGroup_members> get members =>
+      _$this._members ??=
+          ListBuilder<GGetBooksData_books__base_author__asGroup_members>();
+  set members(
+          ListBuilder<GGetBooksData_books__base_author__asGroup_members>?
+              members) =>
+      _$this._members = members;
+
+  GGetBooksData_books__base_author__asGroupBuilder() {
+    GGetBooksData_books__base_author__asGroup._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__base_author__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__base_author__asGroup other) {
+    _$v = other as _$GGetBooksData_books__base_author__asGroup;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__base_author__asGroupBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup build() => _build();
+
+  _$GGetBooksData_books__base_author__asGroup _build() {
+    _$GGetBooksData_books__base_author__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooksData_books__base_author__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                r'GGetBooksData_books__base_author__asGroup', 'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+                r'GGetBooksData_books__base_author__asGroup', 'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GGetBooksData_books__base_author__asGroup',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base_author__asGroup_members__base
+    extends GGetBooksData_books__base_author__asGroup_members__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GGetBooksData_books__base_author__asGroup_members__base(
+          [void Function(
+                  GGetBooksData_books__base_author__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__asGroup_members__baseBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__asGroup_members__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__asGroup_members__base rebuild(
+          void Function(
+                  GGetBooksData_books__base_author__asGroup_members__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__baseBuilder toBuilder() =>
+      GGetBooksData_books__base_author__asGroup_members__baseBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__base_author__asGroup_members__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__asGroup_members__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__asGroup_members__baseBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__asGroup_members__base,
+            GGetBooksData_books__base_author__asGroup_members__baseBuilder> {
+  _$GGetBooksData_books__base_author__asGroup_members__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GGetBooksData_books__base_author__asGroup_members__baseBuilder() {
+    GGetBooksData_books__base_author__asGroup_members__base._initializeBuilder(
+        this);
+  }
+
+  GGetBooksData_books__base_author__asGroup_members__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__base_author__asGroup_members__base other) {
+    _$v = other as _$GGetBooksData_books__base_author__asGroup_members__base;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__base_author__asGroup_members__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__base build() => _build();
+
+  _$GGetBooksData_books__base_author__asGroup_members__base _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base_author__asGroup_members__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__base_author__asGroup_members__base',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__base_author__asGroup_members__base',
+              'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base_author__asGroup_members__asPerson
+    extends GGetBooksData_books__base_author__asGroup_members__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GGetBooksData_books__base_author__asGroup_members__asPerson(
+          [void Function(
+                  GGetBooksData_books__base_author__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__asGroup_members__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__asGroup_members__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asPerson rebuild(
+          void Function(
+                  GGetBooksData_books__base_author__asGroup_members__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asPersonBuilder
+      toBuilder() =>
+          GGetBooksData_books__base_author__asGroup_members__asPersonBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetBooksData_books__base_author__asGroup_members__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__asGroup_members__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__asGroup_members__asPersonBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__asGroup_members__asPerson,
+            GGetBooksData_books__base_author__asGroup_members__asPersonBuilder> {
+  _$GGetBooksData_books__base_author__asGroup_members__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GGetBooksData_books__base_author__asGroup_members__asPersonBuilder() {
+    GGetBooksData_books__base_author__asGroup_members__asPerson
+        ._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__base_author__asGroup_members__asPersonBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetBooksData_books__base_author__asGroup_members__asPerson other) {
+    _$v =
+        other as _$GGetBooksData_books__base_author__asGroup_members__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__base_author__asGroup_members__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asPerson build() =>
+      _build();
+
+  _$GGetBooksData_books__base_author__asGroup_members__asPerson _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base_author__asGroup_members__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__base_author__asGroup_members__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__base_author__asGroup_members__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GGetBooksData_books__base_author__asGroup_members__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GGetBooksData_books__base_author__asGroup_members__asPerson',
+              'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__base_author__asGroup_members__asCompany
+    extends GGetBooksData_books__base_author__asGroup_members__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GGetBooksData_books__base_author__asGroup_members__asCompany(
+          [void Function(
+                  GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__base_author__asGroup_members__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asCompany rebuild(
+          void Function(
+                  GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder
+      toBuilder() =>
+          GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetBooksData_books__base_author__asGroup_members__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__base_author__asGroup_members__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder
+    implements
+        Builder<GGetBooksData_books__base_author__asGroup_members__asCompany,
+            GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder> {
+  _$GGetBooksData_books__base_author__asGroup_members__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder() {
+    GGetBooksData_books__base_author__asGroup_members__asCompany
+        ._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetBooksData_books__base_author__asGroup_members__asCompany other) {
+    _$v =
+        other as _$GGetBooksData_books__base_author__asGroup_members__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__base_author__asGroup_members__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__base_author__asGroup_members__asCompany build() =>
+      _build();
+
+  _$GGetBooksData_books__base_author__asGroup_members__asCompany _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__base_author__asGroup_members__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__base_author__asGroup_members__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__base_author__asGroup_members__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name,
+              r'GGetBooksData_books__base_author__asGroup_members__asCompany',
+              'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
 class _$GGetBooksData_books__asTextbook
     extends GGetBooksData_books__asTextbook {
   @override
@@ -2937,6 +5683,582 @@ class GGetBooksData_books__asTextbook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(name,
               r'GGetBooksData_books__asTextbook_author__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup
+    extends GGetBooksData_books__asTextbook_author__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GGetBooksData_books__asTextbook_author__asGroup_members>
+      members;
+
+  factory _$GGetBooksData_books__asTextbook_author__asGroup(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroupBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__asGroupBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup rebuild(
+          void Function(GGetBooksData_books__asTextbook_author__asGroupBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroupBuilder toBuilder() =>
+      GGetBooksData_books__asTextbook_author__asGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asTextbook_author__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__asGroupBuilder
+    implements
+        Builder<GGetBooksData_books__asTextbook_author__asGroup,
+            GGetBooksData_books__asTextbook_author__asGroupBuilder> {
+  _$GGetBooksData_books__asTextbook_author__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GGetBooksData_books__asTextbook_author__asGroup_members>?
+      _members;
+  ListBuilder<GGetBooksData_books__asTextbook_author__asGroup_members>
+      get members => _$this._members ??= ListBuilder<
+          GGetBooksData_books__asTextbook_author__asGroup_members>();
+  set members(
+          ListBuilder<GGetBooksData_books__asTextbook_author__asGroup_members>?
+              members) =>
+      _$this._members = members;
+
+  GGetBooksData_books__asTextbook_author__asGroupBuilder() {
+    GGetBooksData_books__asTextbook_author__asGroup._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asTextbook_author__asGroup other) {
+    _$v = other as _$GGetBooksData_books__asTextbook_author__asGroup;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asTextbook_author__asGroupBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup build() => _build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup _build() {
+    _$GGetBooksData_books__asTextbook_author__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooksData_books__asTextbook_author__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GGetBooksData_books__asTextbook_author__asGroup',
+                'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(
+                displayName,
+                r'GGetBooksData_books__asTextbook_author__asGroup',
+                'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GGetBooksData_books__asTextbook_author__asGroup',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup_members__base
+    extends GGetBooksData_books__asTextbook_author__asGroup_members__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GGetBooksData_books__asTextbook_author__asGroup_members__base(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__base rebuild(
+          void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder
+      toBuilder() =>
+          GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetBooksData_books__asTextbook_author__asGroup_members__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__asGroup_members__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder
+    implements
+        Builder<GGetBooksData_books__asTextbook_author__asGroup_members__base,
+            GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder> {
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder() {
+    GGetBooksData_books__asTextbook_author__asGroup_members__base
+        ._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetBooksData_books__asTextbook_author__asGroup_members__base other) {
+    _$v = other
+        as _$GGetBooksData_books__asTextbook_author__asGroup_members__base;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__asTextbook_author__asGroup_members__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__base build() =>
+      _build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__base _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asTextbook_author__asGroup_members__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__base',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__base',
+              'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+    extends GGetBooksData_books__asTextbook_author__asGroup_members__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPerson rebuild(
+          void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder
+      toBuilder() =>
+          GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetBooksData_books__asTextbook_author__asGroup_members__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__asGroup_members__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder
+    implements
+        Builder<
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPerson,
+            GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder> {
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder() {
+    GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+        ._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetBooksData_books__asTextbook_author__asGroup_members__asPerson other) {
+    _$v = other
+        as _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__asTextbook_author__asGroup_members__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPerson build() =>
+      _build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asTextbook_author__asGroup_members__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asPerson',
+              'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+    extends GGetBooksData_books__asTextbook_author__asGroup_members__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany(
+          [void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompany rebuild(
+          void Function(
+                  GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder
+      toBuilder() =>
+          GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GGetBooksData_books__asTextbook_author__asGroup_members__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asTextbook_author__asGroup_members__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder
+    implements
+        Builder<
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompany,
+            GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder> {
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder() {
+    GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+        ._initializeBuilder(this);
+  }
+
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+          other) {
+    _$v = other
+        as _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(
+              GGetBooksData_books__asTextbook_author__asGroup_members__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompany build() =>
+      _build();
+
+  _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+      _build() {
+    final _$result = _$v ??
+        _$GGetBooksData_books__asTextbook_author__asGroup_members__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name,
+              r'GGetBooksData_books__asTextbook_author__asGroup_members__asCompany',
+              'name'),
         );
     replace(_$result);
     return _$result;
@@ -3486,32 +6808,196 @@ class GGetBooksData_books__asColoringBook_author__asCompanyBuilder
   }
 }
 
-class _$GAuthorFragmentData__base extends GAuthorFragmentData__base {
+class _$GGetBooksData_books__asColoringBook_author__asGroup
+    extends GGetBooksData_books__asColoringBook_author__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GGetBooksData_books__asColoringBook_author__asGroup_members>
+      members;
+
+  factory _$GGetBooksData_books__asColoringBook_author__asGroup(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroupBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__asGroupBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GGetBooksData_books__asColoringBook_author__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GGetBooksData_books__asColoringBook_author__asGroup rebuild(
+          void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroupBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asGroupBuilder toBuilder() =>
+      GGetBooksData_books__asColoringBook_author__asGroupBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksData_books__asColoringBook_author__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GGetBooksData_books__asColoringBook_author__asGroupBuilder
+    implements
+        Builder<GGetBooksData_books__asColoringBook_author__asGroup,
+            GGetBooksData_books__asColoringBook_author__asGroupBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GGetBooksData_books__asColoringBook_author__asGroup_members>?
+      _members;
+  ListBuilder<GGetBooksData_books__asColoringBook_author__asGroup_members>
+      get members => _$this._members ??= ListBuilder<
+          GGetBooksData_books__asColoringBook_author__asGroup_members>();
+  set members(
+          ListBuilder<
+                  GGetBooksData_books__asColoringBook_author__asGroup_members>?
+              members) =>
+      _$this._members = members;
+
+  GGetBooksData_books__asColoringBook_author__asGroupBuilder() {
+    GGetBooksData_books__asColoringBook_author__asGroup._initializeBuilder(
+        this);
+  }
+
+  GGetBooksData_books__asColoringBook_author__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooksData_books__asColoringBook_author__asGroup other) {
+    _$v = other as _$GGetBooksData_books__asColoringBook_author__asGroup;
+  }
+
+  @override
+  void update(
+      void Function(GGetBooksData_books__asColoringBook_author__asGroupBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksData_books__asColoringBook_author__asGroup build() => _build();
+
+  _$GGetBooksData_books__asColoringBook_author__asGroup _build() {
+    _$GGetBooksData_books__asColoringBook_author__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooksData_books__asColoringBook_author__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GGetBooksData_books__asColoringBook_author__asGroup',
+                'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(
+                displayName,
+                r'GGetBooksData_books__asColoringBook_author__asGroup',
+                'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GGetBooksData_books__asColoringBook_author__asGroup',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GGetBooksData_books__asColoringBook_author__asGroup_members__base
+    extends GGetBooksData_books__asColoringBook_author__asGroup_members__base {
   @override
   final String G__typename;
   @override
   final String displayName;
 
-  factory _$GAuthorFragmentData__base(
-          [void Function(GAuthorFragmentData__baseBuilder)? updates]) =>
-      (GAuthorFragmentData__baseBuilder()..update(updates))._build();
+  factory _$GGetBooksData_books__asColoringBook_author__asGroup_members__base(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder()
+            ..update(updates))
+          ._build();
 
-  _$GAuthorFragmentData__base._(
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__base._(
       {required this.G__typename, required this.displayName})
       : super._();
   @override
-  GAuthorFragmentData__base rebuild(
-          void Function(GAuthorFragmentData__baseBuilder) updates) =>
+  GGetBooksData_books__asColoringBook_author__asGroup_members__base rebuild(
+          void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder)
+              updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GAuthorFragmentData__baseBuilder toBuilder() =>
-      GAuthorFragmentData__baseBuilder()..replace(this);
+  GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder
+      toBuilder() =>
+          GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder()
+            ..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GAuthorFragmentData__base &&
+    return other
+            is GGetBooksData_books__asColoringBook_author__asGroup_members__base &&
         G__typename == other.G__typename &&
         displayName == other.displayName;
   }
@@ -3527,17 +7013,20 @@ class _$GAuthorFragmentData__base extends GAuthorFragmentData__base {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__base')
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__asGroup_members__base')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName))
         .toString();
   }
 }
 
-class GAuthorFragmentData__baseBuilder
+class GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder
     implements
-        Builder<GAuthorFragmentData__base, GAuthorFragmentData__baseBuilder> {
-  _$GAuthorFragmentData__base? _$v;
+        Builder<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__base,
+            GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__base? _$v;
 
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
@@ -3547,11 +7036,13 @@ class GAuthorFragmentData__baseBuilder
   String? get displayName => _$this._displayName;
   set displayName(String? displayName) => _$this._displayName = displayName;
 
-  GAuthorFragmentData__baseBuilder() {
-    GAuthorFragmentData__base._initializeBuilder(this);
+  GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder() {
+    GGetBooksData_books__asColoringBook_author__asGroup_members__base
+        ._initializeBuilder(this);
   }
 
-  GAuthorFragmentData__baseBuilder get _$this {
+  GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder
+      get _$this {
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
@@ -3562,32 +7053,43 @@ class GAuthorFragmentData__baseBuilder
   }
 
   @override
-  void replace(GAuthorFragmentData__base other) {
-    _$v = other as _$GAuthorFragmentData__base;
+  void replace(
+      GGetBooksData_books__asColoringBook_author__asGroup_members__base other) {
+    _$v = other
+        as _$GGetBooksData_books__asColoringBook_author__asGroup_members__base;
   }
 
   @override
-  void update(void Function(GAuthorFragmentData__baseBuilder)? updates) {
+  void update(
+      void Function(
+              GGetBooksData_books__asColoringBook_author__asGroup_members__baseBuilder)?
+          updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  GAuthorFragmentData__base build() => _build();
+  GGetBooksData_books__asColoringBook_author__asGroup_members__base build() =>
+      _build();
 
-  _$GAuthorFragmentData__base _build() {
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__base _build() {
     final _$result = _$v ??
-        _$GAuthorFragmentData__base._(
+        _$GGetBooksData_books__asColoringBook_author__asGroup_members__base._(
           G__typename: BuiltValueNullFieldError.checkNotNull(
-              G__typename, r'GAuthorFragmentData__base', 'G__typename'),
+              G__typename,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__base',
+              'G__typename'),
           displayName: BuiltValueNullFieldError.checkNotNull(
-              displayName, r'GAuthorFragmentData__base', 'displayName'),
+              displayName,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__base',
+              'displayName'),
         );
     replace(_$result);
     return _$result;
   }
 }
 
-class _$GAuthorFragmentData__asPerson extends GAuthorFragmentData__asPerson {
+class _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+    extends GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson {
   @override
   final String G__typename;
   @override
@@ -3597,29 +7099,38 @@ class _$GAuthorFragmentData__asPerson extends GAuthorFragmentData__asPerson {
   @override
   final String lastName;
 
-  factory _$GAuthorFragmentData__asPerson(
-          [void Function(GAuthorFragmentData__asPersonBuilder)? updates]) =>
-      (GAuthorFragmentData__asPersonBuilder()..update(updates))._build();
+  factory _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder()
+            ..update(updates))
+          ._build();
 
-  _$GAuthorFragmentData__asPerson._(
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson._(
       {required this.G__typename,
       required this.displayName,
       required this.firstName,
       required this.lastName})
       : super._();
   @override
-  GAuthorFragmentData__asPerson rebuild(
-          void Function(GAuthorFragmentData__asPersonBuilder) updates) =>
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson rebuild(
+          void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder)
+              updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GAuthorFragmentData__asPersonBuilder toBuilder() =>
-      GAuthorFragmentData__asPersonBuilder()..replace(this);
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder
+      toBuilder() =>
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder()
+            ..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GAuthorFragmentData__asPerson &&
+    return other
+            is GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson &&
         G__typename == other.G__typename &&
         displayName == other.displayName &&
         firstName == other.firstName &&
@@ -3639,7 +7150,8 @@ class _$GAuthorFragmentData__asPerson extends GAuthorFragmentData__asPerson {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asPerson')
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
           ..add('firstName', firstName)
@@ -3648,11 +7160,12 @@ class _$GAuthorFragmentData__asPerson extends GAuthorFragmentData__asPerson {
   }
 }
 
-class GAuthorFragmentData__asPersonBuilder
+class GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder
     implements
-        Builder<GAuthorFragmentData__asPerson,
-            GAuthorFragmentData__asPersonBuilder> {
-  _$GAuthorFragmentData__asPerson? _$v;
+        Builder<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson,
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson? _$v;
 
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
@@ -3670,11 +7183,13 @@ class GAuthorFragmentData__asPersonBuilder
   String? get lastName => _$this._lastName;
   set lastName(String? lastName) => _$this._lastName = lastName;
 
-  GAuthorFragmentData__asPersonBuilder() {
-    GAuthorFragmentData__asPerson._initializeBuilder(this);
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder() {
+    GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+        ._initializeBuilder(this);
   }
 
-  GAuthorFragmentData__asPersonBuilder get _$this {
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder
+      get _$this {
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
@@ -3687,36 +7202,54 @@ class GAuthorFragmentData__asPersonBuilder
   }
 
   @override
-  void replace(GAuthorFragmentData__asPerson other) {
-    _$v = other as _$GAuthorFragmentData__asPerson;
+  void replace(
+      GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+          other) {
+    _$v = other
+        as _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson;
   }
 
   @override
-  void update(void Function(GAuthorFragmentData__asPersonBuilder)? updates) {
+  void update(
+      void Function(
+              GGetBooksData_books__asColoringBook_author__asGroup_members__asPersonBuilder)?
+          updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  GAuthorFragmentData__asPerson build() => _build();
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+      build() => _build();
 
-  _$GAuthorFragmentData__asPerson _build() {
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+      _build() {
     final _$result = _$v ??
-        _$GAuthorFragmentData__asPerson._(
+        _$GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+            ._(
           G__typename: BuiltValueNullFieldError.checkNotNull(
-              G__typename, r'GAuthorFragmentData__asPerson', 'G__typename'),
+              G__typename,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson',
+              'G__typename'),
           displayName: BuiltValueNullFieldError.checkNotNull(
-              displayName, r'GAuthorFragmentData__asPerson', 'displayName'),
+              displayName,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson',
+              'displayName'),
           firstName: BuiltValueNullFieldError.checkNotNull(
-              firstName, r'GAuthorFragmentData__asPerson', 'firstName'),
+              firstName,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson',
+              'firstName'),
           lastName: BuiltValueNullFieldError.checkNotNull(
-              lastName, r'GAuthorFragmentData__asPerson', 'lastName'),
+              lastName,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson',
+              'lastName'),
         );
     replace(_$result);
     return _$result;
   }
 }
 
-class _$GAuthorFragmentData__asCompany extends GAuthorFragmentData__asCompany {
+class _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+    extends GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany {
   @override
   final String G__typename;
   @override
@@ -3724,28 +7257,37 @@ class _$GAuthorFragmentData__asCompany extends GAuthorFragmentData__asCompany {
   @override
   final String name;
 
-  factory _$GAuthorFragmentData__asCompany(
-          [void Function(GAuthorFragmentData__asCompanyBuilder)? updates]) =>
-      (GAuthorFragmentData__asCompanyBuilder()..update(updates))._build();
+  factory _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany(
+          [void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
 
-  _$GAuthorFragmentData__asCompany._(
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany._(
       {required this.G__typename,
       required this.displayName,
       required this.name})
       : super._();
   @override
-  GAuthorFragmentData__asCompany rebuild(
-          void Function(GAuthorFragmentData__asCompanyBuilder) updates) =>
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany rebuild(
+          void Function(
+                  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder)
+              updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GAuthorFragmentData__asCompanyBuilder toBuilder() =>
-      GAuthorFragmentData__asCompanyBuilder()..replace(this);
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder
+      toBuilder() =>
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder()
+            ..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GAuthorFragmentData__asCompany &&
+    return other
+            is GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany &&
         G__typename == other.G__typename &&
         displayName == other.displayName &&
         name == other.name;
@@ -3763,7 +7305,8 @@ class _$GAuthorFragmentData__asCompany extends GAuthorFragmentData__asCompany {
 
   @override
   String toString() {
-    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asCompany')
+    return (newBuiltValueToStringHelper(
+            r'GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany')
           ..add('G__typename', G__typename)
           ..add('displayName', displayName)
           ..add('name', name))
@@ -3771,11 +7314,12 @@ class _$GAuthorFragmentData__asCompany extends GAuthorFragmentData__asCompany {
   }
 }
 
-class GAuthorFragmentData__asCompanyBuilder
+class GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder
     implements
-        Builder<GAuthorFragmentData__asCompany,
-            GAuthorFragmentData__asCompanyBuilder> {
-  _$GAuthorFragmentData__asCompany? _$v;
+        Builder<
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany,
+            GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder> {
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany? _$v;
 
   String? _G__typename;
   String? get G__typename => _$this._G__typename;
@@ -3789,11 +7333,13 @@ class GAuthorFragmentData__asCompanyBuilder
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
 
-  GAuthorFragmentData__asCompanyBuilder() {
-    GAuthorFragmentData__asCompany._initializeBuilder(this);
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder() {
+    GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+        ._initializeBuilder(this);
   }
 
-  GAuthorFragmentData__asCompanyBuilder get _$this {
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder
+      get _$this {
     final $v = _$v;
     if ($v != null) {
       _G__typename = $v.G__typename;
@@ -3805,27 +7351,42 @@ class GAuthorFragmentData__asCompanyBuilder
   }
 
   @override
-  void replace(GAuthorFragmentData__asCompany other) {
-    _$v = other as _$GAuthorFragmentData__asCompany;
+  void replace(
+      GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+          other) {
+    _$v = other
+        as _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany;
   }
 
   @override
-  void update(void Function(GAuthorFragmentData__asCompanyBuilder)? updates) {
+  void update(
+      void Function(
+              GGetBooksData_books__asColoringBook_author__asGroup_members__asCompanyBuilder)?
+          updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  GAuthorFragmentData__asCompany build() => _build();
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+      build() => _build();
 
-  _$GAuthorFragmentData__asCompany _build() {
+  _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+      _build() {
     final _$result = _$v ??
-        _$GAuthorFragmentData__asCompany._(
+        _$GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+            ._(
           G__typename: BuiltValueNullFieldError.checkNotNull(
-              G__typename, r'GAuthorFragmentData__asCompany', 'G__typename'),
+              G__typename,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany',
+              'G__typename'),
           displayName: BuiltValueNullFieldError.checkNotNull(
-              displayName, r'GAuthorFragmentData__asCompany', 'displayName'),
+              displayName,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany',
+              'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(
-              name, r'GAuthorFragmentData__asCompany', 'name'),
+              name,
+              r'GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany',
+              'name'),
         );
     replace(_$result);
     return _$result;
@@ -4302,6 +7863,557 @@ class GBookFragmentData__base_author__asCompanyBuilder
               r'GBookFragmentData__base_author__asCompany', 'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(
               name, r'GBookFragmentData__base_author__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup
+    extends GBookFragmentData__base_author__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GBookFragmentData__base_author__asGroup_members> members;
+
+  factory _$GBookFragmentData__base_author__asGroup(
+          [void Function(GBookFragmentData__base_author__asGroupBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__asGroupBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__base_author__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GBookFragmentData__base_author__asGroup rebuild(
+          void Function(GBookFragmentData__base_author__asGroupBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__asGroupBuilder toBuilder() =>
+      GBookFragmentData__base_author__asGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base_author__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__base_author__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__asGroupBuilder
+    implements
+        Builder<GBookFragmentData__base_author__asGroup,
+            GBookFragmentData__base_author__asGroupBuilder> {
+  _$GBookFragmentData__base_author__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GBookFragmentData__base_author__asGroup_members>? _members;
+  ListBuilder<GBookFragmentData__base_author__asGroup_members> get members =>
+      _$this._members ??=
+          ListBuilder<GBookFragmentData__base_author__asGroup_members>();
+  set members(
+          ListBuilder<GBookFragmentData__base_author__asGroup_members>?
+              members) =>
+      _$this._members = members;
+
+  GBookFragmentData__base_author__asGroupBuilder() {
+    GBookFragmentData__base_author__asGroup._initializeBuilder(this);
+  }
+
+  GBookFragmentData__base_author__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__base_author__asGroup other) {
+    _$v = other as _$GBookFragmentData__base_author__asGroup;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__base_author__asGroupBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup build() => _build();
+
+  _$GBookFragmentData__base_author__asGroup _build() {
+    _$GBookFragmentData__base_author__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GBookFragmentData__base_author__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+                r'GBookFragmentData__base_author__asGroup', 'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+                r'GBookFragmentData__base_author__asGroup', 'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GBookFragmentData__base_author__asGroup',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup_members__base
+    extends GBookFragmentData__base_author__asGroup_members__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GBookFragmentData__base_author__asGroup_members__base(
+          [void Function(
+                  GBookFragmentData__base_author__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__asGroup_members__baseBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__base_author__asGroup_members__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GBookFragmentData__base_author__asGroup_members__base rebuild(
+          void Function(
+                  GBookFragmentData__base_author__asGroup_members__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__baseBuilder toBuilder() =>
+      GBookFragmentData__base_author__asGroup_members__baseBuilder()
+        ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base_author__asGroup_members__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__base_author__asGroup_members__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__asGroup_members__baseBuilder
+    implements
+        Builder<GBookFragmentData__base_author__asGroup_members__base,
+            GBookFragmentData__base_author__asGroup_members__baseBuilder> {
+  _$GBookFragmentData__base_author__asGroup_members__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GBookFragmentData__base_author__asGroup_members__baseBuilder() {
+    GBookFragmentData__base_author__asGroup_members__base._initializeBuilder(
+        this);
+  }
+
+  GBookFragmentData__base_author__asGroup_members__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__base_author__asGroup_members__base other) {
+    _$v = other as _$GBookFragmentData__base_author__asGroup_members__base;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__base_author__asGroup_members__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__base build() => _build();
+
+  _$GBookFragmentData__base_author__asGroup_members__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base_author__asGroup_members__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__base_author__asGroup_members__base',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__base_author__asGroup_members__base',
+              'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup_members__asPerson
+    extends GBookFragmentData__base_author__asGroup_members__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GBookFragmentData__base_author__asGroup_members__asPerson(
+          [void Function(
+                  GBookFragmentData__base_author__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__asGroup_members__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__base_author__asGroup_members__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GBookFragmentData__base_author__asGroup_members__asPerson rebuild(
+          void Function(
+                  GBookFragmentData__base_author__asGroup_members__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__asPersonBuilder
+      toBuilder() =>
+          GBookFragmentData__base_author__asGroup_members__asPersonBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__base_author__asGroup_members__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__base_author__asGroup_members__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__asGroup_members__asPersonBuilder
+    implements
+        Builder<GBookFragmentData__base_author__asGroup_members__asPerson,
+            GBookFragmentData__base_author__asGroup_members__asPersonBuilder> {
+  _$GBookFragmentData__base_author__asGroup_members__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragmentData__base_author__asGroup_members__asPersonBuilder() {
+    GBookFragmentData__base_author__asGroup_members__asPerson
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__base_author__asGroup_members__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__base_author__asGroup_members__asPerson other) {
+    _$v = other as _$GBookFragmentData__base_author__asGroup_members__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__base_author__asGroup_members__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__asPerson build() => _build();
+
+  _$GBookFragmentData__base_author__asGroup_members__asPerson _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base_author__asGroup_members__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__base_author__asGroup_members__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__base_author__asGroup_members__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GBookFragmentData__base_author__asGroup_members__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GBookFragmentData__base_author__asGroup_members__asPerson',
+              'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__base_author__asGroup_members__asCompany
+    extends GBookFragmentData__base_author__asGroup_members__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GBookFragmentData__base_author__asGroup_members__asCompany(
+          [void Function(
+                  GBookFragmentData__base_author__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GBookFragmentData__base_author__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__base_author__asGroup_members__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GBookFragmentData__base_author__asGroup_members__asCompany rebuild(
+          void Function(
+                  GBookFragmentData__base_author__asGroup_members__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__asCompanyBuilder
+      toBuilder() =>
+          GBookFragmentData__base_author__asGroup_members__asCompanyBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__base_author__asGroup_members__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__base_author__asGroup_members__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GBookFragmentData__base_author__asGroup_members__asCompanyBuilder
+    implements
+        Builder<GBookFragmentData__base_author__asGroup_members__asCompany,
+            GBookFragmentData__base_author__asGroup_members__asCompanyBuilder> {
+  _$GBookFragmentData__base_author__asGroup_members__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragmentData__base_author__asGroup_members__asCompanyBuilder() {
+    GBookFragmentData__base_author__asGroup_members__asCompany
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__base_author__asGroup_members__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__base_author__asGroup_members__asCompany other) {
+    _$v = other as _$GBookFragmentData__base_author__asGroup_members__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__base_author__asGroup_members__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__base_author__asGroup_members__asCompany build() =>
+      _build();
+
+  _$GBookFragmentData__base_author__asGroup_members__asCompany _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__base_author__asGroup_members__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__base_author__asGroup_members__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__base_author__asGroup_members__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name,
+              r'GBookFragmentData__base_author__asGroup_members__asCompany',
+              'name'),
         );
     replace(_$result);
     return _$result;
@@ -4818,6 +8930,576 @@ class GBookFragmentData__asTextbook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(
               name, r'GBookFragmentData__asTextbook_author__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup
+    extends GBookFragmentData__asTextbook_author__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GBookFragmentData__asTextbook_author__asGroup_members>
+      members;
+
+  factory _$GBookFragmentData__asTextbook_author__asGroup(
+          [void Function(GBookFragmentData__asTextbook_author__asGroupBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__asGroupBuilder()..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__asGroup rebuild(
+          void Function(GBookFragmentData__asTextbook_author__asGroupBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroupBuilder toBuilder() =>
+      GBookFragmentData__asTextbook_author__asGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asTextbook_author__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__asGroupBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook_author__asGroup,
+            GBookFragmentData__asTextbook_author__asGroupBuilder> {
+  _$GBookFragmentData__asTextbook_author__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GBookFragmentData__asTextbook_author__asGroup_members>? _members;
+  ListBuilder<GBookFragmentData__asTextbook_author__asGroup_members>
+      get members => _$this._members ??=
+          ListBuilder<GBookFragmentData__asTextbook_author__asGroup_members>();
+  set members(
+          ListBuilder<GBookFragmentData__asTextbook_author__asGroup_members>?
+              members) =>
+      _$this._members = members;
+
+  GBookFragmentData__asTextbook_author__asGroupBuilder() {
+    GBookFragmentData__asTextbook_author__asGroup._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asTextbook_author__asGroup other) {
+    _$v = other as _$GBookFragmentData__asTextbook_author__asGroup;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asTextbook_author__asGroupBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup build() => _build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup _build() {
+    _$GBookFragmentData__asTextbook_author__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GBookFragmentData__asTextbook_author__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GBookFragmentData__asTextbook_author__asGroup',
+                'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(
+                displayName,
+                r'GBookFragmentData__asTextbook_author__asGroup',
+                'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GBookFragmentData__asTextbook_author__asGroup',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup_members__base
+    extends GBookFragmentData__asTextbook_author__asGroup_members__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GBookFragmentData__asTextbook_author__asGroup_members__base(
+          [void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup_members__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__base rebuild(
+          void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder
+      toBuilder() =>
+          GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__asTextbook_author__asGroup_members__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__asGroup_members__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook_author__asGroup_members__base,
+            GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder> {
+  _$GBookFragmentData__asTextbook_author__asGroup_members__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder() {
+    GBookFragmentData__asTextbook_author__asGroup_members__base
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__asTextbook_author__asGroup_members__base other) {
+    _$v =
+        other as _$GBookFragmentData__asTextbook_author__asGroup_members__base;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__asTextbook_author__asGroup_members__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__base build() =>
+      _build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup_members__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asTextbook_author__asGroup_members__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__base',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__base',
+              'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+    extends GBookFragmentData__asTextbook_author__asGroup_members__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson(
+          [void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asPerson rebuild(
+          void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder
+      toBuilder() =>
+          GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__asTextbook_author__asGroup_members__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__asGroup_members__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder
+    implements
+        Builder<GBookFragmentData__asTextbook_author__asGroup_members__asPerson,
+            GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder> {
+  _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder() {
+    GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__asTextbook_author__asGroup_members__asPerson other) {
+    _$v = other
+        as _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__asTextbook_author__asGroup_members__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asPerson build() =>
+      _build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asTextbook_author__asGroup_members__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asPerson',
+              'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+    extends GBookFragmentData__asTextbook_author__asGroup_members__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany(
+          [void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompany rebuild(
+          void Function(
+                  GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder
+      toBuilder() =>
+          GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__asTextbook_author__asGroup_members__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asTextbook_author__asGroup_members__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder
+    implements
+        Builder<
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompany,
+            GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder> {
+  _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder() {
+    GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__asTextbook_author__asGroup_members__asCompany other) {
+    _$v = other
+        as _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__asTextbook_author__asGroup_members__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompany build() =>
+      _build();
+
+  _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asTextbook_author__asGroup_members__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name,
+              r'GBookFragmentData__asTextbook_author__asGroup_members__asCompany',
+              'name'),
         );
     replace(_$result);
     return _$result;
@@ -5351,6 +10033,2006 @@ class GBookFragmentData__asColoringBook_author__asCompanyBuilder
               'displayName'),
           name: BuiltValueNullFieldError.checkNotNull(name,
               r'GBookFragmentData__asColoringBook_author__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup
+    extends GBookFragmentData__asColoringBook_author__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GBookFragmentData__asColoringBook_author__asGroup_members>
+      members;
+
+  factory _$GBookFragmentData__asColoringBook_author__asGroup(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroupBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__asGroupBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup rebuild(
+          void Function(
+                  GBookFragmentData__asColoringBook_author__asGroupBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroupBuilder toBuilder() =>
+      GBookFragmentData__asColoringBook_author__asGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentData__asColoringBook_author__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__asGroupBuilder
+    implements
+        Builder<GBookFragmentData__asColoringBook_author__asGroup,
+            GBookFragmentData__asColoringBook_author__asGroupBuilder> {
+  _$GBookFragmentData__asColoringBook_author__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GBookFragmentData__asColoringBook_author__asGroup_members>?
+      _members;
+  ListBuilder<GBookFragmentData__asColoringBook_author__asGroup_members>
+      get members => _$this._members ??= ListBuilder<
+          GBookFragmentData__asColoringBook_author__asGroup_members>();
+  set members(
+          ListBuilder<
+                  GBookFragmentData__asColoringBook_author__asGroup_members>?
+              members) =>
+      _$this._members = members;
+
+  GBookFragmentData__asColoringBook_author__asGroupBuilder() {
+    GBookFragmentData__asColoringBook_author__asGroup._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBook_author__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GBookFragmentData__asColoringBook_author__asGroup other) {
+    _$v = other as _$GBookFragmentData__asColoringBook_author__asGroup;
+  }
+
+  @override
+  void update(
+      void Function(GBookFragmentData__asColoringBook_author__asGroupBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup build() => _build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup _build() {
+    _$GBookFragmentData__asColoringBook_author__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GBookFragmentData__asColoringBook_author__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename,
+                r'GBookFragmentData__asColoringBook_author__asGroup',
+                'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(
+                displayName,
+                r'GBookFragmentData__asColoringBook_author__asGroup',
+                'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GBookFragmentData__asColoringBook_author__asGroup',
+            _$failedField,
+            e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup_members__base
+    extends GBookFragmentData__asColoringBook_author__asGroup_members__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GBookFragmentData__asColoringBook_author__asGroup_members__base(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__base rebuild(
+          void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder
+      toBuilder() =>
+          GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__asColoringBook_author__asGroup_members__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__asGroup_members__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder
+    implements
+        Builder<GBookFragmentData__asColoringBook_author__asGroup_members__base,
+            GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder> {
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder() {
+    GBookFragmentData__asColoringBook_author__asGroup_members__base
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__asColoringBook_author__asGroup_members__base other) {
+    _$v = other
+        as _$GBookFragmentData__asColoringBook_author__asGroup_members__base;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__asColoringBook_author__asGroup_members__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__base build() =>
+      _build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__base _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asColoringBook_author__asGroup_members__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__base',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__base',
+              'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+    extends GBookFragmentData__asColoringBook_author__asGroup_members__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPerson rebuild(
+          void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder
+      toBuilder() =>
+          GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__asColoringBook_author__asGroup_members__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__asGroup_members__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder
+    implements
+        Builder<
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPerson,
+            GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder> {
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder() {
+    GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+          other) {
+    _$v = other
+        as _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__asColoringBook_author__asGroup_members__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPerson build() =>
+      _build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+      _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asColoringBook_author__asGroup_members__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asPerson',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asPerson',
+              'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asPerson',
+              'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asPerson',
+              'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+    extends GBookFragmentData__asColoringBook_author__asGroup_members__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany(
+          [void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompany rebuild(
+          void Function(
+                  GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder
+      toBuilder() =>
+          GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder()
+            ..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other
+            is GBookFragmentData__asColoringBook_author__asGroup_members__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GBookFragmentData__asColoringBook_author__asGroup_members__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder
+    implements
+        Builder<
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompany,
+            GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder> {
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder() {
+    GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+        ._initializeBuilder(this);
+  }
+
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder
+      get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(
+      GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+          other) {
+    _$v = other
+        as _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(
+              GBookFragmentData__asColoringBook_author__asGroup_members__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+      build() => _build();
+
+  _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+      _build() {
+    final _$result = _$v ??
+        _$GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+            ._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name,
+              r'GBookFragmentData__asColoringBook_author__asGroup_members__asCompany',
+              'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__base extends GAuthorFragmentData__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GAuthorFragmentData__base(
+          [void Function(GAuthorFragmentData__baseBuilder)? updates]) =>
+      (GAuthorFragmentData__baseBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GAuthorFragmentData__base rebuild(
+          void Function(GAuthorFragmentData__baseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__baseBuilder toBuilder() =>
+      GAuthorFragmentData__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__baseBuilder
+    implements
+        Builder<GAuthorFragmentData__base, GAuthorFragmentData__baseBuilder> {
+  _$GAuthorFragmentData__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GAuthorFragmentData__baseBuilder() {
+    GAuthorFragmentData__base._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__base other) {
+    _$v = other as _$GAuthorFragmentData__base;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__base build() => _build();
+
+  _$GAuthorFragmentData__base _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorFragmentData__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorFragmentData__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asPerson extends GAuthorFragmentData__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GAuthorFragmentData__asPerson(
+          [void Function(GAuthorFragmentData__asPersonBuilder)? updates]) =>
+      (GAuthorFragmentData__asPersonBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GAuthorFragmentData__asPerson rebuild(
+          void Function(GAuthorFragmentData__asPersonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asPersonBuilder toBuilder() =>
+      GAuthorFragmentData__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asPersonBuilder
+    implements
+        Builder<GAuthorFragmentData__asPerson,
+            GAuthorFragmentData__asPersonBuilder> {
+  _$GAuthorFragmentData__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GAuthorFragmentData__asPersonBuilder() {
+    GAuthorFragmentData__asPerson._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asPerson other) {
+    _$v = other as _$GAuthorFragmentData__asPerson;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__asPersonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asPerson build() => _build();
+
+  _$GAuthorFragmentData__asPerson _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorFragmentData__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorFragmentData__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName, r'GAuthorFragmentData__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName, r'GAuthorFragmentData__asPerson', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asCompany extends GAuthorFragmentData__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GAuthorFragmentData__asCompany(
+          [void Function(GAuthorFragmentData__asCompanyBuilder)? updates]) =>
+      (GAuthorFragmentData__asCompanyBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GAuthorFragmentData__asCompany rebuild(
+          void Function(GAuthorFragmentData__asCompanyBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asCompanyBuilder toBuilder() =>
+      GAuthorFragmentData__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asCompanyBuilder
+    implements
+        Builder<GAuthorFragmentData__asCompany,
+            GAuthorFragmentData__asCompanyBuilder> {
+  _$GAuthorFragmentData__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GAuthorFragmentData__asCompanyBuilder() {
+    GAuthorFragmentData__asCompany._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asCompany other) {
+    _$v = other as _$GAuthorFragmentData__asCompany;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__asCompanyBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asCompany build() => _build();
+
+  _$GAuthorFragmentData__asCompany _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorFragmentData__asCompany', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorFragmentData__asCompany', 'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GAuthorFragmentData__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asGroup extends GAuthorFragmentData__asGroup {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final BuiltList<GAuthorFragmentData__asGroup_members> members;
+
+  factory _$GAuthorFragmentData__asGroup(
+          [void Function(GAuthorFragmentData__asGroupBuilder)? updates]) =>
+      (GAuthorFragmentData__asGroupBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentData__asGroup._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.members})
+      : super._();
+  @override
+  GAuthorFragmentData__asGroup rebuild(
+          void Function(GAuthorFragmentData__asGroupBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asGroupBuilder toBuilder() =>
+      GAuthorFragmentData__asGroupBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asGroup &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        members == other.members;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, members.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorFragmentData__asGroup')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('members', members))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asGroupBuilder
+    implements
+        Builder<GAuthorFragmentData__asGroup,
+            GAuthorFragmentData__asGroupBuilder> {
+  _$GAuthorFragmentData__asGroup? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  ListBuilder<GAuthorFragmentData__asGroup_members>? _members;
+  ListBuilder<GAuthorFragmentData__asGroup_members> get members =>
+      _$this._members ??= ListBuilder<GAuthorFragmentData__asGroup_members>();
+  set members(ListBuilder<GAuthorFragmentData__asGroup_members>? members) =>
+      _$this._members = members;
+
+  GAuthorFragmentData__asGroupBuilder() {
+    GAuthorFragmentData__asGroup._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asGroupBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _members = $v.members.toBuilder();
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asGroup other) {
+    _$v = other as _$GAuthorFragmentData__asGroup;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentData__asGroupBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asGroup build() => _build();
+
+  _$GAuthorFragmentData__asGroup _build() {
+    _$GAuthorFragmentData__asGroup _$result;
+    try {
+      _$result = _$v ??
+          _$GAuthorFragmentData__asGroup._(
+            G__typename: BuiltValueNullFieldError.checkNotNull(
+                G__typename, r'GAuthorFragmentData__asGroup', 'G__typename'),
+            displayName: BuiltValueNullFieldError.checkNotNull(
+                displayName, r'GAuthorFragmentData__asGroup', 'displayName'),
+            members: members.build(),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'members';
+        members.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GAuthorFragmentData__asGroup', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asGroup_members__base
+    extends GAuthorFragmentData__asGroup_members__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GAuthorFragmentData__asGroup_members__base(
+          [void Function(GAuthorFragmentData__asGroup_members__baseBuilder)?
+              updates]) =>
+      (GAuthorFragmentData__asGroup_members__baseBuilder()..update(updates))
+          ._build();
+
+  _$GAuthorFragmentData__asGroup_members__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GAuthorFragmentData__asGroup_members__base rebuild(
+          void Function(GAuthorFragmentData__asGroup_members__baseBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asGroup_members__baseBuilder toBuilder() =>
+      GAuthorFragmentData__asGroup_members__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asGroup_members__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GAuthorFragmentData__asGroup_members__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asGroup_members__baseBuilder
+    implements
+        Builder<GAuthorFragmentData__asGroup_members__base,
+            GAuthorFragmentData__asGroup_members__baseBuilder> {
+  _$GAuthorFragmentData__asGroup_members__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GAuthorFragmentData__asGroup_members__baseBuilder() {
+    GAuthorFragmentData__asGroup_members__base._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asGroup_members__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asGroup_members__base other) {
+    _$v = other as _$GAuthorFragmentData__asGroup_members__base;
+  }
+
+  @override
+  void update(
+      void Function(GAuthorFragmentData__asGroup_members__baseBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asGroup_members__base build() => _build();
+
+  _$GAuthorFragmentData__asGroup_members__base _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asGroup_members__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GAuthorFragmentData__asGroup_members__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GAuthorFragmentData__asGroup_members__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asGroup_members__asPerson
+    extends GAuthorFragmentData__asGroup_members__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GAuthorFragmentData__asGroup_members__asPerson(
+          [void Function(GAuthorFragmentData__asGroup_members__asPersonBuilder)?
+              updates]) =>
+      (GAuthorFragmentData__asGroup_members__asPersonBuilder()..update(updates))
+          ._build();
+
+  _$GAuthorFragmentData__asGroup_members__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GAuthorFragmentData__asGroup_members__asPerson rebuild(
+          void Function(GAuthorFragmentData__asGroup_members__asPersonBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asGroup_members__asPersonBuilder toBuilder() =>
+      GAuthorFragmentData__asGroup_members__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asGroup_members__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GAuthorFragmentData__asGroup_members__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asGroup_members__asPersonBuilder
+    implements
+        Builder<GAuthorFragmentData__asGroup_members__asPerson,
+            GAuthorFragmentData__asGroup_members__asPersonBuilder> {
+  _$GAuthorFragmentData__asGroup_members__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GAuthorFragmentData__asGroup_members__asPersonBuilder() {
+    GAuthorFragmentData__asGroup_members__asPerson._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asGroup_members__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asGroup_members__asPerson other) {
+    _$v = other as _$GAuthorFragmentData__asGroup_members__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GAuthorFragmentData__asGroup_members__asPersonBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asGroup_members__asPerson build() => _build();
+
+  _$GAuthorFragmentData__asGroup_members__asPerson _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asGroup_members__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GAuthorFragmentData__asGroup_members__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GAuthorFragmentData__asGroup_members__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(firstName,
+              r'GAuthorFragmentData__asGroup_members__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(lastName,
+              r'GAuthorFragmentData__asGroup_members__asPerson', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentData__asGroup_members__asCompany
+    extends GAuthorFragmentData__asGroup_members__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GAuthorFragmentData__asGroup_members__asCompany(
+          [void Function(
+                  GAuthorFragmentData__asGroup_members__asCompanyBuilder)?
+              updates]) =>
+      (GAuthorFragmentData__asGroup_members__asCompanyBuilder()
+            ..update(updates))
+          ._build();
+
+  _$GAuthorFragmentData__asGroup_members__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GAuthorFragmentData__asGroup_members__asCompany rebuild(
+          void Function(GAuthorFragmentData__asGroup_members__asCompanyBuilder)
+              updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentData__asGroup_members__asCompanyBuilder toBuilder() =>
+      GAuthorFragmentData__asGroup_members__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentData__asGroup_members__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(
+            r'GAuthorFragmentData__asGroup_members__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GAuthorFragmentData__asGroup_members__asCompanyBuilder
+    implements
+        Builder<GAuthorFragmentData__asGroup_members__asCompany,
+            GAuthorFragmentData__asGroup_members__asCompanyBuilder> {
+  _$GAuthorFragmentData__asGroup_members__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GAuthorFragmentData__asGroup_members__asCompanyBuilder() {
+    GAuthorFragmentData__asGroup_members__asCompany._initializeBuilder(this);
+  }
+
+  GAuthorFragmentData__asGroup_members__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorFragmentData__asGroup_members__asCompany other) {
+    _$v = other as _$GAuthorFragmentData__asGroup_members__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GAuthorFragmentData__asGroup_members__asCompanyBuilder)?
+          updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentData__asGroup_members__asCompany build() => _build();
+
+  _$GAuthorFragmentData__asGroup_members__asCompany _build() {
+    final _$result = _$v ??
+        _$GAuthorFragmentData__asGroup_members__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename,
+              r'GAuthorFragmentData__asGroup_members__asCompany',
+              'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName,
+              r'GAuthorFragmentData__asGroup_members__asCompany',
+              'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GAuthorFragmentData__asGroup_members__asCompany', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorPersonFragmentData extends GAuthorPersonFragmentData {
+  @override
+  final String G__typename;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GAuthorPersonFragmentData(
+          [void Function(GAuthorPersonFragmentDataBuilder)? updates]) =>
+      (GAuthorPersonFragmentDataBuilder()..update(updates))._build();
+
+  _$GAuthorPersonFragmentData._(
+      {required this.G__typename,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GAuthorPersonFragmentData rebuild(
+          void Function(GAuthorPersonFragmentDataBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorPersonFragmentDataBuilder toBuilder() =>
+      GAuthorPersonFragmentDataBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorPersonFragmentData &&
+        G__typename == other.G__typename &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorPersonFragmentData')
+          ..add('G__typename', G__typename)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GAuthorPersonFragmentDataBuilder
+    implements
+        Builder<GAuthorPersonFragmentData, GAuthorPersonFragmentDataBuilder> {
+  _$GAuthorPersonFragmentData? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GAuthorPersonFragmentDataBuilder() {
+    GAuthorPersonFragmentData._initializeBuilder(this);
+  }
+
+  GAuthorPersonFragmentDataBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorPersonFragmentData other) {
+    _$v = other as _$GAuthorPersonFragmentData;
+  }
+
+  @override
+  void update(void Function(GAuthorPersonFragmentDataBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorPersonFragmentData build() => _build();
+
+  _$GAuthorPersonFragmentData _build() {
+    final _$result = _$v ??
+        _$GAuthorPersonFragmentData._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorPersonFragmentData', 'G__typename'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName, r'GAuthorPersonFragmentData', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName, r'GAuthorPersonFragmentData', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorCompanyFragmentData extends GAuthorCompanyFragmentData {
+  @override
+  final String G__typename;
+  @override
+  final String name;
+
+  factory _$GAuthorCompanyFragmentData(
+          [void Function(GAuthorCompanyFragmentDataBuilder)? updates]) =>
+      (GAuthorCompanyFragmentDataBuilder()..update(updates))._build();
+
+  _$GAuthorCompanyFragmentData._(
+      {required this.G__typename, required this.name})
+      : super._();
+  @override
+  GAuthorCompanyFragmentData rebuild(
+          void Function(GAuthorCompanyFragmentDataBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorCompanyFragmentDataBuilder toBuilder() =>
+      GAuthorCompanyFragmentDataBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorCompanyFragmentData &&
+        G__typename == other.G__typename &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorCompanyFragmentData')
+          ..add('G__typename', G__typename)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GAuthorCompanyFragmentDataBuilder
+    implements
+        Builder<GAuthorCompanyFragmentData, GAuthorCompanyFragmentDataBuilder> {
+  _$GAuthorCompanyFragmentData? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GAuthorCompanyFragmentDataBuilder() {
+    GAuthorCompanyFragmentData._initializeBuilder(this);
+  }
+
+  GAuthorCompanyFragmentDataBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorCompanyFragmentData other) {
+    _$v = other as _$GAuthorCompanyFragmentData;
+  }
+
+  @override
+  void update(void Function(GAuthorCompanyFragmentDataBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorCompanyFragmentData build() => _build();
+
+  _$GAuthorCompanyFragmentData _build() {
+    final _$result = _$v ??
+        _$GAuthorCompanyFragmentData._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorCompanyFragmentData', 'G__typename'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GAuthorCompanyFragmentData', 'name'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorGroupFragmentData__base extends GAuthorGroupFragmentData__base {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+
+  factory _$GAuthorGroupFragmentData__base(
+          [void Function(GAuthorGroupFragmentData__baseBuilder)? updates]) =>
+      (GAuthorGroupFragmentData__baseBuilder()..update(updates))._build();
+
+  _$GAuthorGroupFragmentData__base._(
+      {required this.G__typename, required this.displayName})
+      : super._();
+  @override
+  GAuthorGroupFragmentData__base rebuild(
+          void Function(GAuthorGroupFragmentData__baseBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorGroupFragmentData__baseBuilder toBuilder() =>
+      GAuthorGroupFragmentData__baseBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorGroupFragmentData__base &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorGroupFragmentData__base')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName))
+        .toString();
+  }
+}
+
+class GAuthorGroupFragmentData__baseBuilder
+    implements
+        Builder<GAuthorGroupFragmentData__base,
+            GAuthorGroupFragmentData__baseBuilder> {
+  _$GAuthorGroupFragmentData__base? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  GAuthorGroupFragmentData__baseBuilder() {
+    GAuthorGroupFragmentData__base._initializeBuilder(this);
+  }
+
+  GAuthorGroupFragmentData__baseBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorGroupFragmentData__base other) {
+    _$v = other as _$GAuthorGroupFragmentData__base;
+  }
+
+  @override
+  void update(void Function(GAuthorGroupFragmentData__baseBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorGroupFragmentData__base build() => _build();
+
+  _$GAuthorGroupFragmentData__base _build() {
+    final _$result = _$v ??
+        _$GAuthorGroupFragmentData__base._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(
+              G__typename, r'GAuthorGroupFragmentData__base', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(
+              displayName, r'GAuthorGroupFragmentData__base', 'displayName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorGroupFragmentData__asPerson
+    extends GAuthorGroupFragmentData__asPerson {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String firstName;
+  @override
+  final String lastName;
+
+  factory _$GAuthorGroupFragmentData__asPerson(
+          [void Function(GAuthorGroupFragmentData__asPersonBuilder)?
+              updates]) =>
+      (GAuthorGroupFragmentData__asPersonBuilder()..update(updates))._build();
+
+  _$GAuthorGroupFragmentData__asPerson._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.firstName,
+      required this.lastName})
+      : super._();
+  @override
+  GAuthorGroupFragmentData__asPerson rebuild(
+          void Function(GAuthorGroupFragmentData__asPersonBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorGroupFragmentData__asPersonBuilder toBuilder() =>
+      GAuthorGroupFragmentData__asPersonBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorGroupFragmentData__asPerson &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        firstName == other.firstName &&
+        lastName == other.lastName;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, firstName.hashCode);
+    _$hash = $jc(_$hash, lastName.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorGroupFragmentData__asPerson')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('firstName', firstName)
+          ..add('lastName', lastName))
+        .toString();
+  }
+}
+
+class GAuthorGroupFragmentData__asPersonBuilder
+    implements
+        Builder<GAuthorGroupFragmentData__asPerson,
+            GAuthorGroupFragmentData__asPersonBuilder> {
+  _$GAuthorGroupFragmentData__asPerson? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _firstName;
+  String? get firstName => _$this._firstName;
+  set firstName(String? firstName) => _$this._firstName = firstName;
+
+  String? _lastName;
+  String? get lastName => _$this._lastName;
+  set lastName(String? lastName) => _$this._lastName = lastName;
+
+  GAuthorGroupFragmentData__asPersonBuilder() {
+    GAuthorGroupFragmentData__asPerson._initializeBuilder(this);
+  }
+
+  GAuthorGroupFragmentData__asPersonBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _firstName = $v.firstName;
+      _lastName = $v.lastName;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorGroupFragmentData__asPerson other) {
+    _$v = other as _$GAuthorGroupFragmentData__asPerson;
+  }
+
+  @override
+  void update(
+      void Function(GAuthorGroupFragmentData__asPersonBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorGroupFragmentData__asPerson build() => _build();
+
+  _$GAuthorGroupFragmentData__asPerson _build() {
+    final _$result = _$v ??
+        _$GAuthorGroupFragmentData__asPerson._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GAuthorGroupFragmentData__asPerson', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GAuthorGroupFragmentData__asPerson', 'displayName'),
+          firstName: BuiltValueNullFieldError.checkNotNull(
+              firstName, r'GAuthorGroupFragmentData__asPerson', 'firstName'),
+          lastName: BuiltValueNullFieldError.checkNotNull(
+              lastName, r'GAuthorGroupFragmentData__asPerson', 'lastName'),
+        );
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorGroupFragmentData__asCompany
+    extends GAuthorGroupFragmentData__asCompany {
+  @override
+  final String G__typename;
+  @override
+  final String displayName;
+  @override
+  final String name;
+
+  factory _$GAuthorGroupFragmentData__asCompany(
+          [void Function(GAuthorGroupFragmentData__asCompanyBuilder)?
+              updates]) =>
+      (GAuthorGroupFragmentData__asCompanyBuilder()..update(updates))._build();
+
+  _$GAuthorGroupFragmentData__asCompany._(
+      {required this.G__typename,
+      required this.displayName,
+      required this.name})
+      : super._();
+  @override
+  GAuthorGroupFragmentData__asCompany rebuild(
+          void Function(GAuthorGroupFragmentData__asCompanyBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorGroupFragmentData__asCompanyBuilder toBuilder() =>
+      GAuthorGroupFragmentData__asCompanyBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorGroupFragmentData__asCompany &&
+        G__typename == other.G__typename &&
+        displayName == other.displayName &&
+        name == other.name;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, displayName.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GAuthorGroupFragmentData__asCompany')
+          ..add('G__typename', G__typename)
+          ..add('displayName', displayName)
+          ..add('name', name))
+        .toString();
+  }
+}
+
+class GAuthorGroupFragmentData__asCompanyBuilder
+    implements
+        Builder<GAuthorGroupFragmentData__asCompany,
+            GAuthorGroupFragmentData__asCompanyBuilder> {
+  _$GAuthorGroupFragmentData__asCompany? _$v;
+
+  String? _G__typename;
+  String? get G__typename => _$this._G__typename;
+  set G__typename(String? G__typename) => _$this._G__typename = G__typename;
+
+  String? _displayName;
+  String? get displayName => _$this._displayName;
+  set displayName(String? displayName) => _$this._displayName = displayName;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  GAuthorGroupFragmentData__asCompanyBuilder() {
+    GAuthorGroupFragmentData__asCompany._initializeBuilder(this);
+  }
+
+  GAuthorGroupFragmentData__asCompanyBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _G__typename = $v.G__typename;
+      _displayName = $v.displayName;
+      _name = $v.name;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GAuthorGroupFragmentData__asCompany other) {
+    _$v = other as _$GAuthorGroupFragmentData__asCompany;
+  }
+
+  @override
+  void update(
+      void Function(GAuthorGroupFragmentData__asCompanyBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorGroupFragmentData__asCompany build() => _build();
+
+  _$GAuthorGroupFragmentData__asCompany _build() {
+    final _$result = _$v ??
+        _$GAuthorGroupFragmentData__asCompany._(
+          G__typename: BuiltValueNullFieldError.checkNotNull(G__typename,
+              r'GAuthorGroupFragmentData__asCompany', 'G__typename'),
+          displayName: BuiltValueNullFieldError.checkNotNull(displayName,
+              r'GAuthorGroupFragmentData__asCompany', 'displayName'),
+          name: BuiltValueNullFieldError.checkNotNull(
+              name, r'GAuthorGroupFragmentData__asCompany', 'name'),
         );
     replace(_$result);
     return _$result;

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.req.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.req.gql.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.ast.gql.dart'
+    as _i2;
+import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.var.gql.dart'
+    as _i3;
+import 'package:end_to_end_test/graphql/__generated__/serializers.gql.dart'
+    as _i4;
+import 'package:gql_exec/gql_exec.dart' as _i1;
+
+part 'nested_fragments_on_interface.req.gql.g.dart';
+
+abstract class GGetBooks implements Built<GGetBooks, GGetBooksBuilder> {
+  GGetBooks._();
+
+  factory GGetBooks([void Function(GGetBooksBuilder b) updates]) = _$GGetBooks;
+
+  static void _initializeBuilder(GGetBooksBuilder b) => b
+    ..operation = _i1.Operation(
+      document: _i2.document,
+      operationName: 'GetBooks',
+    );
+
+  _i3.GGetBooksVars get vars;
+  _i1.Operation get operation;
+  static Serializer<GGetBooks> get serializer => _$gGetBooksSerializer;
+
+  Map<String, dynamic> toJson() => (_i4.serializers.serializeWith(
+        GGetBooks.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooks? fromJson(Map<String, dynamic> json) =>
+      _i4.serializers.deserializeWith(
+        GGetBooks.serializer,
+        json,
+      );
+}

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.req.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.req.gql.g.dart
@@ -1,0 +1,166 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nested_fragments_on_interface.req.gql.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GGetBooks> _$gGetBooksSerializer = _$GGetBooksSerializer();
+
+class _$GGetBooksSerializer implements StructuredSerializer<GGetBooks> {
+  @override
+  final Iterable<Type> types = const [GGetBooks, _$GGetBooks];
+  @override
+  final String wireName = 'GGetBooks';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GGetBooks object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'vars',
+      serializers.serialize(object.vars,
+          specifiedType: const FullType(_i3.GGetBooksVars)),
+      'operation',
+      serializers.serialize(object.operation,
+          specifiedType: const FullType(_i1.Operation)),
+    ];
+
+    return result;
+  }
+
+  @override
+  GGetBooks deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = GGetBooksBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'vars':
+          result.vars.replace(serializers.deserialize(value,
+                  specifiedType: const FullType(_i3.GGetBooksVars))!
+              as _i3.GGetBooksVars);
+          break;
+        case 'operation':
+          result.operation = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.Operation))! as _i1.Operation;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$GGetBooks extends GGetBooks {
+  @override
+  final _i3.GGetBooksVars vars;
+  @override
+  final _i1.Operation operation;
+
+  factory _$GGetBooks([void Function(GGetBooksBuilder)? updates]) =>
+      (GGetBooksBuilder()..update(updates))._build();
+
+  _$GGetBooks._({required this.vars, required this.operation}) : super._();
+  @override
+  GGetBooks rebuild(void Function(GGetBooksBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksBuilder toBuilder() => GGetBooksBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooks &&
+        vars == other.vars &&
+        operation == other.operation;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'GGetBooks')
+          ..add('vars', vars)
+          ..add('operation', operation))
+        .toString();
+  }
+}
+
+class GGetBooksBuilder implements Builder<GGetBooks, GGetBooksBuilder> {
+  _$GGetBooks? _$v;
+
+  _i3.GGetBooksVarsBuilder? _vars;
+  _i3.GGetBooksVarsBuilder get vars =>
+      _$this._vars ??= _i3.GGetBooksVarsBuilder();
+  set vars(_i3.GGetBooksVarsBuilder? vars) => _$this._vars = vars;
+
+  _i1.Operation? _operation;
+  _i1.Operation? get operation => _$this._operation;
+  set operation(_i1.Operation? operation) => _$this._operation = operation;
+
+  GGetBooksBuilder() {
+    GGetBooks._initializeBuilder(this);
+  }
+
+  GGetBooksBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _vars = $v.vars.toBuilder();
+      _operation = $v.operation;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(GGetBooks other) {
+    _$v = other as _$GGetBooks;
+  }
+
+  @override
+  void update(void Function(GGetBooksBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooks build() => _build();
+
+  _$GGetBooks _build() {
+    _$GGetBooks _$result;
+    try {
+      _$result = _$v ??
+          _$GGetBooks._(
+            vars: vars.build(),
+            operation: BuiltValueNullFieldError.checkNotNull(
+                operation, r'GGetBooks', 'operation'),
+          );
+    } catch (_) {
+      late String _$failedField;
+      try {
+        _$failedField = 'vars';
+        vars.build();
+      } catch (e) {
+        throw BuiltValueNestedFieldError(
+            r'GGetBooks', _$failedField, e.toString());
+      }
+      rethrow;
+    }
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.dart
@@ -1,0 +1,83 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+import 'package:end_to_end_test/graphql/__generated__/serializers.gql.dart'
+    as _i1;
+
+part 'nested_fragments_on_interface.var.gql.g.dart';
+
+abstract class GGetBooksVars
+    implements Built<GGetBooksVars, GGetBooksVarsBuilder> {
+  GGetBooksVars._();
+
+  factory GGetBooksVars([void Function(GGetBooksVarsBuilder b) updates]) =
+      _$GGetBooksVars;
+
+  factory GGetBooksVars.create() => GGetBooksVars();
+
+  static Serializer<GGetBooksVars> get serializer => _$gGetBooksVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GGetBooksVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GGetBooksVars? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GGetBooksVars.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorFragmentVars
+    implements Built<GAuthorFragmentVars, GAuthorFragmentVarsBuilder> {
+  GAuthorFragmentVars._();
+
+  factory GAuthorFragmentVars(
+          [void Function(GAuthorFragmentVarsBuilder b) updates]) =
+      _$GAuthorFragmentVars;
+
+  factory GAuthorFragmentVars.create() => GAuthorFragmentVars();
+
+  static Serializer<GAuthorFragmentVars> get serializer =>
+      _$gAuthorFragmentVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorFragmentVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorFragmentVars? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorFragmentVars.serializer,
+        json,
+      );
+}
+
+abstract class GBookFragmentVars
+    implements Built<GBookFragmentVars, GBookFragmentVarsBuilder> {
+  GBookFragmentVars._();
+
+  factory GBookFragmentVars(
+          [void Function(GBookFragmentVarsBuilder b) updates]) =
+      _$GBookFragmentVars;
+
+  factory GBookFragmentVars.create() => GBookFragmentVars();
+
+  static Serializer<GBookFragmentVars> get serializer =>
+      _$gBookFragmentVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentVars? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentVars.serializer,
+        json,
+      );
+}

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.dart
@@ -32,6 +32,31 @@ abstract class GGetBooksVars
       );
 }
 
+abstract class GBookFragmentVars
+    implements Built<GBookFragmentVars, GBookFragmentVarsBuilder> {
+  GBookFragmentVars._();
+
+  factory GBookFragmentVars(
+          [void Function(GBookFragmentVarsBuilder b) updates]) =
+      _$GBookFragmentVars;
+
+  factory GBookFragmentVars.create() => GBookFragmentVars();
+
+  static Serializer<GBookFragmentVars> get serializer =>
+      _$gBookFragmentVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GBookFragmentVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GBookFragmentVars? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GBookFragmentVars.serializer,
+        json,
+      );
+}
+
 abstract class GAuthorFragmentVars
     implements Built<GAuthorFragmentVars, GAuthorFragmentVarsBuilder> {
   GAuthorFragmentVars._();
@@ -57,27 +82,80 @@ abstract class GAuthorFragmentVars
       );
 }
 
-abstract class GBookFragmentVars
-    implements Built<GBookFragmentVars, GBookFragmentVarsBuilder> {
-  GBookFragmentVars._();
+abstract class GAuthorPersonFragmentVars
+    implements
+        Built<GAuthorPersonFragmentVars, GAuthorPersonFragmentVarsBuilder> {
+  GAuthorPersonFragmentVars._();
 
-  factory GBookFragmentVars(
-          [void Function(GBookFragmentVarsBuilder b) updates]) =
-      _$GBookFragmentVars;
+  factory GAuthorPersonFragmentVars(
+          [void Function(GAuthorPersonFragmentVarsBuilder b) updates]) =
+      _$GAuthorPersonFragmentVars;
 
-  factory GBookFragmentVars.create() => GBookFragmentVars();
+  factory GAuthorPersonFragmentVars.create() => GAuthorPersonFragmentVars();
 
-  static Serializer<GBookFragmentVars> get serializer =>
-      _$gBookFragmentVarsSerializer;
+  static Serializer<GAuthorPersonFragmentVars> get serializer =>
+      _$gAuthorPersonFragmentVarsSerializer;
 
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
-        GBookFragmentVars.serializer,
+        GAuthorPersonFragmentVars.serializer,
         this,
       ) as Map<String, dynamic>);
 
-  static GBookFragmentVars? fromJson(Map<String, dynamic> json) =>
+  static GAuthorPersonFragmentVars? fromJson(Map<String, dynamic> json) =>
       _i1.serializers.deserializeWith(
-        GBookFragmentVars.serializer,
+        GAuthorPersonFragmentVars.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorCompanyFragmentVars
+    implements
+        Built<GAuthorCompanyFragmentVars, GAuthorCompanyFragmentVarsBuilder> {
+  GAuthorCompanyFragmentVars._();
+
+  factory GAuthorCompanyFragmentVars(
+          [void Function(GAuthorCompanyFragmentVarsBuilder b) updates]) =
+      _$GAuthorCompanyFragmentVars;
+
+  factory GAuthorCompanyFragmentVars.create() => GAuthorCompanyFragmentVars();
+
+  static Serializer<GAuthorCompanyFragmentVars> get serializer =>
+      _$gAuthorCompanyFragmentVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorCompanyFragmentVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorCompanyFragmentVars? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorCompanyFragmentVars.serializer,
+        json,
+      );
+}
+
+abstract class GAuthorGroupFragmentVars
+    implements
+        Built<GAuthorGroupFragmentVars, GAuthorGroupFragmentVarsBuilder> {
+  GAuthorGroupFragmentVars._();
+
+  factory GAuthorGroupFragmentVars(
+          [void Function(GAuthorGroupFragmentVarsBuilder b) updates]) =
+      _$GAuthorGroupFragmentVars;
+
+  factory GAuthorGroupFragmentVars.create() => GAuthorGroupFragmentVars();
+
+  static Serializer<GAuthorGroupFragmentVars> get serializer =>
+      _$gAuthorGroupFragmentVarsSerializer;
+
+  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+        GAuthorGroupFragmentVars.serializer,
+        this,
+      ) as Map<String, dynamic>);
+
+  static GAuthorGroupFragmentVars? fromJson(Map<String, dynamic> json) =>
+      _i1.serializers.deserializeWith(
+        GAuthorGroupFragmentVars.serializer,
         json,
       );
 }

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.g.dart
@@ -8,10 +8,16 @@ part of 'nested_fragments_on_interface.var.gql.dart';
 
 Serializer<GGetBooksVars> _$gGetBooksVarsSerializer =
     _$GGetBooksVarsSerializer();
-Serializer<GAuthorFragmentVars> _$gAuthorFragmentVarsSerializer =
-    _$GAuthorFragmentVarsSerializer();
 Serializer<GBookFragmentVars> _$gBookFragmentVarsSerializer =
     _$GBookFragmentVarsSerializer();
+Serializer<GAuthorFragmentVars> _$gAuthorFragmentVarsSerializer =
+    _$GAuthorFragmentVarsSerializer();
+Serializer<GAuthorPersonFragmentVars> _$gAuthorPersonFragmentVarsSerializer =
+    _$GAuthorPersonFragmentVarsSerializer();
+Serializer<GAuthorCompanyFragmentVars> _$gAuthorCompanyFragmentVarsSerializer =
+    _$GAuthorCompanyFragmentVarsSerializer();
+Serializer<GAuthorGroupFragmentVars> _$gAuthorGroupFragmentVarsSerializer =
+    _$GAuthorGroupFragmentVarsSerializer();
 
 class _$GGetBooksVarsSerializer implements StructuredSerializer<GGetBooksVars> {
   @override
@@ -30,6 +36,27 @@ class _$GGetBooksVarsSerializer implements StructuredSerializer<GGetBooksVars> {
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
     return GGetBooksVarsBuilder().build();
+  }
+}
+
+class _$GBookFragmentVarsSerializer
+    implements StructuredSerializer<GBookFragmentVars> {
+  @override
+  final Iterable<Type> types = const [GBookFragmentVars, _$GBookFragmentVars];
+  @override
+  final String wireName = 'GBookFragmentVars';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GBookFragmentVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  GBookFragmentVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return GBookFragmentVarsBuilder().build();
   }
 }
 
@@ -58,24 +85,78 @@ class _$GAuthorFragmentVarsSerializer
   }
 }
 
-class _$GBookFragmentVarsSerializer
-    implements StructuredSerializer<GBookFragmentVars> {
+class _$GAuthorPersonFragmentVarsSerializer
+    implements StructuredSerializer<GAuthorPersonFragmentVars> {
   @override
-  final Iterable<Type> types = const [GBookFragmentVars, _$GBookFragmentVars];
+  final Iterable<Type> types = const [
+    GAuthorPersonFragmentVars,
+    _$GAuthorPersonFragmentVars
+  ];
   @override
-  final String wireName = 'GBookFragmentVars';
+  final String wireName = 'GAuthorPersonFragmentVars';
 
   @override
-  Iterable<Object?> serialize(Serializers serializers, GBookFragmentVars object,
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorPersonFragmentVars object,
       {FullType specifiedType = FullType.unspecified}) {
     return <Object?>[];
   }
 
   @override
-  GBookFragmentVars deserialize(
+  GAuthorPersonFragmentVars deserialize(
       Serializers serializers, Iterable<Object?> serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    return GBookFragmentVarsBuilder().build();
+    return GAuthorPersonFragmentVarsBuilder().build();
+  }
+}
+
+class _$GAuthorCompanyFragmentVarsSerializer
+    implements StructuredSerializer<GAuthorCompanyFragmentVars> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorCompanyFragmentVars,
+    _$GAuthorCompanyFragmentVars
+  ];
+  @override
+  final String wireName = 'GAuthorCompanyFragmentVars';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorCompanyFragmentVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  GAuthorCompanyFragmentVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return GAuthorCompanyFragmentVarsBuilder().build();
+  }
+}
+
+class _$GAuthorGroupFragmentVarsSerializer
+    implements StructuredSerializer<GAuthorGroupFragmentVars> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorGroupFragmentVars,
+    _$GAuthorGroupFragmentVars
+  ];
+  @override
+  final String wireName = 'GAuthorGroupFragmentVars';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorGroupFragmentVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  GAuthorGroupFragmentVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return GAuthorGroupFragmentVarsBuilder().build();
   }
 }
 
@@ -129,6 +210,63 @@ class GGetBooksVarsBuilder
 
   _$GGetBooksVars _build() {
     final _$result = _$v ?? _$GGetBooksVars._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentVars extends GBookFragmentVars {
+  factory _$GBookFragmentVars(
+          [void Function(GBookFragmentVarsBuilder)? updates]) =>
+      (GBookFragmentVarsBuilder()..update(updates))._build();
+
+  _$GBookFragmentVars._() : super._();
+  @override
+  GBookFragmentVars rebuild(void Function(GBookFragmentVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentVarsBuilder toBuilder() =>
+      GBookFragmentVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentVars;
+  }
+
+  @override
+  int get hashCode {
+    return 845341956;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'GBookFragmentVars').toString();
+  }
+}
+
+class GBookFragmentVarsBuilder
+    implements Builder<GBookFragmentVars, GBookFragmentVarsBuilder> {
+  _$GBookFragmentVars? _$v;
+
+  GBookFragmentVarsBuilder();
+
+  @override
+  void replace(GBookFragmentVars other) {
+    _$v = other as _$GBookFragmentVars;
+  }
+
+  @override
+  void update(void Function(GBookFragmentVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentVars build() => _build();
+
+  _$GBookFragmentVars _build() {
+    final _$result = _$v ?? _$GBookFragmentVars._();
     replace(_$result);
     return _$result;
   }
@@ -192,58 +330,179 @@ class GAuthorFragmentVarsBuilder
   }
 }
 
-class _$GBookFragmentVars extends GBookFragmentVars {
-  factory _$GBookFragmentVars(
-          [void Function(GBookFragmentVarsBuilder)? updates]) =>
-      (GBookFragmentVarsBuilder()..update(updates))._build();
+class _$GAuthorPersonFragmentVars extends GAuthorPersonFragmentVars {
+  factory _$GAuthorPersonFragmentVars(
+          [void Function(GAuthorPersonFragmentVarsBuilder)? updates]) =>
+      (GAuthorPersonFragmentVarsBuilder()..update(updates))._build();
 
-  _$GBookFragmentVars._() : super._();
+  _$GAuthorPersonFragmentVars._() : super._();
   @override
-  GBookFragmentVars rebuild(void Function(GBookFragmentVarsBuilder) updates) =>
+  GAuthorPersonFragmentVars rebuild(
+          void Function(GAuthorPersonFragmentVarsBuilder) updates) =>
       (toBuilder()..update(updates)).build();
 
   @override
-  GBookFragmentVarsBuilder toBuilder() =>
-      GBookFragmentVarsBuilder()..replace(this);
+  GAuthorPersonFragmentVarsBuilder toBuilder() =>
+      GAuthorPersonFragmentVarsBuilder()..replace(this);
 
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is GBookFragmentVars;
+    return other is GAuthorPersonFragmentVars;
   }
 
   @override
   int get hashCode {
-    return 845341956;
+    return 635985902;
   }
 
   @override
   String toString() {
-    return newBuiltValueToStringHelper(r'GBookFragmentVars').toString();
+    return newBuiltValueToStringHelper(r'GAuthorPersonFragmentVars').toString();
   }
 }
 
-class GBookFragmentVarsBuilder
-    implements Builder<GBookFragmentVars, GBookFragmentVarsBuilder> {
-  _$GBookFragmentVars? _$v;
+class GAuthorPersonFragmentVarsBuilder
+    implements
+        Builder<GAuthorPersonFragmentVars, GAuthorPersonFragmentVarsBuilder> {
+  _$GAuthorPersonFragmentVars? _$v;
 
-  GBookFragmentVarsBuilder();
+  GAuthorPersonFragmentVarsBuilder();
 
   @override
-  void replace(GBookFragmentVars other) {
-    _$v = other as _$GBookFragmentVars;
+  void replace(GAuthorPersonFragmentVars other) {
+    _$v = other as _$GAuthorPersonFragmentVars;
   }
 
   @override
-  void update(void Function(GBookFragmentVarsBuilder)? updates) {
+  void update(void Function(GAuthorPersonFragmentVarsBuilder)? updates) {
     if (updates != null) updates(this);
   }
 
   @override
-  GBookFragmentVars build() => _build();
+  GAuthorPersonFragmentVars build() => _build();
 
-  _$GBookFragmentVars _build() {
-    final _$result = _$v ?? _$GBookFragmentVars._();
+  _$GAuthorPersonFragmentVars _build() {
+    final _$result = _$v ?? _$GAuthorPersonFragmentVars._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorCompanyFragmentVars extends GAuthorCompanyFragmentVars {
+  factory _$GAuthorCompanyFragmentVars(
+          [void Function(GAuthorCompanyFragmentVarsBuilder)? updates]) =>
+      (GAuthorCompanyFragmentVarsBuilder()..update(updates))._build();
+
+  _$GAuthorCompanyFragmentVars._() : super._();
+  @override
+  GAuthorCompanyFragmentVars rebuild(
+          void Function(GAuthorCompanyFragmentVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorCompanyFragmentVarsBuilder toBuilder() =>
+      GAuthorCompanyFragmentVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorCompanyFragmentVars;
+  }
+
+  @override
+  int get hashCode {
+    return 111580029;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'GAuthorCompanyFragmentVars')
+        .toString();
+  }
+}
+
+class GAuthorCompanyFragmentVarsBuilder
+    implements
+        Builder<GAuthorCompanyFragmentVars, GAuthorCompanyFragmentVarsBuilder> {
+  _$GAuthorCompanyFragmentVars? _$v;
+
+  GAuthorCompanyFragmentVarsBuilder();
+
+  @override
+  void replace(GAuthorCompanyFragmentVars other) {
+    _$v = other as _$GAuthorCompanyFragmentVars;
+  }
+
+  @override
+  void update(void Function(GAuthorCompanyFragmentVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorCompanyFragmentVars build() => _build();
+
+  _$GAuthorCompanyFragmentVars _build() {
+    final _$result = _$v ?? _$GAuthorCompanyFragmentVars._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorGroupFragmentVars extends GAuthorGroupFragmentVars {
+  factory _$GAuthorGroupFragmentVars(
+          [void Function(GAuthorGroupFragmentVarsBuilder)? updates]) =>
+      (GAuthorGroupFragmentVarsBuilder()..update(updates))._build();
+
+  _$GAuthorGroupFragmentVars._() : super._();
+  @override
+  GAuthorGroupFragmentVars rebuild(
+          void Function(GAuthorGroupFragmentVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorGroupFragmentVarsBuilder toBuilder() =>
+      GAuthorGroupFragmentVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorGroupFragmentVars;
+  }
+
+  @override
+  int get hashCode {
+    return 565461358;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'GAuthorGroupFragmentVars').toString();
+  }
+}
+
+class GAuthorGroupFragmentVarsBuilder
+    implements
+        Builder<GAuthorGroupFragmentVars, GAuthorGroupFragmentVarsBuilder> {
+  _$GAuthorGroupFragmentVars? _$v;
+
+  GAuthorGroupFragmentVarsBuilder();
+
+  @override
+  void replace(GAuthorGroupFragmentVars other) {
+    _$v = other as _$GAuthorGroupFragmentVars;
+  }
+
+  @override
+  void update(void Function(GAuthorGroupFragmentVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorGroupFragmentVars build() => _build();
+
+  _$GAuthorGroupFragmentVars _build() {
+    final _$result = _$v ?? _$GAuthorGroupFragmentVars._();
     replace(_$result);
     return _$result;
   }

--- a/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.g.dart
+++ b/codegen/end_to_end_test/lib/fragments/__generated__/nested_fragments_on_interface.var.gql.g.dart
@@ -1,0 +1,252 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nested_fragments_on_interface.var.gql.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<GGetBooksVars> _$gGetBooksVarsSerializer =
+    _$GGetBooksVarsSerializer();
+Serializer<GAuthorFragmentVars> _$gAuthorFragmentVarsSerializer =
+    _$GAuthorFragmentVarsSerializer();
+Serializer<GBookFragmentVars> _$gBookFragmentVarsSerializer =
+    _$GBookFragmentVarsSerializer();
+
+class _$GGetBooksVarsSerializer implements StructuredSerializer<GGetBooksVars> {
+  @override
+  final Iterable<Type> types = const [GGetBooksVars, _$GGetBooksVars];
+  @override
+  final String wireName = 'GGetBooksVars';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GGetBooksVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  GGetBooksVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return GGetBooksVarsBuilder().build();
+  }
+}
+
+class _$GAuthorFragmentVarsSerializer
+    implements StructuredSerializer<GAuthorFragmentVars> {
+  @override
+  final Iterable<Type> types = const [
+    GAuthorFragmentVars,
+    _$GAuthorFragmentVars
+  ];
+  @override
+  final String wireName = 'GAuthorFragmentVars';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, GAuthorFragmentVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  GAuthorFragmentVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return GAuthorFragmentVarsBuilder().build();
+  }
+}
+
+class _$GBookFragmentVarsSerializer
+    implements StructuredSerializer<GBookFragmentVars> {
+  @override
+  final Iterable<Type> types = const [GBookFragmentVars, _$GBookFragmentVars];
+  @override
+  final String wireName = 'GBookFragmentVars';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, GBookFragmentVars object,
+      {FullType specifiedType = FullType.unspecified}) {
+    return <Object?>[];
+  }
+
+  @override
+  GBookFragmentVars deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    return GBookFragmentVarsBuilder().build();
+  }
+}
+
+class _$GGetBooksVars extends GGetBooksVars {
+  factory _$GGetBooksVars([void Function(GGetBooksVarsBuilder)? updates]) =>
+      (GGetBooksVarsBuilder()..update(updates))._build();
+
+  _$GGetBooksVars._() : super._();
+  @override
+  GGetBooksVars rebuild(void Function(GGetBooksVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GGetBooksVarsBuilder toBuilder() => GGetBooksVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GGetBooksVars;
+  }
+
+  @override
+  int get hashCode {
+    return 53836182;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'GGetBooksVars').toString();
+  }
+}
+
+class GGetBooksVarsBuilder
+    implements Builder<GGetBooksVars, GGetBooksVarsBuilder> {
+  _$GGetBooksVars? _$v;
+
+  GGetBooksVarsBuilder();
+
+  @override
+  void replace(GGetBooksVars other) {
+    _$v = other as _$GGetBooksVars;
+  }
+
+  @override
+  void update(void Function(GGetBooksVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GGetBooksVars build() => _build();
+
+  _$GGetBooksVars _build() {
+    final _$result = _$v ?? _$GGetBooksVars._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GAuthorFragmentVars extends GAuthorFragmentVars {
+  factory _$GAuthorFragmentVars(
+          [void Function(GAuthorFragmentVarsBuilder)? updates]) =>
+      (GAuthorFragmentVarsBuilder()..update(updates))._build();
+
+  _$GAuthorFragmentVars._() : super._();
+  @override
+  GAuthorFragmentVars rebuild(
+          void Function(GAuthorFragmentVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GAuthorFragmentVarsBuilder toBuilder() =>
+      GAuthorFragmentVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GAuthorFragmentVars;
+  }
+
+  @override
+  int get hashCode {
+    return 102842534;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'GAuthorFragmentVars').toString();
+  }
+}
+
+class GAuthorFragmentVarsBuilder
+    implements Builder<GAuthorFragmentVars, GAuthorFragmentVarsBuilder> {
+  _$GAuthorFragmentVars? _$v;
+
+  GAuthorFragmentVarsBuilder();
+
+  @override
+  void replace(GAuthorFragmentVars other) {
+    _$v = other as _$GAuthorFragmentVars;
+  }
+
+  @override
+  void update(void Function(GAuthorFragmentVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GAuthorFragmentVars build() => _build();
+
+  _$GAuthorFragmentVars _build() {
+    final _$result = _$v ?? _$GAuthorFragmentVars._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+class _$GBookFragmentVars extends GBookFragmentVars {
+  factory _$GBookFragmentVars(
+          [void Function(GBookFragmentVarsBuilder)? updates]) =>
+      (GBookFragmentVarsBuilder()..update(updates))._build();
+
+  _$GBookFragmentVars._() : super._();
+  @override
+  GBookFragmentVars rebuild(void Function(GBookFragmentVarsBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  GBookFragmentVarsBuilder toBuilder() =>
+      GBookFragmentVarsBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is GBookFragmentVars;
+  }
+
+  @override
+  int get hashCode {
+    return 845341956;
+  }
+
+  @override
+  String toString() {
+    return newBuiltValueToStringHelper(r'GBookFragmentVars').toString();
+  }
+}
+
+class GBookFragmentVarsBuilder
+    implements Builder<GBookFragmentVars, GBookFragmentVarsBuilder> {
+  _$GBookFragmentVars? _$v;
+
+  GBookFragmentVarsBuilder();
+
+  @override
+  void replace(GBookFragmentVars other) {
+    _$v = other as _$GBookFragmentVars;
+  }
+
+  @override
+  void update(void Function(GBookFragmentVarsBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  GBookFragmentVars build() => _build();
+
+  _$GBookFragmentVars _build() {
+    final _$result = _$v ?? _$GBookFragmentVars._();
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/codegen/end_to_end_test/lib/fragments/nested_fragments_on_interface.graphql
+++ b/codegen/end_to_end_test/lib/fragments/nested_fragments_on_interface.graphql
@@ -17,13 +17,6 @@ fragment BookFragment on Book {
   }
 }
 
-
-
-
-
-
-
-
 fragment AuthorFragment on Author {
   displayName
   ... on Person {

--- a/codegen/end_to_end_test/lib/fragments/nested_fragments_on_interface.graphql
+++ b/codegen/end_to_end_test/lib/fragments/nested_fragments_on_interface.graphql
@@ -1,0 +1,30 @@
+query GetBooks {
+  books {
+    ...BookFragment
+  }
+} 
+
+fragment AuthorFragment on Author {
+  displayName
+  ... on Person {
+      firstName
+      lastName
+  }
+  ... on Company {
+      name
+  }
+}
+
+fragment BookFragment on Book {
+  author {
+    ...AuthorFragment
+  }
+  title
+  ... on Textbook {
+      courses
+  }
+  ... on ColoringBook {
+      colors
+  }
+}
+

--- a/codegen/end_to_end_test/lib/fragments/nested_fragments_on_interface.graphql
+++ b/codegen/end_to_end_test/lib/fragments/nested_fragments_on_interface.graphql
@@ -4,17 +4,6 @@ query GetBooks {
   }
 } 
 
-fragment AuthorFragment on Author {
-  displayName
-  ... on Person {
-      firstName
-      lastName
-  }
-  ... on Company {
-      name
-  }
-}
-
 fragment BookFragment on Book {
   author {
     ...AuthorFragment
@@ -25,6 +14,47 @@ fragment BookFragment on Book {
   }
   ... on ColoringBook {
       colors
+  }
+}
+
+
+
+
+
+
+
+
+fragment AuthorFragment on Author {
+  displayName
+  ... on Person {
+    ...AuthorPersonFragment
+  }
+  ... on Company {
+    ...AuthorCompanyFragment
+  }
+  ... on Group {
+    members {
+      ...AuthorGroupFragment
+    }
+  }
+}
+
+fragment AuthorPersonFragment on Person {
+  firstName
+  lastName
+}
+
+fragment AuthorCompanyFragment on Company {
+  name
+}
+
+fragment AuthorGroupFragment on Author {
+  displayName
+  ... on Person {
+    ...AuthorPersonFragment
+  }
+  ... on Company {
+    ...AuthorCompanyFragment
   }
 }
 

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
@@ -1224,6 +1224,39 @@ const Company = _i1.ObjectTypeDefinitionNode(
     ),
   ],
 );
+const Group = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'Group'),
+  directives: [],
+  interfaces: [
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'Author'),
+      isNonNull: false,
+    )
+  ],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'displayName'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'members'),
+      directives: [],
+      args: [],
+      type: _i1.ListTypeNode(
+        type: _i1.NamedTypeNode(
+          name: _i1.NameNode(value: 'Author'),
+          isNonNull: true,
+        ),
+        isNonNull: true,
+      ),
+    ),
+  ],
+);
 const Book = _i1.InterfaceTypeDefinitionNode(
   name: _i1.NameNode(value: 'Book'),
   directives: [],
@@ -1394,6 +1427,7 @@ const document = _i1.DocumentNode(definitions: [
   Author,
   Person,
   Company,
+  Group,
   Book,
   Textbook,
   ColoringBook,

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.ast.gql.dart
@@ -226,6 +226,18 @@ const Query = _i1.ObjectTypeDefinitionNode(
         isNonNull: false,
       ),
     ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'books'),
+      directives: [],
+      args: [],
+      type: _i1.ListTypeNode(
+        type: _i1.NamedTypeNode(
+          name: _i1.NameNode(value: 'Book'),
+          isNonNull: true,
+        ),
+        isNonNull: true,
+      ),
+    ),
   ],
 );
 const Mutation = _i1.ObjectTypeDefinitionNode(
@@ -1127,6 +1139,200 @@ const PostFavoritesInput = _i1.InputObjectTypeDefinitionNode(
     )
   ],
 );
+const Author = _i1.InterfaceTypeDefinitionNode(
+  name: _i1.NameNode(value: 'Author'),
+  directives: [],
+  interfaces: [],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'displayName'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    )
+  ],
+);
+const Person = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'Person'),
+  directives: [],
+  interfaces: [
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'Author'),
+      isNonNull: false,
+    )
+  ],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'firstName'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'lastName'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'displayName'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+  ],
+);
+const Company = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'Company'),
+  directives: [],
+  interfaces: [
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'Author'),
+      isNonNull: false,
+    )
+  ],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'name'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'displayName'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+  ],
+);
+const Book = _i1.InterfaceTypeDefinitionNode(
+  name: _i1.NameNode(value: 'Book'),
+  directives: [],
+  interfaces: [],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'title'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'author'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Author'),
+        isNonNull: true,
+      ),
+    ),
+  ],
+);
+const Textbook = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'Textbook'),
+  directives: [],
+  interfaces: [
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'Book'),
+      isNonNull: false,
+    )
+  ],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'title'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'author'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Author'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'courses'),
+      directives: [],
+      args: [],
+      type: _i1.ListTypeNode(
+        type: _i1.NamedTypeNode(
+          name: _i1.NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        isNonNull: true,
+      ),
+    ),
+  ],
+);
+const ColoringBook = _i1.ObjectTypeDefinitionNode(
+  name: _i1.NameNode(value: 'ColoringBook'),
+  directives: [],
+  interfaces: [
+    _i1.NamedTypeNode(
+      name: _i1.NameNode(value: 'Book'),
+      isNonNull: false,
+    )
+  ],
+  fields: [
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'title'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'String'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'author'),
+      directives: [],
+      args: [],
+      type: _i1.NamedTypeNode(
+        name: _i1.NameNode(value: 'Author'),
+        isNonNull: true,
+      ),
+    ),
+    _i1.FieldDefinitionNode(
+      name: _i1.NameNode(value: 'colors'),
+      directives: [],
+      args: [],
+      type: _i1.ListTypeNode(
+        type: _i1.NamedTypeNode(
+          name: _i1.NameNode(value: 'String'),
+          isNonNull: true,
+        ),
+        isNonNull: true,
+      ),
+    ),
+  ],
+);
 const SearchResult = _i1.UnionTypeDefinitionNode(
   name: _i1.NameNode(value: 'SearchResult'),
   directives: [],
@@ -1185,6 +1391,12 @@ const document = _i1.DocumentNode(definitions: [
   PostFavorites,
   PostLikesInput,
   PostFavoritesInput,
+  Author,
+  Person,
+  Company,
+  Book,
+  Textbook,
+  ColoringBook,
   SearchResult,
   Date,
   ISODate,

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
@@ -236,6 +236,7 @@ const Map<String, Set<String>> possibleTypesMap = {
   'Author': {
     'Person',
     'Company',
+    'Group',
   },
   'Book': {
     'Textbook',

--- a/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/schema.schema.gql.dart
@@ -233,6 +233,14 @@ const Map<String, Set<String>> possibleTypesMap = {
     'Human',
     'Droid',
   },
+  'Author': {
+    'Person',
+    'Company',
+  },
+  'Book': {
+    'Textbook',
+    'ColoringBook',
+  },
   'SearchResult': {
     'Human',
     'Droid',

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.dart
@@ -91,7 +91,13 @@ import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_inte
 import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.req.gql.dart'
     show GGetBooks;
 import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.var.gql.dart'
-    show GAuthorFragmentVars, GBookFragmentVars, GGetBooksVars;
+    show
+        GAuthorCompanyFragmentVars,
+        GAuthorFragmentVars,
+        GAuthorGroupFragmentVars,
+        GAuthorPersonFragmentVars,
+        GBookFragmentVars,
+        GGetBooksVars;
 import 'package:end_to_end_test/graphql/__generated__/schema.schema.gql.dart'
     show
         GColorInput,
@@ -154,14 +160,22 @@ final SerializersBuilder _serializersBuilder = _$serializers.toBuilder()
   ..add(DateSerializer())
   ..add(CustomFieldSerializer())
   ..add(GAuthorFragmentData.serializer)
+  ..add(GAuthorFragmentData__asGroup_members.serializer)
+  ..add(GAuthorGroupFragmentData.serializer)
   ..add(GBookFragmentData.serializer)
   ..add(GBookFragmentData__asColoringBook_author.serializer)
+  ..add(GBookFragmentData__asColoringBook_author__asGroup_members.serializer)
   ..add(GBookFragmentData__asTextbook_author.serializer)
+  ..add(GBookFragmentData__asTextbook_author__asGroup_members.serializer)
   ..add(GBookFragmentData__base_author.serializer)
+  ..add(GBookFragmentData__base_author__asGroup_members.serializer)
   ..add(GGetBooksData_books.serializer)
   ..add(GGetBooksData_books__asColoringBook_author.serializer)
+  ..add(GGetBooksData_books__asColoringBook_author__asGroup_members.serializer)
   ..add(GGetBooksData_books__asTextbook_author.serializer)
+  ..add(GGetBooksData_books__asTextbook_author__asGroup_members.serializer)
   ..add(GGetBooksData_books__base_author.serializer)
+  ..add(GGetBooksData_books__base_author__asGroup_members.serializer)
   ..add(GHeroForEpisodeData_hero.serializer)
   ..add(GHeroWithInterfaceSubTypedFragmentsData_hero.serializer)
   ..add(
@@ -180,20 +194,44 @@ final SerializersBuilder _serializersBuilder = _$serializers.toBuilder()
   GAliasedHeroData_empireHero,
   GAliasedHeroData_jediHero,
   GAliasedHeroVars,
+  GAuthorCompanyFragmentData,
+  GAuthorCompanyFragmentVars,
   GAuthorFragmentData__asCompany,
+  GAuthorFragmentData__asGroup,
+  GAuthorFragmentData__asGroup_members__asCompany,
+  GAuthorFragmentData__asGroup_members__asPerson,
+  GAuthorFragmentData__asGroup_members__base,
   GAuthorFragmentData__asPerson,
   GAuthorFragmentData__base,
   GAuthorFragmentVars,
+  GAuthorGroupFragmentData__asCompany,
+  GAuthorGroupFragmentData__asPerson,
+  GAuthorGroupFragmentData__base,
+  GAuthorGroupFragmentVars,
+  GAuthorPersonFragmentData,
+  GAuthorPersonFragmentVars,
   GBookFragmentData__asColoringBook,
   GBookFragmentData__asColoringBook_author__asCompany,
+  GBookFragmentData__asColoringBook_author__asGroup,
+  GBookFragmentData__asColoringBook_author__asGroup_members__asCompany,
+  GBookFragmentData__asColoringBook_author__asGroup_members__asPerson,
+  GBookFragmentData__asColoringBook_author__asGroup_members__base,
   GBookFragmentData__asColoringBook_author__asPerson,
   GBookFragmentData__asColoringBook_author__base,
   GBookFragmentData__asTextbook,
   GBookFragmentData__asTextbook_author__asCompany,
+  GBookFragmentData__asTextbook_author__asGroup,
+  GBookFragmentData__asTextbook_author__asGroup_members__asCompany,
+  GBookFragmentData__asTextbook_author__asGroup_members__asPerson,
+  GBookFragmentData__asTextbook_author__asGroup_members__base,
   GBookFragmentData__asTextbook_author__asPerson,
   GBookFragmentData__asTextbook_author__base,
   GBookFragmentData__base,
   GBookFragmentData__base_author__asCompany,
+  GBookFragmentData__base_author__asGroup,
+  GBookFragmentData__base_author__asGroup_members__asCompany,
+  GBookFragmentData__base_author__asGroup_members__asPerson,
+  GBookFragmentData__base_author__asGroup_members__base,
   GBookFragmentData__base_author__asPerson,
   GBookFragmentData__base_author__base,
   GBookFragmentVars,
@@ -224,14 +262,26 @@ final SerializersBuilder _serializersBuilder = _$serializers.toBuilder()
   GGetBooksData,
   GGetBooksData_books__asColoringBook,
   GGetBooksData_books__asColoringBook_author__asCompany,
+  GGetBooksData_books__asColoringBook_author__asGroup,
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany,
+  GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson,
+  GGetBooksData_books__asColoringBook_author__asGroup_members__base,
   GGetBooksData_books__asColoringBook_author__asPerson,
   GGetBooksData_books__asColoringBook_author__base,
   GGetBooksData_books__asTextbook,
   GGetBooksData_books__asTextbook_author__asCompany,
+  GGetBooksData_books__asTextbook_author__asGroup,
+  GGetBooksData_books__asTextbook_author__asGroup_members__asCompany,
+  GGetBooksData_books__asTextbook_author__asGroup_members__asPerson,
+  GGetBooksData_books__asTextbook_author__asGroup_members__base,
   GGetBooksData_books__asTextbook_author__asPerson,
   GGetBooksData_books__asTextbook_author__base,
   GGetBooksData_books__base,
   GGetBooksData_books__base_author__asCompany,
+  GGetBooksData_books__base_author__asGroup,
+  GGetBooksData_books__base_author__asGroup_members__asCompany,
+  GGetBooksData_books__base_author__asGroup_members__asPerson,
+  GGetBooksData_books__base_author__asGroup_members__base,
   GGetBooksData_books__base_author__asPerson,
   GGetBooksData_books__base_author__base,
   GGetBooksVars,

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.dart
@@ -87,6 +87,11 @@ import 'package:end_to_end_test/fragments/__generated__/nested_duplicate_fragmen
         GCharacterDetailsVars,
         GFriendInfoVars,
         GSearchResultsQueryVars;
+import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.data.gql.dart';
+import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.req.gql.dart'
+    show GGetBooks;
+import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.var.gql.dart'
+    show GAuthorFragmentVars, GBookFragmentVars, GGetBooksVars;
 import 'package:end_to_end_test/graphql/__generated__/schema.schema.gql.dart'
     show
         GColorInput,
@@ -144,32 +149,54 @@ import 'package:gql_code_builder_serializers/gql_code_builder_serializers.dart'
 
 part 'serializers.gql.g.dart';
 
-final SerializersBuilder _serializersBuilder =
-    _$serializers.toBuilder()
-      ..add(OperationSerializer())
-      ..add(DateSerializer())
-      ..add(CustomFieldSerializer())
-      ..add(GHeroForEpisodeData_hero.serializer)
-      ..add(GHeroWithInterfaceSubTypedFragmentsData_hero.serializer)
-      ..add(
-        GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends
-            .serializer,
-      )
-      ..add(GHeroWithInterfaceUnnamedFragmentsData_hero.serializer)
-      ..add(
-        GHeroWithInterfaceUnnamedFragmentsData_hero__asHuman_friends.serializer,
-      )
-      ..add(GSearchResultsQueryData_search.serializer)
-      ..add(GheroFieldsFragmentData.serializer)
-      ..add(GheroFieldsFragmentData__asHuman_friends.serializer)
-      ..add(GhumanFieldsFragmentData_friends.serializer)
-      ..addPlugin(StandardJsonPlugin());
+final SerializersBuilder _serializersBuilder = _$serializers.toBuilder()
+  ..add(OperationSerializer())
+  ..add(DateSerializer())
+  ..add(CustomFieldSerializer())
+  ..add(GAuthorFragmentData.serializer)
+  ..add(GBookFragmentData.serializer)
+  ..add(GBookFragmentData__asColoringBook_author.serializer)
+  ..add(GBookFragmentData__asTextbook_author.serializer)
+  ..add(GBookFragmentData__base_author.serializer)
+  ..add(GGetBooksData_books.serializer)
+  ..add(GGetBooksData_books__asColoringBook_author.serializer)
+  ..add(GGetBooksData_books__asTextbook_author.serializer)
+  ..add(GGetBooksData_books__base_author.serializer)
+  ..add(GHeroForEpisodeData_hero.serializer)
+  ..add(GHeroWithInterfaceSubTypedFragmentsData_hero.serializer)
+  ..add(
+    GHeroWithInterfaceSubTypedFragmentsData_hero__asHuman_friends.serializer,
+  )
+  ..add(GHeroWithInterfaceUnnamedFragmentsData_hero.serializer)
+  ..add(GHeroWithInterfaceUnnamedFragmentsData_hero__asHuman_friends.serializer)
+  ..add(GSearchResultsQueryData_search.serializer)
+  ..add(GheroFieldsFragmentData.serializer)
+  ..add(GheroFieldsFragmentData__asHuman_friends.serializer)
+  ..add(GhumanFieldsFragmentData_friends.serializer)
+  ..addPlugin(StandardJsonPlugin());
 @SerializersFor([
   GAliasedHero,
   GAliasedHeroData,
   GAliasedHeroData_empireHero,
   GAliasedHeroData_jediHero,
   GAliasedHeroVars,
+  GAuthorFragmentData__asCompany,
+  GAuthorFragmentData__asPerson,
+  GAuthorFragmentData__base,
+  GAuthorFragmentVars,
+  GBookFragmentData__asColoringBook,
+  GBookFragmentData__asColoringBook_author__asCompany,
+  GBookFragmentData__asColoringBook_author__asPerson,
+  GBookFragmentData__asColoringBook_author__base,
+  GBookFragmentData__asTextbook,
+  GBookFragmentData__asTextbook_author__asCompany,
+  GBookFragmentData__asTextbook_author__asPerson,
+  GBookFragmentData__asTextbook_author__base,
+  GBookFragmentData__base,
+  GBookFragmentData__base_author__asCompany,
+  GBookFragmentData__base_author__asPerson,
+  GBookFragmentData__base_author__base,
+  GBookFragmentVars,
   GCharacterBasicData,
   GCharacterBasicVars,
   GCharacterDetailsData,
@@ -193,6 +220,21 @@ final SerializersBuilder _serializersBuilder =
   GFriendInfoData_friendsConnection,
   GFriendInfoData_friendsConnection_friends,
   GFriendInfoVars,
+  GGetBooks,
+  GGetBooksData,
+  GGetBooksData_books__asColoringBook,
+  GGetBooksData_books__asColoringBook_author__asCompany,
+  GGetBooksData_books__asColoringBook_author__asPerson,
+  GGetBooksData_books__asColoringBook_author__base,
+  GGetBooksData_books__asTextbook,
+  GGetBooksData_books__asTextbook_author__asCompany,
+  GGetBooksData_books__asTextbook_author__asPerson,
+  GGetBooksData_books__asTextbook_author__base,
+  GGetBooksData_books__base,
+  GGetBooksData_books__base_author__asCompany,
+  GGetBooksData_books__base_author__asPerson,
+  GGetBooksData_books__base_author__base,
+  GGetBooksVars,
   GHeroForEpisode,
   GHeroForEpisodeData,
   GHeroForEpisodeData_hero__asDroid,

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
@@ -12,6 +12,23 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..add(GAliasedHeroData_empireHero.serializer)
       ..add(GAliasedHeroData_jediHero.serializer)
       ..add(GAliasedHeroVars.serializer)
+      ..add(GAuthorFragmentData__asCompany.serializer)
+      ..add(GAuthorFragmentData__asPerson.serializer)
+      ..add(GAuthorFragmentData__base.serializer)
+      ..add(GAuthorFragmentVars.serializer)
+      ..add(GBookFragmentData__asColoringBook.serializer)
+      ..add(GBookFragmentData__asColoringBook_author__asCompany.serializer)
+      ..add(GBookFragmentData__asColoringBook_author__asPerson.serializer)
+      ..add(GBookFragmentData__asColoringBook_author__base.serializer)
+      ..add(GBookFragmentData__asTextbook.serializer)
+      ..add(GBookFragmentData__asTextbook_author__asCompany.serializer)
+      ..add(GBookFragmentData__asTextbook_author__asPerson.serializer)
+      ..add(GBookFragmentData__asTextbook_author__base.serializer)
+      ..add(GBookFragmentData__base.serializer)
+      ..add(GBookFragmentData__base_author__asCompany.serializer)
+      ..add(GBookFragmentData__base_author__asPerson.serializer)
+      ..add(GBookFragmentData__base_author__base.serializer)
+      ..add(GBookFragmentVars.serializer)
       ..add(GCharacterBasicData.serializer)
       ..add(GCharacterBasicVars.serializer)
       ..add(GCharacterDetailsData.serializer)
@@ -35,6 +52,21 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..add(GFriendInfoData_friendsConnection.serializer)
       ..add(GFriendInfoData_friendsConnection_friends.serializer)
       ..add(GFriendInfoVars.serializer)
+      ..add(GGetBooks.serializer)
+      ..add(GGetBooksData.serializer)
+      ..add(GGetBooksData_books__asColoringBook.serializer)
+      ..add(GGetBooksData_books__asColoringBook_author__asCompany.serializer)
+      ..add(GGetBooksData_books__asColoringBook_author__asPerson.serializer)
+      ..add(GGetBooksData_books__asColoringBook_author__base.serializer)
+      ..add(GGetBooksData_books__asTextbook.serializer)
+      ..add(GGetBooksData_books__asTextbook_author__asCompany.serializer)
+      ..add(GGetBooksData_books__asTextbook_author__asPerson.serializer)
+      ..add(GGetBooksData_books__asTextbook_author__base.serializer)
+      ..add(GGetBooksData_books__base.serializer)
+      ..add(GGetBooksData_books__base_author__asCompany.serializer)
+      ..add(GGetBooksData_books__base_author__asPerson.serializer)
+      ..add(GGetBooksData_books__base_author__base.serializer)
+      ..add(GGetBooksVars.serializer)
       ..add(GHeroForEpisode.serializer)
       ..add(GHeroForEpisodeData.serializer)
       ..add(GHeroForEpisodeData_hero__asDroid.serializer)
@@ -170,6 +202,22 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(CustomField)]),
           () => ListBuilder<CustomField>())
+      ..addBuilderFactory(
+          const FullType(
+              BuiltList, const [const FullType(GGetBooksData_books)]),
+          () => ListBuilder<GGetBooksData_books>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => ListBuilder<String>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [const FullType(String)]),
+          () => ListBuilder<String>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(int)]),
           () => ListBuilder<int>())

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
@@ -338,16 +338,6 @@ Serializers _$serializers = (Serializers().toBuilder()
           () => ListBuilder<GheroFieldsFragmentData__asHuman_friends?>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [
-            const FullType.nullable(GheroFieldsFragment__asHuman_friends)
-          ]),
-          () => ListBuilder<GheroFieldsFragment__asHuman_friends?>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [
-            const FullType.nullable(GheroFieldsFragment__asHuman_friends)
-          ]),
-          () => ListBuilder<GheroFieldsFragment__asHuman_friends?>())
-      ..addBuilderFactory(
-          const FullType(BuiltList, const [
             const FullType.nullable(GhumanFieldsFragmentData_friends)
           ]),
           () => ListBuilder<GhumanFieldsFragmentData_friends?>())

--- a/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
+++ b/codegen/end_to_end_test/lib/graphql/__generated__/serializers.gql.g.dart
@@ -12,20 +12,52 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..add(GAliasedHeroData_empireHero.serializer)
       ..add(GAliasedHeroData_jediHero.serializer)
       ..add(GAliasedHeroVars.serializer)
+      ..add(GAuthorCompanyFragmentData.serializer)
+      ..add(GAuthorCompanyFragmentVars.serializer)
       ..add(GAuthorFragmentData__asCompany.serializer)
+      ..add(GAuthorFragmentData__asGroup.serializer)
+      ..add(GAuthorFragmentData__asGroup_members__asCompany.serializer)
+      ..add(GAuthorFragmentData__asGroup_members__asPerson.serializer)
+      ..add(GAuthorFragmentData__asGroup_members__base.serializer)
       ..add(GAuthorFragmentData__asPerson.serializer)
       ..add(GAuthorFragmentData__base.serializer)
       ..add(GAuthorFragmentVars.serializer)
+      ..add(GAuthorGroupFragmentData__asCompany.serializer)
+      ..add(GAuthorGroupFragmentData__asPerson.serializer)
+      ..add(GAuthorGroupFragmentData__base.serializer)
+      ..add(GAuthorGroupFragmentVars.serializer)
+      ..add(GAuthorPersonFragmentData.serializer)
+      ..add(GAuthorPersonFragmentVars.serializer)
       ..add(GBookFragmentData__asColoringBook.serializer)
       ..add(GBookFragmentData__asColoringBook_author__asCompany.serializer)
+      ..add(GBookFragmentData__asColoringBook_author__asGroup.serializer)
+      ..add(GBookFragmentData__asColoringBook_author__asGroup_members__asCompany
+          .serializer)
+      ..add(GBookFragmentData__asColoringBook_author__asGroup_members__asPerson
+          .serializer)
+      ..add(GBookFragmentData__asColoringBook_author__asGroup_members__base
+          .serializer)
       ..add(GBookFragmentData__asColoringBook_author__asPerson.serializer)
       ..add(GBookFragmentData__asColoringBook_author__base.serializer)
       ..add(GBookFragmentData__asTextbook.serializer)
       ..add(GBookFragmentData__asTextbook_author__asCompany.serializer)
+      ..add(GBookFragmentData__asTextbook_author__asGroup.serializer)
+      ..add(GBookFragmentData__asTextbook_author__asGroup_members__asCompany
+          .serializer)
+      ..add(GBookFragmentData__asTextbook_author__asGroup_members__asPerson
+          .serializer)
+      ..add(GBookFragmentData__asTextbook_author__asGroup_members__base
+          .serializer)
       ..add(GBookFragmentData__asTextbook_author__asPerson.serializer)
       ..add(GBookFragmentData__asTextbook_author__base.serializer)
       ..add(GBookFragmentData__base.serializer)
       ..add(GBookFragmentData__base_author__asCompany.serializer)
+      ..add(GBookFragmentData__base_author__asGroup.serializer)
+      ..add(
+          GBookFragmentData__base_author__asGroup_members__asCompany.serializer)
+      ..add(
+          GBookFragmentData__base_author__asGroup_members__asPerson.serializer)
+      ..add(GBookFragmentData__base_author__asGroup_members__base.serializer)
       ..add(GBookFragmentData__base_author__asPerson.serializer)
       ..add(GBookFragmentData__base_author__base.serializer)
       ..add(GBookFragmentVars.serializer)
@@ -56,14 +88,36 @@ Serializers _$serializers = (Serializers().toBuilder()
       ..add(GGetBooksData.serializer)
       ..add(GGetBooksData_books__asColoringBook.serializer)
       ..add(GGetBooksData_books__asColoringBook_author__asCompany.serializer)
+      ..add(GGetBooksData_books__asColoringBook_author__asGroup.serializer)
+      ..add(
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asCompany
+              .serializer)
+      ..add(
+          GGetBooksData_books__asColoringBook_author__asGroup_members__asPerson
+              .serializer)
+      ..add(GGetBooksData_books__asColoringBook_author__asGroup_members__base
+          .serializer)
       ..add(GGetBooksData_books__asColoringBook_author__asPerson.serializer)
       ..add(GGetBooksData_books__asColoringBook_author__base.serializer)
       ..add(GGetBooksData_books__asTextbook.serializer)
       ..add(GGetBooksData_books__asTextbook_author__asCompany.serializer)
+      ..add(GGetBooksData_books__asTextbook_author__asGroup.serializer)
+      ..add(GGetBooksData_books__asTextbook_author__asGroup_members__asCompany
+          .serializer)
+      ..add(GGetBooksData_books__asTextbook_author__asGroup_members__asPerson
+          .serializer)
+      ..add(GGetBooksData_books__asTextbook_author__asGroup_members__base
+          .serializer)
       ..add(GGetBooksData_books__asTextbook_author__asPerson.serializer)
       ..add(GGetBooksData_books__asTextbook_author__base.serializer)
       ..add(GGetBooksData_books__base.serializer)
       ..add(GGetBooksData_books__base_author__asCompany.serializer)
+      ..add(GGetBooksData_books__base_author__asGroup.serializer)
+      ..add(GGetBooksData_books__base_author__asGroup_members__asCompany
+          .serializer)
+      ..add(GGetBooksData_books__base_author__asGroup_members__asPerson
+          .serializer)
+      ..add(GGetBooksData_books__base_author__asGroup_members__base.serializer)
       ..add(GGetBooksData_books__base_author__asPerson.serializer)
       ..add(GGetBooksData_books__base_author__base.serializer)
       ..add(GGetBooksVars.serializer)
@@ -203,9 +257,52 @@ Serializers _$serializers = (Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(CustomField)]),
           () => ListBuilder<CustomField>())
       ..addBuilderFactory(
+          const FullType(BuiltList,
+              const [const FullType(GAuthorFragmentData__asGroup_members)]),
+          () => ListBuilder<GAuthorFragmentData__asGroup_members>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType(
+                GBookFragmentData__asColoringBook_author__asGroup_members)
+          ]),
+          () => ListBuilder<
+              GBookFragmentData__asColoringBook_author__asGroup_members>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType(
+                GBookFragmentData__asTextbook_author__asGroup_members)
+          ]),
+          () => ListBuilder<
+              GBookFragmentData__asTextbook_author__asGroup_members>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType(GBookFragmentData__base_author__asGroup_members)
+          ]),
+          () => ListBuilder<GBookFragmentData__base_author__asGroup_members>())
+      ..addBuilderFactory(
           const FullType(
               BuiltList, const [const FullType(GGetBooksData_books)]),
           () => ListBuilder<GGetBooksData_books>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType(
+                GGetBooksData_books__asColoringBook_author__asGroup_members)
+          ]),
+          () => ListBuilder<
+              GGetBooksData_books__asColoringBook_author__asGroup_members>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType(
+                GGetBooksData_books__asTextbook_author__asGroup_members)
+          ]),
+          () => ListBuilder<
+              GGetBooksData_books__asTextbook_author__asGroup_members>())
+      ..addBuilderFactory(
+          const FullType(BuiltList, const [
+            const FullType(GGetBooksData_books__base_author__asGroup_members)
+          ]),
+          () =>
+              ListBuilder<GGetBooksData_books__base_author__asGroup_members>())
       ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType(String)]),
           () => ListBuilder<String>())

--- a/codegen/end_to_end_test/lib/graphql/schema.graphql
+++ b/codegen/end_to_end_test/lib/graphql/schema.graphql
@@ -219,6 +219,11 @@ type Company implements Author {
   displayName: String!
 }
 
+type Group implements Author {
+  displayName: String!
+  members: [Author!]!
+}
+
 interface Book {
   title: String!
   author: Author!

--- a/codegen/end_to_end_test/lib/graphql/schema.graphql
+++ b/codegen/end_to_end_test/lib/graphql/schema.graphql
@@ -18,6 +18,7 @@ type Query {
   human(id: ID!): Human
   starship(id: ID!): Starship
   posts(userId: ID!, filter: Json): [Post]
+  books: [Book!]!
 }
 
 # The mutation type, represents all updates we can make to our data
@@ -201,6 +202,38 @@ input PostLikesInput {
 
 input PostFavoritesInput {
   id: ID!
+}
+
+interface Author {
+  displayName: String!
+}
+
+type Person implements Author {
+  firstName: String!
+  lastName: String!
+  displayName: String!
+}
+
+type Company implements Author {
+  name: String!
+  displayName: String!
+}
+
+interface Book {
+  title: String!
+  author: Author!
+}
+
+type Textbook implements Book {
+  title: String!
+  author: Author!
+  courses: [String!]!
+}
+
+type ColoringBook implements Book {
+  title: String!
+  author: Author!
+  colors: [String!]!
 }
 
 union SearchResult = Human | Droid | Starship

--- a/codegen/end_to_end_test/test/operation/nested_fragments_on_interface_test.dart
+++ b/codegen/end_to_end_test/test/operation/nested_fragments_on_interface_test.dart
@@ -1,0 +1,107 @@
+import 'package:end_to_end_test/fragments/__generated__/nested_fragments_on_interface.data.gql.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Nested Fragments on Interface', () {
+    test('can deserialize correctly from sub-Typed data', () {
+      final jsonBooks = [
+        {
+          "__typename": "Textbook",
+          "author": {
+            "__typename": "Person",
+            "displayName": "Hugh Teach",
+            "firstName": "Hugh",
+            "lastName": "Teach",
+          },
+          "title": "Teaching 101",
+          "courses": ["Education", "Teaching"],
+        },
+        {
+          "__typename": "ColoringBook",
+          "author": {
+            "__typename": "Company",
+            "displayName": "Fiona Fiction",
+            "name": "Fiona Fiction Ltd.",
+          },
+          "title": "Fictional Realities",
+          "colors": ["Green", "Red"],
+        }
+      ];
+
+      final textbook = GGetBooksData_books__asTextbook.fromJson(jsonBooks[0])!;
+      expect(textbook.author.displayName, 'Hugh Teach');
+      expect(textbook.author, isA<GAuthorFragment>());
+      expect(
+        textbook.author.maybeWhen(
+          person: (x) => x.firstName == 'Hugh' && x.lastName == 'Teach',
+          orElse: () => false,
+        ),
+        isTrue,
+      );
+
+      final coloringBook =
+          GGetBooksData_books__asColoringBook.fromJson(jsonBooks[1])!;
+      expect(coloringBook.author.displayName, 'Fiona Fiction');
+      expect(coloringBook.author, isA<GAuthorFragment>());
+      expect(
+        coloringBook.author.maybeWhen(
+          company: (x) => x.name == 'Fiona Fiction Ltd.',
+          orElse: () => false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('can be serialized and deserialized', () {
+      final textbook = GGetBooksData_books__asTextbook(
+        (b) => b
+          ..author = GGetBooksData_books__asTextbook_author__asPerson(
+            (a) => a
+              ..displayName = 'Hugh Teach'
+              ..firstName = 'Hugh'
+              ..lastName = 'Teach',
+          )
+          ..title = 'Teaching 101'
+          ..courses.addAll(['Education', 'Teaching']),
+      );
+
+      final jsonTextbook = {
+        "__typename": "Textbook",
+        "author": {
+          "__typename": "Person",
+          "displayName": "Hugh Teach",
+          "firstName": "Hugh",
+          "lastName": "Teach",
+        },
+        "title": "Teaching 101",
+        "courses": ["Education", "Teaching"],
+      };
+
+      expect(textbook.toJson(), equals(jsonTextbook));
+
+      final coloringBook = GGetBooksData_books__asColoringBook(
+        (b) => b
+          ..author = GGetBooksData_books__asColoringBook_author__asCompany(
+            (a) => a
+              ..displayName = 'Fiona Fiction'
+              ..name = 'Fiona Fiction Ltd.',
+          )
+          ..title = 'Fictional Realities'
+          ..colors.addAll(['Green', 'Red']),
+      );
+
+      final jsonColoringBook = {
+        "__typename": "ColoringBook",
+        "author": {
+          "__typename": "Company",
+          "displayName": "Fiona Fiction",
+          "name": "Fiona Fiction Ltd.",
+        },
+        "title": "Fictional Realities",
+        "colors": ["Green", "Red"],
+      };
+
+      expect(coloringBook.toJson(), equals(jsonColoringBook));
+    });
+  });
+}

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -347,20 +347,18 @@ List<Spec> _buildTypeSpecificClasses({
           final nestedSpecializedName =
               context.specialize(nestedBaseName, fragmentTypeName);
 
-          if (specializedInterface.startsWith(nestedSpecializedName)) {
-            // Add selections for nested specialized interfaces
-            expandedSuperclassSelections[nestedSpecializedName] =
-                SourceSelections(
-              url: superclassSelections[specializedInterface]?.url,
-              selections: [
-                ...superclassSelections[specializedInterface]?.selections ?? [],
-                ...inlineFragment.selectionSet.selections,
-              ],
-            );
+          // Add selections for nested specialized interfaces
+          expandedSuperclassSelections[nestedSpecializedName] =
+              SourceSelections(
+            url: superclassSelections[specializedInterface]?.url,
+            selections: [
+              ...superclassSelections[specializedInterface]?.selections ?? [],
+              ...inlineFragment.selectionSet.selections,
+            ],
+          );
 
-            // Map nested interfaces
-            nestedInterfaceMap[specializedInterface] = nestedSpecializedName;
-          }
+          // Map nested interfaces
+          nestedInterfaceMap[specializedInterface] = nestedSpecializedName;
         }
       }
     }

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -310,8 +310,7 @@ List<Spec> _buildTypeSpecificClasses({
     final expandedSuperclassSelections = {...superclassSelections};
     final nestedInterfaceMap = <String, String>{};
 
-    // Process each base interface from the superclass selections
-    // These represent the actual GraphQL fragment hierarchy, not just name-based relationships
+    // Process each base interface from the superclass selections.
     for (final baseInterfaceName in superclassSelections.keys) {
       final specializedName =
           context.specialize(baseInterfaceName, fragmentTypeName);
@@ -348,18 +347,20 @@ List<Spec> _buildTypeSpecificClasses({
           final nestedSpecializedName =
               context.specialize(nestedBaseName, fragmentTypeName);
 
-          // Add selections for nested specialized interfaces
-          expandedSuperclassSelections[nestedSpecializedName] =
-              SourceSelections(
-            url: superclassSelections[specializedInterface]?.url,
-            selections: [
-              ...superclassSelections[specializedInterface]?.selections ?? [],
-              ...inlineFragment.selectionSet.selections,
-            ],
-          );
+          if (specializedInterface.startsWith(nestedSpecializedName)) {
+            // Add selections for nested specialized interfaces
+            expandedSuperclassSelections[nestedSpecializedName] =
+                SourceSelections(
+              url: superclassSelections[specializedInterface]?.url,
+              selections: [
+                ...superclassSelections[specializedInterface]?.selections ?? [],
+                ...inlineFragment.selectionSet.selections,
+              ],
+            );
 
-          // Map nested interfaces
-          nestedInterfaceMap[specializedInterface] = nestedSpecializedName;
+            // Map nested interfaces
+            nestedInterfaceMap[specializedInterface] = nestedSpecializedName;
+          }
         }
       }
     }

--- a/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
+++ b/codegen/gql_code_builder/lib/src/inline_fragment_classes.dart
@@ -310,8 +310,9 @@ List<Spec> _buildTypeSpecificClasses({
     final expandedSuperclassSelections = {...superclassSelections};
     final nestedInterfaceMap = <String, String>{};
 
-    // Process each base interface found in the hierarchy
-    for (final baseInterfaceName in context.hierarchy.keys) {
+    // Process each base interface from the superclass selections
+    // These represent the actual GraphQL fragment hierarchy, not just name-based relationships
+    for (final baseInterfaceName in superclassSelections.keys) {
       final specializedName =
           context.specialize(baseInterfaceName, fragmentTypeName);
 

--- a/codegen/gql_code_builder/lib/src/utils/field_utils.dart
+++ b/codegen/gql_code_builder/lib/src/utils/field_utils.dart
@@ -229,7 +229,10 @@ Map<String, SourceSelections> fragmentSelectionsForField(
       final potentialNestedName =
           "${baseFragmentName}__as${typeName}_${fieldKey}";
 
-      if (fragmentMap.containsKey(superName)) {
+      // We need to check if the nested interface make sense by verifiying if
+      // its name contains the superName.
+      if (fragmentMap.containsKey(superName) &&
+          potentialNestedName.contains(superName)) {
         result[potentialNestedName] = SourceSelections(
           url: sourceSelections.url,
           selections: [], // Empty since this is just for interface implementation


### PR DESCRIPTION
This PR aims to fix https://github.com/gql-dart/ferry/issues/610.
I don't fully understand the code, so I'm not sure why I needed to use `superclassSelections` instead of `context.hierarchy` in `inline_fragment_classes.dart`, but it seems to work. I've tested it in our codebase and so far I don't see any regression and we can now use the kind of fragments discussed in the issue 🥳 .