### PR TITLE
Backport analyzer 12 support for gql codegen stable

### DIFF
--- a/codegen/gql_build/CHANGELOG.md
+++ b/codegen/gql_build/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.3
+
+ - Support analyzer 12.x.
+ - Require Dart 3.10+ for dart_style 3.1.8 compatibility.
+
 ## 0.13.2
 
  - Support analyzer 9.x and 10.x.

--- a/codegen/gql_build/lib/gql_build.dart
+++ b/codegen/gql_build/lib/gql_build.dart
@@ -9,72 +9,49 @@ import "./src/utils/config.dart";
 import "./src/var_builder.dart";
 
 /// Builds AST of a GraphQL document
-Builder astBuilder(
-  BuilderOptions options,
-) =>
+Builder astBuilder(BuilderOptions options) =>
     AstBuilder(dartFormatter(options.config));
 
 /// Builds type-safe data viewer
-Builder dataBuilder(
-  BuilderOptions options,
-) =>
-    DataBuilder(
-      AssetId.parse(
-        options.config["schema"] as String,
-      ),
-      (options.config["add_typenames"] ?? true) as bool,
-      typeOverrideMap(options.config["type_overrides"]),
-      dartFormatter(options.config),
-      whenExtensionConfig: whenExtensionConfig(options.config),
-      dataClassConfig: dataClassConfig(options.config),
-    );
+Builder dataBuilder(BuilderOptions options) => DataBuilder(
+  AssetId.parse(options.config["schema"] as String),
+  (options.config["add_typenames"] ?? true) as bool,
+  typeOverrideMap(options.config["type_overrides"]),
+  dartFormatter(options.config),
+  whenExtensionConfig: whenExtensionConfig(options.config),
+  dataClassConfig: dataClassConfig(options.config),
+);
 
 /// Builds GraphQL type-safe request builder
-Builder reqBuilder(
-  BuilderOptions options,
-) =>
-    ReqBuilder(
-      AssetId.parse(
-        options.config["schema"] as String,
-      ),
-      dartFormatter(options.config),
-    );
+Builder reqBuilder(BuilderOptions options) => ReqBuilder(
+  AssetId.parse(options.config["schema"] as String),
+  dartFormatter(options.config),
+);
 
 /// Builds GraphQL type-safe variables builder
-Builder varBuilder(
-  BuilderOptions options,
-) =>
-    VarBuilder(
-        AssetId.parse(
-          options.config["schema"] as String,
-        ),
-        typeOverrideMap(options.config["type_overrides"]),
-        triStateOptionalsConfig(options.config),
-        varsCreateFactoriesConfig(options.config),
-        dartFormatter(options.config));
+Builder varBuilder(BuilderOptions options) => VarBuilder(
+  AssetId.parse(options.config["schema"] as String),
+  typeOverrideMap(options.config["type_overrides"]),
+  triStateOptionalsConfig(options.config),
+  varsCreateFactoriesConfig(options.config),
+  dartFormatter(options.config),
+);
 
 /// Builds GraphQL schema types
-Builder schemaBuilder(
-  BuilderOptions options,
-) =>
-    SchemaBuilder(
-        typeOverrideMap(options.config["type_overrides"]),
-        enumFallbackConfig(options.config),
-        generatePossibleTypesConfig(options.config),
-        triStateOptionalsConfig(options.config),
-        varsCreateFactoriesConfig(options.config),
-        dartFormatter(options.config));
+Builder schemaBuilder(BuilderOptions options) => SchemaBuilder(
+  typeOverrideMap(options.config["type_overrides"]),
+  enumFallbackConfig(options.config),
+  generatePossibleTypesConfig(options.config),
+  triStateOptionalsConfig(options.config),
+  varsCreateFactoriesConfig(options.config),
+  dartFormatter(options.config),
+);
 
 /// Builds an aggregate Serlializers object for [built_value]s
 ///
 /// Builds to the same directory as the passed schema.
-Builder serializerBuilder(
-  BuilderOptions options,
-) =>
-    SerializerBuilder(
-      AssetId.parse(
-        options.config["schema"] as String,
-      ),
-      customSerializers(options.config["custom_serializers"]),
-      typeOverrideMap(options.config["type_overrides"]),
-    );
+Builder serializerBuilder(BuilderOptions options) => SerializerBuilder(
+  AssetId.parse(options.config["schema"] as String),
+  customSerializers(options.config["custom_serializers"]),
+  typeOverrideMap(options.config["type_overrides"]),
+);

--- a/codegen/gql_build/lib/src/allocators/gql_allocator.dart
+++ b/codegen/gql_build/lib/src/allocators/gql_allocator.dart
@@ -3,9 +3,7 @@ import "package:gql_build/src/config.dart";
 import "package:path/path.dart" as p;
 
 class GqlAllocator implements Allocator {
-  static const _doNotImport = [
-    "dart:core",
-  ];
+  static const _doNotImport = ["dart:core"];
 
   static const _doNotPrefix = [
     "package:built_value/built_value.dart",
@@ -21,11 +19,7 @@ class GqlAllocator implements Allocator {
   final _imports = <String, int?>{};
   var _keys = 1;
 
-  GqlAllocator(
-    this.sourceUrl,
-    this.currentUrl,
-    this.schemaUrl,
-  );
+  GqlAllocator(this.sourceUrl, this.currentUrl, this.schemaUrl);
 
   @override
   String allocate(Reference reference) {
@@ -44,10 +38,9 @@ class GqlAllocator implements Allocator {
     if (uri.path.endsWith(sourceExtension)) {
       final replacedUrl = uri
           .replace(
-            path: outputPath(uri.path).replaceAll(
-              RegExp(r".graphql$"),
-              ".${uri.fragment}.gql.dart",
-            ),
+            path: outputPath(
+              uri.path,
+            ).replaceAll(RegExp(r".graphql$"), ".${uri.fragment}.gql.dart"),
           )
           .removeFragment()
           .toString();
@@ -66,10 +59,9 @@ class GqlAllocator implements Allocator {
       } else if (uri.fragment == "serializer") {
         replacedUrl = "${p.dirname(schemaUrl!)}/serializers.gql.dart";
       } else {
-        replacedUrl = outputPath(sourceUrl).replaceAll(
-          RegExp(r".graphql$"),
-          ".${uri.fragment}.gql.dart",
-        );
+        replacedUrl = outputPath(
+          sourceUrl,
+        ).replaceAll(RegExp(r".graphql$"), ".${uri.fragment}.gql.dart");
       }
 
       if (replacedUrl == currentUrl) {
@@ -86,8 +78,8 @@ class GqlAllocator implements Allocator {
 
   @override
   Iterable<Directive> get imports => _imports.keys.map(
-        (u) => _imports[u] == null
-            ? Directive.import(u)
-            : Directive.import(u, as: "_i${_imports[u]}"),
-      );
+    (u) => _imports[u] == null
+        ? Directive.import(u)
+        : Directive.import(u, as: "_i${_imports[u]}"),
+  );
 }

--- a/codegen/gql_build/lib/src/allocators/pick_allocator.dart
+++ b/codegen/gql_build/lib/src/allocators/pick_allocator.dart
@@ -7,18 +7,13 @@ class PickAllocator implements Allocator {
 
   final Map<String, List<String>?> _imports = {};
 
-  PickAllocator({
-    this.doNotPick = const [],
-    this.include = const [],
-  }) {
+  PickAllocator({this.doNotPick = const [], this.include = const []}) {
     for (final url in include) {
       _imports[url] = null;
     }
   }
 
-  static const _doNotImport = [
-    "dart:core",
-  ];
+  static const _doNotImport = ["dart:core"];
 
   @override
   String allocate(Reference reference) {
@@ -32,16 +27,19 @@ class PickAllocator implements Allocator {
       return symbol;
     }
 
-    _imports.update(url, (symbols) => symbols?..add(symbol),
-        ifAbsent: () => [symbol]);
+    _imports.update(
+      url,
+      (symbols) => symbols?..add(symbol),
+      ifAbsent: () => [symbol],
+    );
 
     return symbol;
   }
 
   @override
   Iterable<Directive> get imports => _imports.entries.map(
-        (u) => u.value == null
-            ? Directive.import(u.key)
-            : Directive.import(u.key, show: u.value!),
-      );
+    (u) => u.value == null
+        ? Directive.import(u.key)
+        : Directive.import(u.key, show: u.value!),
+  );
 }

--- a/codegen/gql_build/lib/src/ast_builder.dart
+++ b/codegen/gql_build/lib/src/ast_builder.dart
@@ -15,16 +15,14 @@ class AstBuilder implements Builder {
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        inputPattern: [outputPattern(astExtension)],
-      };
+    inputPattern: [outputPattern(astExtension)],
+  };
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
     final doc = await readDocument(buildStep);
 
-    final library = buildAstLibrary(
-      doc,
-    );
+    final library = buildAstLibrary(doc);
 
     return writeDocument(library, buildStep, astExtension, formatter);
   }

--- a/codegen/gql_build/lib/src/config.dart
+++ b/codegen/gql_build/lib/src/config.dart
@@ -26,9 +26,9 @@ String outputPath(String inputPath) {
 }
 
 AssetId outputAssetId(AssetId inputAssetId, String extension) => AssetId(
-      inputAssetId.package,
-      outputPath(inputAssetId.path),
-    ).changeExtension(extension);
+  inputAssetId.package,
+  outputPath(inputAssetId.path),
+).changeExtension(extension);
 
 String generatedFileExtension(String sourceExtension) {
   final parts = sourceExtension.split(".");

--- a/codegen/gql_build/lib/src/data_builder.dart
+++ b/codegen/gql_build/lib/src/data_builder.dart
@@ -27,15 +27,13 @@ class DataBuilder implements Builder {
       generateWhenExtensionMethod: false,
       generateMaybeWhenExtensionMethod: false,
     ),
-    this.dataClassConfig = const DataClassConfig(
-      reuseFragments: false,
-    ),
+    this.dataClassConfig = const DataClassConfig(reuseFragments: false),
   });
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        inputPattern: [outputPattern(dataExtension)],
-      };
+    inputPattern: [outputPattern(dataExtension)],
+  };
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {

--- a/codegen/gql_build/lib/src/req_builder.dart
+++ b/codegen/gql_build/lib/src/req_builder.dart
@@ -13,15 +13,12 @@ class ReqBuilder implements Builder {
   final AssetId schemaId;
   final DartFormatter formatter;
 
-  ReqBuilder(
-    this.schemaId,
-    this.formatter,
-  );
+  ReqBuilder(this.schemaId, this.formatter);
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        inputPattern: [outputPattern(reqExtension)],
-      };
+    inputPattern: [outputPattern(reqExtension)],
+  };
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
@@ -32,10 +29,7 @@ class ReqBuilder implements Builder {
         .uri
         .path;
 
-    final library = buildReqLibrary(
-      doc,
-      basename(generatedPartUrl),
-    );
+    final library = buildReqLibrary(doc, basename(generatedPartUrl));
 
     return writeDocument(
       library,

--- a/codegen/gql_build/lib/src/schema_builder.dart
+++ b/codegen/gql_build/lib/src/schema_builder.dart
@@ -20,17 +20,18 @@ class SchemaBuilder implements Builder {
   final DartFormatter formatter;
 
   SchemaBuilder(
-      this.typeOverrides,
-      this.enumFallbackConfig,
-      this.generatePossibleTypesMap,
-      this.triStateValueConfig,
-      this.generateVarsCreateFactories,
-      this.formatter);
+    this.typeOverrides,
+    this.enumFallbackConfig,
+    this.generatePossibleTypesMap,
+    this.triStateValueConfig,
+    this.generateVarsCreateFactories,
+    this.formatter,
+  );
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        inputPattern: [outputPattern(schemaExtension)],
-      };
+    inputPattern: [outputPattern(schemaExtension)],
+  };
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
@@ -41,8 +42,10 @@ class SchemaBuilder implements Builder {
         .uri
         .path;
 
-    final schemaUrl =
-        outputAssetId(buildStep.inputId, schemaExtension).uri.toString();
+    final schemaUrl = outputAssetId(
+      buildStep.inputId,
+      schemaExtension,
+    ).uri.toString();
     final allocator = GqlAllocator(
       buildStep.inputId.uri.toString(),
       outputAssetId(buildStep.inputId, schemaExtension).uri.toString(),
@@ -61,6 +64,12 @@ class SchemaBuilder implements Builder {
     );
 
     return writeDocument(
-        library, buildStep, schemaExtension, formatter, schemaUrl, allocator);
+      library,
+      buildStep,
+      schemaExtension,
+      formatter,
+      schemaUrl,
+      allocator,
+    );
   }
 }

--- a/codegen/gql_build/lib/src/serializer_builder.dart
+++ b/codegen/gql_build/lib/src/serializer_builder.dart
@@ -19,14 +19,11 @@ class SerializerBuilder implements Builder {
   final Set<Reference> customSerializers;
   final Map<String, Reference> typeOverrides;
 
-  SerializerBuilder(
-    this.schemaId,
-    this.customSerializers,
-    this.typeOverrides,
-  );
+  SerializerBuilder(this.schemaId, this.customSerializers, this.typeOverrides);
 
-  static final _formatter =
-      DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
+  static final _formatter = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  );
   static final _generatedFiles = Glob("lib/**.gql.dart");
 
   // create a path for the serializers output in same directory as schema
@@ -37,35 +34,41 @@ class SerializerBuilder implements Builder {
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        // buildExtensions already include the 'lib' path segment, so we must remove it here
-        r"$lib$": [p.joinAll(pathSegments.skip(1))],
-      };
+    // buildExtensions already include the 'lib' path segment, so we must remove it here
+    r"$lib$": [p.joinAll(pathSegments.skip(1))],
+  };
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
     /// BuiltValue classes with serializers. These will be added automatically
     /// using `@SerializersFor`.
-    final builtClasses =
-        SplayTreeSet<ClassElement>((a, b) => a.name!.compareTo(b.name!));
+    final builtClasses = SplayTreeSet<ClassElement>(
+      (a, b) => a.name!.compareTo(b.name!),
+    );
 
     /// Non BuiltValue classes with serializers (i.e. inline fragment classes).
     /// These need to be added manually since `@SerializersFor` only recognizes
     /// BuiltValue classes.
-    final nonBuiltClasses =
-        SplayTreeSet<ClassElement>((a, b) => a.name!.compareTo(b.name!));
+    final nonBuiltClasses = SplayTreeSet<ClassElement>(
+      (a, b) => a.name!.compareTo(b.name!),
+    );
 
-    final hasSerializer = (ClassElement c) => c.fields.any((field) =>
-        field.isStatic &&
-        field.name == "serializer" &&
-        field.type.element?.name == "Serializer" &&
-        field.type.element?.library?.uri.toString() ==
-            "package:built_value/serializer.dart");
+    final hasSerializer = (ClassElement c) => c.fields.any(
+      (field) =>
+          field.isStatic &&
+          field.name == "serializer" &&
+          field.type.element?.name == "Serializer" &&
+          field.type.element?.library?.uri.toString() ==
+              "package:built_value/serializer.dart",
+    );
 
-    final isBuiltValue = (ClassElement c) => c.allSupertypes.any((interface) =>
-        (interface.element.name == "Built" ||
-            interface.element.name == "EnumClass") &&
-        interface.element.library.uri.toString() ==
-            "package:built_value/built_value.dart");
+    final isBuiltValue = (ClassElement c) => c.allSupertypes.any(
+      (interface) =>
+          (interface.element.name == "Built" ||
+              interface.element.name == "EnumClass") &&
+          interface.element.library.uri.toString() ==
+              "package:built_value/built_value.dart",
+    );
 
     await for (final input in buildStep.findAssets(_generatedFiles)) {
       final lib = await buildStep.resolver.libraryFor(input);
@@ -74,9 +77,7 @@ class SerializerBuilder implements Builder {
           .forEach(builtClasses.add);
 
       lib.classes
-          .where(
-            (c) => hasSerializer(c) && !isBuiltValue(c),
-          )
+          .where((c) => hasSerializer(c) && !isBuiltValue(c))
           .forEach(nonBuiltClasses.add);
     }
 
@@ -126,10 +127,7 @@ class SerializerBuilder implements Builder {
       useNullSafetySyntax: true,
     );
 
-    final output = AssetId(
-      buildStep.inputId.package,
-      p.joinAll(pathSegments),
-    );
+    final output = AssetId(buildStep.inputId.package, p.joinAll(pathSegments));
 
     return buildStep.writeAsString(
       output,

--- a/codegen/gql_build/lib/src/utils/add_introspection.dart
+++ b/codegen/gql_build/lib/src/utils/add_introspection.dart
@@ -2,15 +2,8 @@ import "package:gql/ast.dart";
 import "package:gql_code_builder/source.dart";
 
 const typenameField = FieldDefinitionNode(
-  name: NameNode(
-    value: "__typename",
-  ),
-  type: NamedTypeNode(
-    name: NameNode(
-      value: "String",
-    ),
-    isNonNull: true,
-  ),
+  name: NameNode(value: "__typename"),
+  type: NamedTypeNode(name: NameNode(value: "String"), isNonNull: true),
 );
 
 class AddTypenameField extends TransformingVisitor {
@@ -18,39 +11,29 @@ class AddTypenameField extends TransformingVisitor {
   @override
   ObjectTypeDefinitionNode visitObjectTypeDefinitionNode(
     ObjectTypeDefinitionNode node,
-  ) =>
-      ObjectTypeDefinitionNode(
-        name: node.name,
-        description: node.description,
-        directives: node.directives,
-        fields: [
-          typenameField,
-          ...node.fields,
-        ],
-        interfaces: node.interfaces,
-        span: node.span,
-      );
+  ) => ObjectTypeDefinitionNode(
+    name: node.name,
+    description: node.description,
+    directives: node.directives,
+    fields: [typenameField, ...node.fields],
+    interfaces: node.interfaces,
+    span: node.span,
+  );
 
   @override
   InterfaceTypeDefinitionNode visitInterfaceTypeDefinitionNode(
     InterfaceTypeDefinitionNode node,
-  ) =>
-      InterfaceTypeDefinitionNode(
-        name: node.name,
-        fields: [
-          typenameField,
-          ...node.fields,
-        ],
-        directives: node.directives,
-        description: node.description,
-        interfaces: node.interfaces,
-        span: node.span,
-      );
+  ) => InterfaceTypeDefinitionNode(
+    name: node.name,
+    fields: [typenameField, ...node.fields],
+    directives: node.directives,
+    description: node.description,
+    interfaces: node.interfaces,
+    span: node.span,
+  );
 
   @override
-  FieldNode visitFieldNode(
-    FieldNode node,
-  ) {
+  FieldNode visitFieldNode(FieldNode node) {
     if (node.selectionSet == null) {
       return node;
     }
@@ -68,9 +51,7 @@ class AddTypenameField extends TransformingVisitor {
       directives: node.directives,
       selectionSet: SelectionSetNode(
         selections: <SelectionNode>[
-          FieldNode(
-            name: NameNode(value: "__typename"),
-          ),
+          FieldNode(name: NameNode(value: "__typename")),
           ...node.selectionSet!.selections,
         ],
       ),
@@ -81,9 +62,9 @@ class AddTypenameField extends TransformingVisitor {
   FragmentDefinitionNode visitFragmentDefinitionNode(
     FragmentDefinitionNode node,
   ) {
-    final hasTypename = node.selectionSet.selections
-        .whereType<FieldNode>()
-        .any((node) => node.name.value == "__typename");
+    final hasTypename = node.selectionSet.selections.whereType<FieldNode>().any(
+      (node) => node.name.value == "__typename",
+    );
 
     if (hasTypename) return node;
 
@@ -93,9 +74,7 @@ class AddTypenameField extends TransformingVisitor {
       directives: node.directives,
       selectionSet: SelectionSetNode(
         selections: <SelectionNode>[
-          FieldNode(
-            name: NameNode(value: "__typename"),
-          ),
+          FieldNode(name: NameNode(value: "__typename")),
           ...node.selectionSet.selections,
         ],
       ),
@@ -104,10 +83,11 @@ class AddTypenameField extends TransformingVisitor {
 
   @override
   OperationDefinitionNode visitOperationDefinitionNode(
-      OperationDefinitionNode node) {
-    final hasTypename = node.selectionSet.selections
-        .whereType<FieldNode>()
-        .any((node) => node.name.value == "__typename");
+    OperationDefinitionNode node,
+  ) {
+    final hasTypename = node.selectionSet.selections.whereType<FieldNode>().any(
+      (node) => node.name.value == "__typename",
+    );
 
     if (hasTypename) return node;
 
@@ -118,9 +98,7 @@ class AddTypenameField extends TransformingVisitor {
       directives: node.directives,
       selectionSet: SelectionSetNode(
         selections: <SelectionNode>[
-          FieldNode(
-            name: NameNode(value: "__typename"),
-          ),
+          FieldNode(name: NameNode(value: "__typename")),
           ...node.selectionSet.selections,
         ],
       ),
@@ -128,15 +106,11 @@ class AddTypenameField extends TransformingVisitor {
   }
 }
 
-DocumentNode _transform(DocumentNode doc) => transform(
-      doc,
-      const [
-        AddTypenameField(),
-      ],
-    );
+DocumentNode _transform(DocumentNode doc) =>
+    transform(doc, const [AddTypenameField()]);
 
 SourceNode addTypenames(SourceNode source) => SourceNode(
-      url: source.url,
-      document: _transform(source.document),
-      imports: source.imports.map(addTypenames).toSet(),
-    );
+  url: source.url,
+  document: _transform(source.document),
+  imports: source.imports.map(addTypenames).toSet(),
+);

--- a/codegen/gql_build/lib/src/utils/config.dart
+++ b/codegen/gql_build/lib/src/utils/config.dart
@@ -38,18 +38,19 @@ Set<Reference> customSerializers(dynamic customSerializersConfig) {
 
 EnumFallbackConfig enumFallbackConfig(Map<String, dynamic> config) =>
     EnumFallbackConfig(
-      globalEnumFallbackName: (config["global_enum_fallback_name"] ??
-          "gUnknownEnumValue") as String,
+      globalEnumFallbackName:
+          (config["global_enum_fallback_name"] ?? "gUnknownEnumValue")
+              as String,
       generateFallbackValuesGlobally: config["global_enum_fallbacks"] == true,
       fallbackValueMap: enumFallbackMap(config["enum_fallbacks"]),
     );
 
-DataClassConfig dataClassConfig(Map<String, dynamic> config) => DataClassConfig(
-      reuseFragments: config["reuse_fragments"] == true,
-    );
+DataClassConfig dataClassConfig(Map<String, dynamic> config) =>
+    DataClassConfig(reuseFragments: config["reuse_fragments"] == true);
 
 InlineFragmentSpreadWhenExtensionConfig whenExtensionConfig(
-    Map<String, dynamic> config) {
+  Map<String, dynamic> config,
+) {
   final whenYamlConfig = config["when_extensions"] as YamlMap?;
 
   return InlineFragmentSpreadWhenExtensionConfig(
@@ -65,10 +66,7 @@ Map<String, String> enumFallbackMap(final dynamic enumFallbacks) {
   if (enumFallbacks is YamlMap) {
     return Map.fromEntries(
       enumFallbacks.entries.map(
-        (entry) => MapEntry(
-          entry.key as String,
-          entry.value as String,
-        ),
+        (entry) => MapEntry(entry.key as String, entry.value as String),
       ),
     );
   }
@@ -100,8 +98,5 @@ DartFormatter dartFormatter(Map<String, dynamic> config) {
       ? Version.parse(languageVersion)
       : DartFormatter.latestLanguageVersion;
 
-  return DartFormatter(
-    languageVersion: parsedVersion,
-    pageWidth: pageWidth,
-  );
+  return DartFormatter(languageVersion: parsedVersion, pageWidth: pageWidth);
 }

--- a/codegen/gql_build/lib/src/utils/reader.dart
+++ b/codegen/gql_build/lib/src/utils/reader.dart
@@ -6,10 +6,7 @@ import "package:gql_code_builder/source.dart";
 
 import "../config.dart";
 
-Set<AssetId> _getImports(
-  String source, {
-  AssetId? from,
-}) {
+Set<AssetId> _getImports(String source, {AssetId? from}) {
   final imports = <Uri>{};
 
   final patterns = [
@@ -18,28 +15,19 @@ Set<AssetId> _getImports(
   ];
 
   for (final pattern in patterns) {
-    pattern.allMatches(source).forEach(
-      (match) {
-        final path = match.group(1);
-        if (path != null) {
-          imports.add(
-            Uri.parse(
-              path.endsWith(sourceExtension) ? path : "$path$sourceExtension",
-            ),
-          );
-        }
-      },
-    );
+    pattern.allMatches(source).forEach((match) {
+      final path = match.group(1);
+      if (path != null) {
+        imports.add(
+          Uri.parse(
+            path.endsWith(sourceExtension) ? path : "$path$sourceExtension",
+          ),
+        );
+      }
+    });
   }
 
-  return imports
-      .map(
-        (import) => AssetId.resolve(
-          import,
-          from: from,
-        ),
-      )
-      .toSet();
+  return imports.map((import) => AssetId.resolve(import, from: from)).toSet();
 }
 
 Future<SourceNode> _assetToSourceNode(
@@ -48,35 +36,20 @@ Future<SourceNode> _assetToSourceNode(
 ) async {
   final sourceString = await buildStep.readAsString(assetId);
 
-  final imports = _getImports(
-    sourceString,
-    from: assetId,
-  );
+  final imports = _getImports(sourceString, from: assetId);
 
   final url = assetId.uri.toString();
 
   return SourceNode(
     url: url,
-    document: parseString(
-      sourceString,
-      url: url,
-    ),
+    document: parseString(sourceString, url: url),
     imports: await Stream.fromIterable(imports)
         .asyncMap(
-          (importedAssetId) => _assetToSourceNode(
-            buildStep,
-            importedAssetId,
-          ),
+          (importedAssetId) => _assetToSourceNode(buildStep, importedAssetId),
         )
         .toSet(),
   );
 }
 
-Future<SourceNode> readDocument(
-  BuildStep buildStep, [
-  AssetId? rootId,
-]) =>
-    _assetToSourceNode(
-      buildStep,
-      rootId ?? buildStep.inputId,
-    );
+Future<SourceNode> readDocument(BuildStep buildStep, [AssetId? rootId]) =>
+    _assetToSourceNode(buildStep, rootId ?? buildStep.inputId);

--- a/codegen/gql_build/lib/src/utils/writer.dart
+++ b/codegen/gql_build/lib/src/utils/writer.dart
@@ -25,13 +25,9 @@ Future<void> writeDocument(
 
   final generatedAsset = outputAssetId(buildStep.inputId, extension);
 
-  final genSrc = dartfmt.format("${library.accept(
-    DartEmitter(
-      allocator: allocator,
-      orderDirectives: true,
-      useNullSafetySyntax: true,
-    ),
-  )}");
+  final genSrc = dartfmt.format(
+    "${library.accept(DartEmitter(allocator: allocator, orderDirectives: true, useNullSafetySyntax: true))}",
+  );
 
   return buildStep.writeAsString(
     generatedAsset,

--- a/codegen/gql_build/lib/src/var_builder.dart
+++ b/codegen/gql_build/lib/src/var_builder.dart
@@ -29,8 +29,8 @@ class VarBuilder implements Builder {
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        inputPattern: [outputPattern(varExtension)],
-      };
+    inputPattern: [outputPattern(varExtension)],
+  };
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -1,21 +1,21 @@
 name: gql_build
-version: 0.13.2
+version: 0.13.3
 description: Useful builders for your GraphQL SDL and documents. Based on package:gql_code_builder and package:build
 repository: https://github.com/gql-dart/gql
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.10.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <13.0.0'
   build: ^4.0.0
   built_collection: ^5.0.0
   built_value: ^8.0.6
   built_value_generator: ^8.0.6
   code_builder: ^4.3.0
-  dart_style: ^3.0.0
+  dart_style: ^3.1.8
   pub_semver: ^2.0.0
   glob: ^2.0.0
   gql: ^1.0.1
-  gql_code_builder: ^0.13.3
+  gql_code_builder: ^0.13.4
   gql_code_builder_serializers: ^0.1.0+1
   path: ^1.8.0
   yaml: ^3.1.0

--- a/codegen/gql_code_builder/CHANGELOG.md
+++ b/codegen/gql_code_builder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.4
+
+- support analyzer 12.x
+
 ## 0.13.3
 
 - support analyzer 9.x and 10.x

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -1,11 +1,11 @@
 name: gql_code_builder
-version: 0.13.3
+version: 0.13.4
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
 environment: 
   sdk: ^3.7.0
 dependencies: 
-  analyzer: ">=8.0.0 <11.0.0"
+  analyzer: ">=8.0.0 <13.0.0"
   built_collection: ^5.0.0
   built_value: ^8.0.6
   code_builder: ^4.7.0


### PR DESCRIPTION
Summary
- backport analyzer 12.x support to the stable `gql_code_builder` line by releasing `gql_code_builder 0.13.4`
- backport analyzer 12.x support to the stable `gql_build` line by releasing `gql_build 0.13.3`
- move the stable `gql_build` line to `dart_style 3.1.8`, which requires Dart 3.10+

Testing
- temp stable worktree `gql_code_builder`: forced `analyzer 12.1.0` via `pubspec_overrides.yaml`; `dart analyze` succeeded (one pre-existing deprecation info) and `dart test` passed
- temp stable worktree `end_to_end_test_tristate`: path-overridden local `gql_build`/`gql_code_builder`, forced `analyzer 12.1.0`; `dart run build_runner build --delete-conflicting-outputs && dart test` passed under Dart 3.11 with `dart_style 3.1.8`
- branch `codegen/gql_build`: `dart analyze` passes with the updated metadata on Dart 3.11

Notes
- `gql_code_builder` itself does not need a Dart SDK floor bump for analyzer 12
- `gql_build` now effectively requires Dart 3.10+ because `dart_style 3.1.8` is the first formatter release that works with analyzer 12
