### PR TITLE
feat: widen analyzer constraint to support analyzer 12

### DIFF
--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/gql-dart/gql
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <13.0.0'
   build: ^4.0.0
   built_collection: ^5.0.0
   built_value: ^8.0.6

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/gql-dart/gql
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <13.0.0'
   built_collection: ^5.0.0
   built_value: ^8.0.6
   code_builder: ^4.7.0


### PR DESCRIPTION
## Summary
- Extends the `analyzer` version constraint from `>=9.0.0 <11.0.0` to `>=9.0.0 <13.0.0` in both `gql_build` and `gql_code_builder` packages.
- Analyzer 12's breaking changes (ClassBody/EnumBody sealed classes, LibraryIdentifier removal, DottedName changes) do not affect the `ClassElement` APIs used by these packages.

## Test plan
- [x] `dart analyze` passes on both `gql_code_builder` and `gql_build`
- [x] All `gql_code_builder` tests pass (8/8)
- [x] All `gql` core tests pass (155/155)
- [x] All `gql_exec` tests pass (7/7)
- [x] All `gql_tristate_value` tests pass (14/14)
- [x] `melos bootstrap` resolves dependencies successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)