### PR TITLE
fix(gql_code_builder): support analyzer 14

### DIFF
--- a/codegen/gql_build/pubspec.yaml
+++ b/codegen/gql_build/pubspec.yaml
@@ -1,11 +1,11 @@
 name: gql_build
-version: 0.13.1
+version: 0.13.2
 description: Useful builders for your GraphQL SDL and documents. Based on package:gql_code_builder and package:build
 repository: https://github.com/gql-dart/gql
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <14.0.0'
+  analyzer: '>=9.0.0 <15.0.0'
   build: ^4.0.0
   built_collection: ^5.0.0
   built_value: ^8.0.6

--- a/codegen/gql_code_builder/lib/src/tristate_optionals.dart
+++ b/codegen/gql_code_builder/lib/src/tristate_optionals.dart
@@ -231,7 +231,7 @@ String _getWireName(Method m) {
         }
         return null;
       })
-      .whereNotNull()
+      .nonNulls
       .firstOrNull;
 
   if (wireNameExpr is! LiteralExpression) {

--- a/codegen/gql_code_builder/pubspec.yaml
+++ b/codegen/gql_code_builder/pubspec.yaml
@@ -1,11 +1,11 @@
 name: gql_code_builder
-version: 0.15.2
+version: 0.15.3
 description: Dart code builders taking *.graphql documents and SDL to build useful classes.
 repository: https://github.com/gql-dart/gql
 environment:
   sdk: '>=3.0.0 <4.0.0'
 dependencies:
-  analyzer: '>=9.0.0 <14.0.0'
+  analyzer: '>=9.0.0 <15.0.0'
   built_collection: ^5.0.0
   built_value: ^8.0.6
   code_builder: ^4.7.0


### PR DESCRIPTION
## Summary
- allow analyzer versions through 14.x in gql_code_builder and gql_build
- release gql_code_builder 0.15.3 and gql_build 0.13.2
- replace deprecated whereNotNull with nonNulls

## Validation
- gql_code_builder: dart analyze; dart test (8 passing)
- gql_build: dart analyze
- codegen end-to-end: dart analyze; dart test (56 passing)
- downstream ferry_generator with analyzer 14.1.0: dart analyze; dart test (2 passing)