### PR TITLE
Release gql_code_builder 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-06-17
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`gql_code_builder` - `v0.15.2`](#gql_code_builder---v0152)
+
+---
+
+#### `gql_code_builder` - `v0.15.2`
+
+ - Support analyzer 13 while keeping analyzer 9 as the minimum supported version.
+
+ - **FEAT**: support analyzer 9.x and 10.x (#505).
+
+
 ## 2025-09-20
 
 ### Changes

--- a/codegen/gql_code_builder/CHANGELOG.md
+++ b/codegen/gql_code_builder/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.2
+
+ - Support analyzer 13 while keeping analyzer 9 as the minimum supported version.
+
+ - **FEAT**: support analyzer 9.x and 10.x (#505).
+
 ## 0.15.1
 
  - **FIX**: vars_create_factories handle BuiltList type (#447).

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gql_code_builder
-version: 0.15.1
+version: 0.15.2
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
 environment:


### PR DESCRIPTION
Summary
- Bump gql_code_builder to 0.15.2.
- Add gql_code_builder and aggregate changelog entries for analyzer 13 support.

Testing
- dart pub publish --dry-run in codegen/gql_code_builder (warned only because release files are modified before commit)
