### PR TITLE
feat(gql_dio_link): support per-request timeouts via DioLinkTimeoutCo…

### DIFF
--- a/links/gql_dio_link/lib/gql_dio_link.dart
+++ b/links/gql_dio_link/lib/gql_dio_link.dart
@@ -4,4 +4,5 @@ export "package:gql_exec/gql_exec.dart"
     show HttpLinkResponseContext, HttpLinkHeaders;
 export "src/dio_cancel_token_context_entry.dart";
 export "src/dio_link.dart";
+export "src/dio_timeout_context_entry.dart";
 export "src/exceptions.dart";

--- a/links/gql_dio_link/lib/src/dio_link.dart
+++ b/links/gql_dio_link/lib/src/dio_link.dart
@@ -6,6 +6,7 @@ import "package:gql_link/gql_link.dart";
 
 import "_utils.dart";
 import "dio_cancel_token_context_entry.dart";
+import "dio_timeout_context_entry.dart";
 import "exceptions.dart";
 
 @Deprecated("Use HttpLinkResponseContext instead")
@@ -177,6 +178,14 @@ class DioLink extends Link {
       dio.Response<dynamic> res;
       final dio.CancelToken? cancelToken =
           request.context.entry<DioLinkCancelTokenContextEntry>()?.token;
+      final DioLinkTimeoutContextEntry? timeout =
+          request.context.entry<DioLinkTimeoutContextEntry>();
+      final dio.Options requestOptions = dio.Options(
+        responseType: dio.ResponseType.json,
+        headers: headers,
+        sendTimeout: timeout?.sendTimeout,
+        receiveTimeout: timeout?.receiveTimeout,
+      );
 
       final useGet =
           useGETForQueries && body is Map<String, dynamic> && isQuery;
@@ -189,20 +198,14 @@ class DioLink extends Link {
             )(body as Map<String, dynamic>),
           ),
           cancelToken: cancelToken,
-          options: dio.Options(
-            responseType: dio.ResponseType.json,
-            headers: headers,
-          ),
+          options: requestOptions,
         );
       } else {
         res = await client.post<dynamic>(
           endpoint,
           cancelToken: cancelToken,
           data: body,
-          options: dio.Options(
-            responseType: dio.ResponseType.json,
-            headers: headers,
-          ),
+          options: requestOptions,
         );
       }
       if (res.data is Map<String, dynamic> == false) {

--- a/links/gql_dio_link/lib/src/dio_timeout_context_entry.dart
+++ b/links/gql_dio_link/lib/src/dio_timeout_context_entry.dart
@@ -1,0 +1,14 @@
+import "package:gql_exec/gql_exec.dart";
+
+/// Per-request send/receive timeouts for the underlying Dio call, e.g. for
+/// a single long-running GraphQL operation. Fields left `null` keep the
+/// timeouts configured on the Dio client.
+class DioLinkTimeoutContextEntry extends ContextEntry {
+  final Duration? sendTimeout;
+  final Duration? receiveTimeout;
+
+  const DioLinkTimeoutContextEntry({this.sendTimeout, this.receiveTimeout});
+
+  @override
+  List<Object?> get fieldsForEquality => [sendTimeout, receiveTimeout];
+}

--- a/links/gql_dio_link/test/gql_dio_link_test.dart
+++ b/links/gql_dio_link/test/gql_dio_link_test.dart
@@ -187,6 +187,70 @@ void main() {
       ).called(1);
     });
 
+    test("applies timeouts from context", () async {
+      when(
+        client.post<dynamic>(
+          any,
+          data: anyNamed("data"),
+          options: anyNamed("options"),
+        ),
+      ).thenAnswer(
+        (invocation) {
+          final options = invocation.namedArguments.entries
+              .firstWhere((element) => element.key == Symbol("options"))
+              .value as dio.Options;
+          return Future.value(
+            dio.Response<Map<String, dynamic>>(
+              data: <String, dynamic>{
+                "data": <String, dynamic>{},
+              },
+              statusCode: 200,
+              requestOptions: dio.RequestOptions(
+                path: path,
+                headers: options.headers,
+              ),
+            ),
+          );
+        },
+      );
+
+      await execute(
+        Request(
+          operation: Operation(
+            document: parseString("query MyQuery {}"),
+          ),
+          variables: const <String, dynamic>{"i": 12},
+          context: Context.fromList(
+            const [
+              DioLinkTimeoutContextEntry(
+                sendTimeout: Duration(seconds: 20),
+                receiveTimeout: Duration(seconds: 20),
+              ),
+            ],
+          ),
+        ),
+      ).first;
+
+      verify(
+        client.post<dynamic>(
+          any,
+          data: anyNamed("data"),
+          options: argThat(
+            predicate((dio.Options o) => o.extEqual(dio.Options(
+                  sendTimeout: const Duration(seconds: 20),
+                  receiveTimeout: const Duration(seconds: 20),
+                  responseType: dio.ResponseType.json,
+                  headers: <String, dynamic>{
+                    dio.Headers.contentTypeHeader: dio.Headers.jsonContentType,
+                    dio.Headers.acceptHeader: "*/*",
+                  },
+                ))),
+            named: "options",
+          ),
+        ),
+      ).called(1);
+    });
+
     test("adds headers from context", () async {
       when(
         client.post<dynamic>(


### PR DESCRIPTION
## Why

`DioLink` reads only `DioLinkCancelTokenContextEntry` and `HttpLinkHeaders`
from the request context — there is no way to set Dio's
`sendTimeout`/`receiveTimeout` for a single operation. Long-running
operations (e.g. a mutation waiting ~20 s for a device to acknowledge a
command) then require a second Dio/GraphQLClient instance, or smuggling a
marker header through `HttpLinkHeaders` and converting it in an interceptor.

## What

Adds `DioLinkTimeoutContextEntry({sendTimeout, receiveTimeout})`, following
the same pattern as `DioLinkCancelTokenContextEntry`. `null` fields keep the
client-wide timeouts. Deliberately limited to timeouts (instead of a whole
`dio.Options`) so the link keeps control of `responseType` and headers —
happy to generalize if you'd prefer.

```dart
client.mutate(MutationOptions(
  document: ...,
  context: const Context().withEntry(
    const DioLinkTimeoutContextEntry(receiveTimeout: Duration(seconds: 20)),
  ),
));