### PR TITLE
Support analyzer 13 in gql codegen

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -152,3 +152,25 @@ jobs:
         
       - name: Run tests
         run: melos exec --scope $PACKAGE --dir-exists=test -- dart test
+
+  min_dependencies:
+    runs-on: ubuntu-latest
+    container:
+      image: dart:latest
+    name: Verify minimum dependencies
+    steps:
+      - name: Configure Git for safe directory
+        run: |
+          git config --global --add safe.directory /__w/gql/gql
+          git config --global --add safe.directory /__w/gql
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Melos
+        run: |
+          echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
+          dart pub global activate melos && dart pub get
+
+      - name: Verify minimum dependencies
+        run: melos run verify-min-dependencies

--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/gql-dart/gql
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <14.0.0'
   build: ^4.0.0
   built_collection: ^5.0.0
   built_value: ^8.0.6

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/gql-dart/gql
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <11.0.0'
+  analyzer: '>=9.0.0 <14.0.0'
   built_collection: ^5.0.0
   built_value: ^8.0.6
   code_builder: ^4.7.0
@@ -16,6 +16,7 @@ dependencies:
   gql_tristate_value: ^1.1.0
   gql_code_builder_serializers: ^0.1.0+1
 dev_dependencies:
+  frontend_server_client: ^4.0.0
   gql_pedantic: ^1.2.0
   test: ^1.16.8
 topics:

--- a/melos.yaml
+++ b/melos.yaml
@@ -64,6 +64,10 @@ scripts:
     packageFilters:
       dependsOn: build_runner
 
+  verify-min-dependencies:
+    run: ./tool/verify_min_dependencies.sh
+    description: Verify gql codegen packages against minimum supported dependency versions
+
   bump-alpha:
     description: Bump all packages to next alpha version
     run: |

--- a/tool/verify_min_dependencies.sh
+++ b/tool/verify_min_dependencies.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+copy_package() {
+  local package_path="$1"
+  local package_name="$2"
+
+  cp -R "$repo_root/$package_path" "$work_dir/$package_name"
+  rm -rf "$work_dir/$package_name/.dart_tool"
+  rm -f "$work_dir/$package_name/pubspec_overrides.yaml"
+  rm -f "$work_dir/$package_name/pubspec.lock"
+}
+
+resolved_package_version() {
+  local package_name="$1"
+  local deps_output
+
+  deps_output="$(dart pub deps --style=list)"
+  awk -v package_name="$package_name" '$2 == package_name {print $3; exit}' <<<"$deps_output"
+}
+
+verify_package() {
+  local package_dir="$1"
+  local package_name="$2"
+
+  echo "Verifying $package_name with downgraded dependencies"
+  (
+    cd "$package_dir"
+    dart pub downgrade
+
+    local analyzer_version
+    analyzer_version="$(resolved_package_version analyzer)"
+    echo "$package_name resolved analyzer $analyzer_version"
+
+    dart analyze --fatal-warnings
+
+    if [ -d test ]; then
+      dart test
+    fi
+  )
+}
+
+copy_package "codegen/gql_code_builder" "gql_code_builder"
+copy_package "codegen/gql_build" "gql_build"
+
+perl -0pi -e 's/  gql_code_builder: \^[^\n]+/  gql_code_builder:\n    path: ..\/gql_code_builder/' \
+  "$work_dir/gql_build/pubspec.yaml"
+perl -0pi -e 's/name: gql_build\n/name: gql_build\npublish_to: none\n/' \
+  "$work_dir/gql_build/pubspec.yaml"
+
+verify_package "$work_dir/gql_code_builder" "gql_code_builder"
+verify_package "$work_dir/gql_build" "gql_build"


### PR DESCRIPTION
Summary
- Widen gql_code_builder and gql_build analyzer constraints to support analyzer 13 while keeping the existing >=9.0.0 analyzer minimum.
- Add a minimum-dependency verification script that runs full dart pub downgrade in temp package copies, analyzes both codegen packages, and runs tests when present.
- Add a dev dependency floor for frontend_server_client so downgraded gql_code_builder tests run on the current Dart SDK.
- Wire the minimum dependency check into Melos and PR validation CI.

Testing
- ./tool/verify_min_dependencies.sh
- dart run melos run verify-min-dependencies
- Clean temp latest-resolution check with analyzer 13.3.0 for gql_code_builder and gql_build
- dart test in codegen/gql_code_builder
